### PR TITLE
reduceRight() doesn't have an initial value either

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -68,8 +68,14 @@ $(document).ready(function() {
   });
 
   test('collections: reduceRight', function() {
-    var list = _.foldr([1, 2, 3], function(memo, num){ return memo + num; }, '');
-    equals(list, '321', 'can perform right folds');
+    var list = _.reduceRight(["foo", "bar", "baz"], function(memo, str){ return memo + str; }, '');
+    equals(list, 'bazbarfoo', 'can perform right folds');
+    
+    var list = _.foldr(["foo", "bar", "baz"], function(memo, str){ return memo + str; }, '');
+    equals(list, 'bazbarfoo', 'aliased as "foldr"');
+    
+    var list = _.foldr(["foo", "bar", "baz"], function(memo, str){ return memo + str; });
+    equals(list, 'bazbarfoo', 'default initial value');
   });
 
   test('collections: detect', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -107,7 +107,9 @@
   _.reduceRight = _.foldr = function(obj, iterator, memo, context) {
     if (nativeReduceRight && obj.reduceRight === nativeReduceRight) {
       if (context) iterator = _.bind(iterator, context);
-      return obj.reduceRight(iterator, memo);
+      var args = [iterator];
+      if (memo !== undefined) args.push(memo);
+      return obj.reduceRight.apply(obj, args);
     }
     var reversed = (_.isArray(obj) ? obj.slice() : _.toArray(obj)).reverse();
     return _.reduce(reversed, iterator, memo, context);


### PR DESCRIPTION
Similar to reduce(), except if you don't pass an initial value for reduceRight(), it's supposed to use the _last_ value in the collection.
