### PR TITLE
Override toString to facilitate client/server reuse

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -6,7 +6,7 @@
 //     For all details and documentation:
 //     http://documentcloud.github.com/underscore
 
-(function() {
+(function closure() {
 
   // Baseline setup
   // --------------
@@ -46,6 +46,10 @@
 
   // Create a safe reference to the Underscore object for use below.
   var _ = function(obj) { return new wrapper(obj); };
+
+  // Override toString to facilitate client/server reuse
+  var source = "(" + closure + ")()";
+  _.toString = function() { return source; };
 
   // Export the Underscore object for **CommonJS**.
   if (typeof exports !== 'undefined') exports._ = _;


### PR DESCRIPTION
hey guys,

not sure what you think, but i'm a huge fan of this pattern. the idea is to override _.toString to make it easier to send Underscore to the client. all you need to do is:

```
var _ = require( "underscore" )._
```

and then when you want to send it to an HTML response in the client:

```
response.write( "<script>" + _ + "</script>" )
```

thanks and keep up the great work,

jed
