### PR TITLE
groupBy tests may fail in some cases.

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -188,9 +188,9 @@ $(document).ready(function() {
   
   test('collections: groupBy', function() {
     var parity = _.groupBy([1, 2, 3, 4, 5, 6], function(num){ return num % 2; });
-    equals(_.keys(parity).join(', '), '0, 1', 'created a group for each value');
+    ok('0' in parity && '1' in parity, 'created a group for each value');
     equals(parity[0].join(', '), '2, 4, 6', 'put each even number in the right group');
-  })
+  });
 
   test('collections: sortedIndex', function() {
     var numbers = [10, 20, 30, 40, 50], num = 35;


### PR DESCRIPTION
Hashmap keys are not necessarily ordered. groupBy test may fail if the expected order is not correct.
Fixing this by checking if the keys are present in the hash so the order is not deterministic.
