### PR TITLE
Fixed the example for _.templateSettings within the _.template() docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1108,9 +1108,11 @@ _.template(list, {people : ['moe', 'curly', 'larry']});
       </p>
 
       <pre>
-_.templateSettings = {
+// Change just the 'interpolate' setting.  
+// (Another setting is 'evaluate', used to evaluate javascript expressions ) 
+_.extend(_.templateSettings, {
   interpolate : /\{\{(.+?)\}\}/g
-};
+});
 
 var template = _.template("Hello {{ name }}!");
 template({name : "Mustache"});


### PR DESCRIPTION
Small fix for index.html.

Corrected and clarified the documentation for _.template(). The prior example completely clobbers _.templateSettings.evaluate by innocently setting _.templateSettings.interpolate via _.templateSettings={interpolate : /.../g}

The end-result of the example is a broken _.templateSettings.evaluate as a nasty side-effect.
