### PR TITLE
Using jQuery.noConflict for tests

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+jQuery(document).ready(function() {
 
   module("Array-only functions (last, compact, uniq, and so on...)");
 

--- a/test/chaining.js
+++ b/test/chaining.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+jQuery(document).ready(function() {
 
   module("Underscore chaining.");
 

--- a/test/collections.js
+++ b/test/collections.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+jQuery(document).ready(function() {
 
   module("Collection functions (each, any, select, and so on...)");
 

--- a/test/functions.js
+++ b/test/functions.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+jQuery(document).ready(function() {
 
   module("Function functions (bind, bindAll, and so on...)");
 

--- a/test/objects.js
+++ b/test/objects.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+jQuery(document).ready(function() {
 
   module("Object functions (values, extend, isEqual, and so on...)");
 
@@ -122,7 +122,7 @@ $(document).ready(function() {
 
   test("objects: isElement", function() {
     ok(!_.isElement('div'), 'strings are not dom elements');
-    ok(_.isElement($('html')[0]), 'the html tag is a DOM element');
+    ok(_.isElement(jQuery('html')[0]), 'the html tag is a DOM element');
     ok(_.isElement(iElement), 'even from another frame');
   });
 

--- a/test/test.html
+++ b/test/test.html
@@ -14,6 +14,9 @@
   <script type="text/javascript" src="utility.js"></script>
   <script type="text/javascript" src="chaining.js"></script>
   <script type="text/javascript" src="speed.js"></script>
+
+  <script>jQuery.noConflict();</script>
+
 </head>
 <body>
   <h1 id="qunit-header">Underscore Test Suite</h1>

--- a/test/utility.js
+++ b/test/utility.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+jQuery(document).ready(function() {
 
   module("Utility functions (uniqueId, template)");
 
@@ -81,8 +81,8 @@ $(document).ready(function() {
     var withNewlinesAndTabs = _.template('This\n\t\tis: <%= x %>.\n\tok.\nend.');
     equals(withNewlinesAndTabs({x: 'that'}), 'This\n\t\tis: that.\n\tok.\nend.');
 
-    if (!$.browser.msie) {
-      var fromHTML = _.template($('#template').html());
+    if (!jQuery.browser.msie) {
+      var fromHTML = _.template(jQuery('#template').html());
       equals(fromHTML({data : 12345}).replace(/\s/g, ''), '<li>24690</li>');
     }
 


### PR DESCRIPTION
The current tests depend on jQuery owning the $ variable. Luckily, it was easy to take that out.
I did this so tests can be run with Prototype.js or ender-js by inserting it into test.html.

After you accept this pull request, I will post some conflicts that I found Prototype.js to have with underscore's methods.

I'm glad to help fixing them to make underscore really framework agnostic!
