### PR TITLE
Look for truthy values by default in _.detect, _.select, and _.reject.

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,10 +303,11 @@ var flat = _.reduceRight(list, function(a, b) { return a.concat(b); }, []);
 </pre>
 
       <p id="detect">
-        <b class="header">detect</b><code>_.detect(list, iterator, [context])</code>
+        <b class="header">detect</b><code>_.detect(list, [iterator], [context])</code>
         <br />
         Looks through each value in the <b>list</b>, returning the first one that
-        passes a truth test (<b>iterator</b>). The function returns as
+        passes a truth test (<b>iterator</b>). If an <b>iterator</b> is not provided,
+        the truthy value of the element will be used instead. The function returns as
         soon as it finds an acceptable element, and doesn't traverse the
         entire list.
       </p>
@@ -316,11 +317,12 @@ var even = _.detect([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
 </pre>
 
       <p id="select">
-        <b class="header">select</b><code>_.select(list, iterator, [context])</code>
+        <b class="header">select</b><code>_.select(list, [iterator], [context])</code>
         <span class="alias">Alias: <b>filter</b></span>
         <br />
         Looks through each value in the <b>list</b>, returning an array of all
-        the values that pass a truth test (<b>iterator</b>). Delegates to the
+        the values that pass a truth test (<b>iterator</b>). If an <b>iterator</b> is not
+        provided, the truthy value of the element will be used instead. Delegates to the
         native <b>filter</b> method, if it exists.
       </p>
       <pre>
@@ -329,10 +331,11 @@ var evens = _.select([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
 </pre>
 
       <p id="reject">
-        <b class="header">reject</b><code>_.reject(list, iterator, [context])</code>
+        <b class="header">reject</b><code>_.reject(list, [iterator], [context])</code>
         <br />
         Returns the values in <b>list</b> without the elements that the truth
-        test (<b>iterator</b>) passes. The opposite of <b>select</b>.
+        test (<b>iterator</b>) passes. If an <b>iterator</b> is not provided, the truthy
+        value of the element will be used instead. The opposite of <b>select</b>.
       </p>
       <pre>
 var odds = _.reject([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });

--- a/test/collections.js
+++ b/test/collections.js
@@ -107,19 +107,32 @@ $(document).ready(function() {
   test('collections: detect', function() {
     var result = _.detect([1, 2, 3], function(num){ return num * 2 == 4; });
     equals(result, 2, 'found the first "2" and broke the loop');
+
+    result = _.detect([0, 1, 2, 3]);
+    equals(result, 1, 'found the first truthy value and broke the loop');
   });
 
   test('collections: select', function() {
     var evens = _.select([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
     equals(evens.join(', '), '2, 4, 6', 'selected each even number');
 
+    var truths = _.select(['foo', '', null, 'bar', 0, 'baz', undefined]);
+    equals(truths.join(', '), 'foo, bar, baz', 'selected each truthy value');
+
     evens = _.filter([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
     equals(evens.join(', '), '2, 4, 6', 'aliased as "filter"');
+
+    truths = _.select(['foo', '', null, 'bar', 0, 'baz', undefined]);
+    equals(truths.join(', '), 'foo, bar, baz', 'aliased as "filter" (selecting truthy values)');
   });
 
   test('collections: reject', function() {
     var odds = _.reject([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
     equals(odds.join(', '), '1, 3, 5', 'rejected each even number');
+
+    var myths = _.reject(['foo', '', null, 'bar', 0, 'baz', undefined]);
+    ok(myths.length === 4 && myths[0] === '' && myths[1] === null && myths[2] === 0 && myths[3] === undefined,
+      'rejected each truthy value');
   });
 
   test('collections: all', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -131,6 +131,7 @@
 
   // Return the first value which passes a truth test. Aliased as `detect`.
   _.find = _.detect = function(obj, iterator, context) {
+    iterator = iterator || _.identity;
     var result;
     any(obj, function(value, index, list) {
       if (iterator.call(context, value, index, list)) {
@@ -145,6 +146,7 @@
   // Delegates to **ECMAScript 5**'s native `filter` if available.
   // Aliased as `select`.
   _.filter = _.select = function(obj, iterator, context) {
+    iterator = iterator || _.identity;
     var results = [];
     if (obj == null) return results;
     if (nativeFilter && obj.filter === nativeFilter) return obj.filter(iterator, context);
@@ -156,6 +158,7 @@
 
   // Return all the elements for which a truth test fails.
   _.reject = function(obj, iterator, context) {
+    iterator = iterator || _.identity;
     var results = [];
     if (obj == null) return results;
     each(obj, function(value, index, list) {


### PR DESCRIPTION
`_.detect`, `_.select`, and `_.reject` all require an iterator function, but a default truthy iterator could be useful in each case, particularly `_.select`. In my own code, I want a truthy iterator far more often than anything else.

```
// Turn a path into an array of segments.
_.select('/foo/bar/baz/'.split('/'));
// returns
[ 'foo', 'bar', 'baz' ]

// Read a text file in Node.js.
fs = require('fs');
_.select(fs.readFileSync('path/to/list-of-words', 'ascii').split(/\s+/));
// returns words in list
```
