### PR TITLE
Added omap function

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -16,7 +16,7 @@ $(document).ready(function() {
     "flatten", "foldl", "foldr", "forEach", "functions", "head", "identity", "include",
     "indexOf", "inject", "intersect", "invoke", "isArguments", "isArray", "isBoolean", "isDate", "isElement", "isEmpty", "isEqual",
     "isFunction", "isNaN", "isNull", "isNumber", "isRegExp", "isString", "isUndefined", "keys", "last", "lastIndexOf", "map", "max",
-    "memoize", "methods", "min", "mixin", "noConflict", "pluck", "range", "reduce", "reduceRight", "reject", "rest", "select",
+    "memoize", "methods", "min", "mixin", "noConflict", "omap", "pluck", "range", "reduce", "reduceRight", "reject", "rest", "select",
     "size", "some", "sortBy", "sortedIndex", "tail", "tap", "template", "times", "toArray", "uniq", "unique",
     "uniqueId", "values", "without", "wrap", "zip"];
     same(expected, _.methods(_), 'provides a sorted list of functions');
@@ -211,4 +211,13 @@ $(document).ready(function() {
       value();
     ok(returned == 6 && intercepted == 6, 'can use tapped objects in a chain');
   });
+
+  test("objects: omap", function() {
+    var o = {a: 1, b: 3, c: 5};
+    var r = _.omap(_.clone(o), function(x) { return x * 2; });
+    same(r, {a: 2, b: 6, c: 10}, 'all keys are mapped');
+    var r = _.omap(_.clone(o), ['a', 'c'], function(x) { return x * 2; });
+    same(r, {a: 2, b: 3, c: 10}, 'only specified keys are mapped');
+  });
+
 });

--- a/underscore.js
+++ b/underscore.js
@@ -480,6 +480,22 @@
     return obj;
   };
 
+  // Map all properties of an object 
+  //
+  // Usage:
+  //   _.omap(o, [*keys], map_function)
+  _.omap = function(obj, a, b) {
+    var keys = _.isArray(a) ? a : _.keys(obj), 
+        f = _.isFunction(a) ? a : b;
+
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
+      obj[key] = f.call(obj, obj[key]);
+    }
+
+    return obj;
+  };
+
   // Perform a deep comparison to check if two objects are equal.
   _.isEqual = function(a, b) {
     // Check object identity.


### PR DESCRIPTION
Hi,

I've added a function called "omap", which allows functional mapping on objects. It comes in two flavors:

1) _.omap(o, f)
2) _.omap(o, keys, f)

1) calls function f on each key of o, setting o.key to the result of the called function. 
2) calls function f on each key specified by keys, setting o.key to the result of the called function. 

The object is modified in place and a copy of the object is returned. To call this function without modifying the called object, _.omap(_.clone(o), ...) can be used. I made in-place modification the default because this was my most common used case and is cheaper than always copying the object. 

This function is useful when storing s set of similar items in an object and wanting to act on all of them in a similar way. 

I added tests, but did not add documentation because I had some trouble building the docs (general npm problems).
