### PR TITLE
Add optional iterator to _.uniq

### DIFF
--- a/index.html
+++ b/index.html
@@ -549,16 +549,20 @@ _.without([1, 2, 1, 0, 3, 1, 4], 0, 1);
 </pre>
 
       <p id="uniq">
-        <b class="header">uniq</b><code>_.uniq(array, [isSorted])</code>
+        <b class="header">uniq</b><code>_.uniq(array, [isSorted], [iterator])</code>
         <span class="alias">Alias: <b>unique</b></span>
         <br />
         Produces a duplicate-free version of the <b>array</b>, using <i>===</i> to test
         object equality. If you know in advance that the <b>array</b> is sorted,
         passing <i>true</i> for <b>isSorted</b> will run a much faster algorithm.
+        Can receive an iterator to determine which part of the element gets tested.
       </p>
       <pre>
 _.uniq([1, 2, 1, 3, 1, 4]);
 =&gt; [1, 2, 3, 4]
+
+_.uniq([{name:'moe'}, {name:'curly'}, {name:'larry'}, {name:'curly'}], false, function (value) { return value.name; })
+=&gt;[{name:'moe'}, {name:'curly'}, {name:'larry'}]
 </pre>
 
       <p id="intersect">

--- a/test/arrays.js
+++ b/test/arrays.js
@@ -61,6 +61,10 @@ $(document).ready(function() {
     var list = [1, 1, 1, 2, 2, 3];
     equals(_.uniq(list, true).join(', '), '1, 2, 3', 'can find the unique values of a sorted array faster');
 
+	var list = [{name:'moe'}, {name:'curly'}, {name:'larry'}, {name:'curly'}]
+	var iterator = function(value) { return value.name; }
+	equals(_.map(_.uniq(list, false, iterator), iterator).join(', '), 'moe, curly, larry', 'can find the unique values of an array using a custom iterator');
+
     var result = (function(){ return _.uniq(arguments); })(1, 2, 1, 3, 1, 4);
     equals(result.join(', '), '1, 2, 3, 4', 'works on an arguments object');
   });

--- a/underscore.js
+++ b/underscore.js
@@ -324,9 +324,10 @@
   // Produce a duplicate-free version of the array. If the array has already
   // been sorted, you have the option of using a faster algorithm.
   // Aliased as `unique`.
-  _.uniq = _.unique = function(array, isSorted) {
+  _.uniq = _.unique = function(array, isSorted, iterator) {
+	iterator = iterator || _.identity;
     return _.reduce(array, function(memo, el, i) {
-      if (0 == i || (isSorted === true ? _.last(memo) != el : !_.include(memo, el))) memo[memo.length] = el;
+      if (0 == i || (isSorted === true ? _.last(memo) != el : !_.include(_.map(memo, iterator), iterator(el)))) memo[memo.length] = el;
       return memo;
     }, []);
   };


### PR DESCRIPTION
Hi guys, 
I needed to be able to pass in an iterator to `_.uniq` to do things like:

```
_.uniq([{name:'moe'}, {name:'curly'}, {name:'larry'}, {name:'curly'}], false, function (value) { return value.name; })
=>[{name:'moe'}, {name:'curly'}, {name:'larry'}]
```

I didn't see an example of a function taking more than one optional argument, I would have preferred to do this with and options hash for the `sorted` flag and the `iterator` function but didn't want to mess with the signature.

Added test and updated docs too, any feedback welcome.

Cheers!
Alfredo Mesén

edit: markdown backticks
