### PR TITLE
_.once: Run a function just once

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -98,6 +98,15 @@ $(document).ready(function() {
     setTimeout(debouncedIncr, 150);
     _.delay(function(){ ok(counter == 1, "incr was debounced"); start(); }, 220);
   });
+  
+  test("functions: once", function() {
+    var addBang = function(str) { return str + "!"; };
+    hi = "Hi";
+    hi2 = _.once(addBang, hi);
+    hi3 = _.once(addBang, hi);
+    equals(hi2, "Hi!");
+    equals(hi3, undefined);
+  });
 
   test("functions: wrap", function() {
     var greet = function(name){ return "hi: " + name; };

--- a/underscore.js
+++ b/underscore.js
@@ -471,6 +471,17 @@
   _.debounce = function(func, wait) {
     return limit(func, wait, true);
   };
+  
+  // Runs a function only if it's never been run before.
+  _.once = function(func) {
+    if (_.indexOf(onceRunFunctions, func)) {
+      onceRunFunctions.push(func);
+      return func.apply(func, slice.call(arguments, 1));
+    }
+  }
+  
+  // Internal record of functions that have been run via `_.once`.
+  var onceRunFunctions = [];
 
   // Returns the first function passed as an argument to the second,
   // allowing you to adjust arguments, run code before and after, and


### PR DESCRIPTION
Here's a common scenario: You want to run a function just once, globally. This patch implements a `_.once` functional function to do just that.

For instance, rather than writing

```
isInitialized = false
initialize = ->
  ...
  isInitialized = true
func1 = ->
  unless isInitialized
    initialize()
  ...
```

and potentially putting that same `isInitialized` check in every function that depends on `initialize`, this lets you write

```
initialize = ->
  ...
func1 = ->
  _.once initialize
```

If `initialize` has already been run, nothing happens. Pretty handy, right? `_.once` also accepts additional arguments, and returns the result of the function execution if it runs.
