### PR TITLE
underscore attempts to iterate over any object exposing forEach

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -34,7 +34,25 @@ $(document).ready(function() {
     _.each(null, function(){ ++answers; });
     equals(answers, 0, 'handles a null properly');
   });
-
+  
+  test("collections: each - any object exposing forEach can be used by underscore each", function() {
+    var Stream = function(contents){ this.contents = contents };
+    Stream.prototype.forEach = function(iterator, context) {
+      var position = 0;
+      while (this.contents.length>0) {
+        var item = this.contents.shift();
+        iterator.call(context, item, position, this);  //this is a stream, so feeding 'this' back is strange (arguably).
+        position += 1;
+      };
+    };
+    
+    var answers = [];
+    _.each(new Stream([7,8,9]), function(v, i){ answers.push([v]); });
+    equals(answers.join(', '), '7, 8, 9', 'underscore will attempt to iterate over any object responding to forEach. ' +
+                                          'Particularly useful if you have a general iterator ' +
+                                          '(perhaps because not all values are present in ram at the moment iteration starts).');
+  });
+  
   test('collections: map', function() {
     var doubled = _.map([1, 2, 3], function(num){ return num * 2; });
     equals(doubled.join(', '), '2, 4, 6', 'doubled numbers');

--- a/underscore.js
+++ b/underscore.js
@@ -68,7 +68,7 @@
   // Delegates to **ECMAScript 5**'s native `forEach` if available.
   var each = _.each = _.forEach = function(obj, iterator, context) {
     if (obj == null) return;
-    if (nativeForEach && obj.forEach === nativeForEach) {
+    if (obj.forEach) {
       obj.forEach(iterator, context);
     } else if (_.isNumber(obj.length)) {
       for (var i = 0, l = obj.length; i < l; i++) {


### PR DESCRIPTION
I intend this pull request to at least be the start of a conversation.  I'm a fan of underscore and am at the point where I'd like the ability to use the power of the library with custom iterators - in other words, I might not be holding the data in ram, or it may be coming across the wire or off of disk.

However it may be that simply assuming .forEach will do the right thing is bad...you may be trying to specifically avoid non-native forEach implementations for other reasons.

I'd be happy to name the iterator method something else and put an extra else-if clause in the each function.  Something like underscoreForEach, or just each (ruby-like)?  Thoughts?
