### PR TITLE
Preserve backslashes in _.template()

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -55,6 +55,9 @@ $(document).ready(function() {
     var result = basicTemplate({thing : 'This'});
     equals(result, "This is gettin' on my noives!", 'can do basic attribute interpolation');
 
+    var backslashTemplate = _.template("<%= thing %> is \\ridanculous");
+    equals(backslashTemplate({thing: 'This'}), "This is \\ridanculous");
+
     var fancyTemplate = _.template("<ul><% \
       for (key in people) { \
     %><li><%= people[key] %></li><% } %></ul>");

--- a/underscore.js
+++ b/underscore.js
@@ -646,7 +646,8 @@
     var c  = _.templateSettings;
     var tmpl = 'var __p=[],print=function(){__p.push.apply(__p,arguments);};' +
       'with(obj||{}){__p.push(\'' +
-      str.replace(/'/g, "\\'")
+      str.replace(/\\/g, '\\\\')
+         .replace(/'/g, "\\'")
          .replace(c.interpolate, function(match, code) {
            return "'," + code.replace(/\\'/g, "'") + ",'";
          })


### PR DESCRIPTION
This is important for LaTeX templates!  For example, `\ribbit` would produce an output containing a carriage return instead of the literal string `\r`.
