### PR TITLE
Support object collections in addition to arrays in enumeration operations

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -280,13 +280,13 @@
     if (!keyProperty) {
 	    each(iterable, function(value, key, list) {
 	      results[key] = value;
-	    }
+	    });
     } else {
 	    each(iterable, function(value, originalKey, list) {
 	   	  var key = value[keyProperty];
 	      delete value[keyProperty]; // Remove duplicate data
 	      results[key || originalKey] = value;
-	    }    	
+	    });    	
     }
     
     return results;


### PR DESCRIPTION
I made some simple changes to underscore to support object collections better in the enumeration functions.  I did this because I'm using object collections rather than arrays in my app to take advantage of getters/setters support which array iterators don't currently handle.

I'm a bit of a noob to js so I wasn't planning on sending a pull request, but given that jquery 1.6 has this theme for their update, I figure it's worth a look for underscore, even if you just take the concept and rewrite the changes I made.

I'd also appreciate feedback on my changes so I can improve my javascript skills.  Thanks.
- jcb
