### PR TITLE
Jslintify

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -302,7 +302,7 @@
   // the rest of the values in the array from that index onward. The **guard**
   // check allows it to work with `_.map`.
   _.rest = _.tail = function(array, index, guard) {
-    return slice.call(array, ((index == null) || _.isUndefined(index)) || guard ? 1 : index);
+    return slice.call(array, ((index === null) || _.isUndefined(index)) || guard ? 1 : index);
   };
 
   // Get the last element of an array.


### PR DESCRIPTION
Hi,

I know this can end up being a "religious" argument, but doing if() statements without brackets, etc just makes the interpreter work harder (very slightly). More importantly though, it breaks jslint. Titanium Mobile also runs javascript through JSLint before trying to compile, making this library unusable in any development environment that runs its JS through JSLint (and without having control of the output).  I left 3 jslint errors in there b/c those are just stylistic warnings. However, I fixed all the more "serious" JSLint problems.

I was going to next tackle backbone.js :-).
