### PR TITLE
Upgraded _.pluck to support objects

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -192,8 +192,19 @@
   };
 
   // Convenience version of a common use case of `map`: fetching a property.
-  _.pluck = function(obj, key) {
-    return _.map(obj, function(value){ return value[key]; });
+  _.pluck = function(obj, keys) {
+    if (_.isArray(obj)) {
+      return _.map(obj, function(value){ return value[keys]; });
+    } else {
+      if (_.isString(keys)) keys = keys.split(' ');
+      var newObj = {};
+      _.each(obj, function (value, key) {
+        if (_.indexOf(keys, key) != -1) {
+          newObj[key] = value;
+        }
+      });
+      return newObj;
+    }  
   };
 
   // Return the maximum element or (element-based computation).


### PR DESCRIPTION
_.pluck now supports arrays _and_ objects.  I've added a helper for the keys requires (not sure if it's overly helpful), but _.pluck can now also be used for the following:

```
var objectA = { 
  name: "remy",
  age: 32,
  nationality: "GBP",
  location: "Brighton",
  legs: 2,
  married: true
};

var objectB = _.pluck(objectA, "name age married");
// or: objectB = _.pluck(objectA, ["name", "age", "married"]);
// but there's a helper to split the string

console.log(objectB);
// { name: "remy", age: 32, married: true }
```

Hope that's of help to others too (note that the syntax hasn't changed if the argument is an array).
