### PR TITLE
set "_" extern for use with Closure Compilers ADVANCED_OPTIMIZATIONS

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -55,7 +55,7 @@
     module.exports = _;
     _._ = _;
   } else {
-    root._ = _;
+    root['_'] = _;
   }
 
   // Current version.
@@ -250,7 +250,7 @@
       return a < b ? -1 : a > b ? 1 : 0;
     }), 'value');
   };
-  
+
   // Groups the object's values by a criterion produced by an iterator
   _.groupBy = function(obj, iterator) {
     var result = {};


### PR DESCRIPTION
Many libs don't compile under Closure Compilers [Advanced Optimizations](http://code.google.com/closure/compiler/docs/api-tutorial3.html) flag simply because they don't export their utils as an extern. See the linked docs for the happs. Long story short, using subscript notation is what makes it all work.

``` js
root['_'] = _;
```

Kind of silly but makes a huge difference.
