### PR TITLE
Added reference to handle optional template parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -1108,6 +1108,17 @@ compiled({epithet: "stooge"});
 =&gt; "Hello stooge."</pre>
 
       <p>
+        If you know that the attribute may or may not exist, you can use <tt>_maybe</tt>.
+      </p>
+      
+      <pre>
+var compiled = _.template("Nick: &lt;%= nick %&gt;&lt;% if (_maybe.adminTag) { print(_maybe.adminTag); } %&gt;");
+compiled({nick: "Bob"});
+=&gt; "nick: Bob"
+compiled({nick: "Alice", adminTag: "[Hi, I own the place]"});
+=&gt; "nick: Alice[Hi, I own the place]"</pre>
+
+      <p>
         If ERB-style delimiters aren't your cup of tea, you can change Underscore's
         template settings to use different symbols to set off interpolated code.
         Define an <b>interpolate</b> regex, and an (optional) <b>evaluate</b> regex

--- a/test/utility.js
+++ b/test/utility.js
@@ -66,6 +66,16 @@ $(document).ready(function() {
     });
     equals(result, "3 p3-thumbnail.gif <div class=\"thumbnail\" rel=\"p1-thumbnail.gif\"></div><div class=\"thumbnail\" rel=\"p2-thumbnail.gif\"></div><div class=\"thumbnail\" rel=\"p3-thumbnail.gif\"></div>");
 
+    var maybeTemplate = _.template("<h3>Contact Info:</h3><p>Email: <%= email %></p><p>Phone: <%= _maybe.phone %></p>");
+    result = maybeTemplate({ email:"bob@example.com" });
+    equals(result, "<h3>Contact Info:</h3><p>Email: bob@example.com</p><p>Phone: </p>");
+    
+    var maybeConditionTemplate = _.template("<p>Nick: <%= nick %><% if (_maybe.adminTag) { print(_maybe.adminTag); } %></p>");
+    result = maybeConditionTemplate({ nick:"bob" });
+    equals(result, "<p>Nick: bob</p>");
+    result = maybeConditionTemplate({ nick:"alice", adminTag:"[Hi, I own the place]" });
+    equals(result, "<p>Nick: alice[Hi, I own the place]</p>");
+
     var noInterpolateTemplate = _.template("<div><p>Just some text. Hey, I know this is silly but it aids consistency.</p></div>");
     result = noInterpolateTemplate();
     equals(result, "<div><p>Just some text. Hey, I know this is silly but it aids consistency.</p></div>");

--- a/underscore.js
+++ b/underscore.js
@@ -706,6 +706,7 @@
   _.template = function(str, data) {
     var c  = _.templateSettings;
     var tmpl = 'var __p=[],print=function(){__p.push.apply(__p,arguments);};' +
+      '_maybe = obj || {};' +
       'with(obj||{}){__p.push(\'' +
       str.replace(/\\/g, '\\\\')
          .replace(/'/g, "\\'")


### PR DESCRIPTION
Added `_maybe` reference available to templates for values that may or may not exist. I found it useful for my project that has models with little-to-no schema, and thought I'd pass it on if others find it useful as well.

Check out the change to index.html and the tests for some use cases.
