### PR TITLE
Should be 'A convenient,' not 'An convenient'

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,7 +393,7 @@ _.invoke([[5, 1, 7], [3, 2, 1]], 'sort');
       <p id="pluck">
         <b class="header">pluck</b><code>_.pluck(list, propertyName)</code>
         <br />
-        An convenient version of what is perhaps the most common use-case for
+        A convenient version of what is perhaps the most common use-case for
         <b>map</b>: extracting a list of property values.
       </p>
       <pre>


### PR DESCRIPTION
As noted in issue #189
