### PR TITLE
Export _ object as the entire module

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -47,11 +47,16 @@
   // Create a safe reference to the Underscore object for use below.
   var _ = function(obj) { return new wrapper(obj); };
 
-  // Export the Underscore object for **CommonJS**.
-  if (typeof exports !== 'undefined') exports._ = _;
+  if (typeof module !== 'undefined') {
+    // Export the Underscore object for **CommonJS**.
+    module.exports = _;
 
-  // Export Underscore to the global scope.
-  root._ = _;
+    // Backwards compat with old requiring api
+    _._ = _;
+  } else {
+    // Export Underscore to the global scope.
+    root._ = _;
+  }
 
   // Current version.
   _.VERSION = '1.1.2';


### PR DESCRIPTION
- Exports `_` as the entire module. This allows you to just `var _ = require('underscore');`. `_([1, 2, 3]).map` will still work with this approach.
- Adds backwards compatibility support for `var _ = require('underscore')._;`
- Fixes strange `_` leak in node.js. Simply doing `require('underscore')` would assign a local `_` in your file. Could be a node.js bug but it was related to `root._ = _;`
