### PR TITLE
adding support for getters and setters to extend

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -24,6 +24,9 @@ $(document).ready(function() {
     ok(_.isEqual(result, {x:'x', a:'a', b:'b'}), 'can extend from multiple source objects');
     result = _.extend({x:'x'}, {a:'a', x:2}, {a:'b'});
     ok(_.isEqual(result, {x:2, a:'b'}), 'extending from multiple source objects last property trumps');
+	result = _.extend({}, { set x(x){ this._x = 'set' }, get x(){ return this._x} } )
+	result.x = 'x';
+    ok(_.isEqual(result.x, 'set'), 'getters and setters are applied in destination');
   });
 
   test("objects: clone", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -515,10 +515,15 @@
     return _.filter(_.keys(obj), function(key){ return _.isFunction(obj[key]); }).sort();
   };
 
-  // Extend a given object with all the properties in passed-in object(s).
+  // Extend a given object with all the properties in passed-in object(s), including getters and setters
   _.extend = function(obj) {
     each(slice.call(arguments, 1), function(source) {
-      for (var prop in source) obj[prop] = source[prop];
+		for (var prop in source){
+			var s = source.__lookupSetter__(prop), g = source.__lookupGetter__(prop);
+			if ( s ) obj.__defineSetter__(prop, s);
+			if ( g ) obj.__defineGetter__(prop, g);
+			obj[prop] = source[prop];
+		}
     });
     return obj;
   };


### PR DESCRIPTION
This adds a small update to the _.extend() method supporting the copying of getters and setters from source to destination. I also added a test to cover the change.
