### PR TITLE
Make _.each() return object

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -81,6 +81,7 @@
         }
       }
     }
+	return obj;
   };
 
   // Return the results of applying the iterator to each element.


### PR DESCRIPTION
This just adds the return statement at the end of _.each() that was left off in commit 2d06e1d5262ca2e17aa7. Fixes issue 73: https://github.com/documentcloud/underscore/issues#issue/73.
