### PR TITLE
reduce() doesn't have a default initial value

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -65,6 +65,9 @@ $(document).ready(function() {
 
     sum = _([1, 2, 3]).reduce(function(sum, num){ return sum + num; }, 0);
     equals(sum, 6, 'OO-style reduce');
+    
+    var sum = _.reduce([1, 2, 3], function(sum, num){ return sum + num; });
+    equals(sum, 6, 'default initial value');
   });
 
   test('collections: reduceRight', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -94,10 +94,16 @@
   _.reduce = _.foldl = _.inject = function(obj, iterator, memo, context) {
     if (nativeReduce && obj.reduce === nativeReduce) {
       if (context) iterator = _.bind(iterator, context);
-      return obj.reduce(iterator, memo);
+      var args = [iterator];
+      if (memo !== undefined) args.push(memo);
+      return obj.reduce.apply(obj, args);
     }
     each(obj, function(value, index, list) {
-      memo = iterator.call(context, memo, value, index, list);
+      if (memo === undefined && index == 0) {
+        memo = value;
+      } else {
+        memo = iterator.call(context, memo, value, index, list);
+      }
     });
     return memo;
   };


### PR DESCRIPTION
Hi there. According to the ECMA 5 spec (15.4.4.21), if an initial value is not given to reduce(), then it should be the first value of the array (and the iterator starts from the second value). I noticed that Underscore doesn't do this currently for the non-native version of reduce().

Additionally, when using native reduce(), if no memo is passed to _.reduce(), then an "undefined" memo will be given to the native reduce(), which will screw things up. So this commit handles that case as well.
