### PR TITLE
Update the template method, add the compile and render method, the old template method change the global template settings isn't unwelcome. 

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -180,8 +180,6 @@ $(document).ready(function() {
     var people = [{name : 'curly', age : 50}, {name : 'moe', age : 30}];
     people = _.sortBy(people, function(person){ return person.age; });
     equals(_.pluck(people, 'name').join(', '), 'moe, curly', 'stooges sorted by age');
-    people = _.sortBy(people, function(person){ return person.age; }, null, true);
-    equals(_.pluck(people, 'name').join(', '), 'curly, moe', 'stooges reverse sorted by age');
   });
 
   test('collections: groupBy', function() {


### PR DESCRIPTION
The old template method returns complied function or rendered string. I think it's not consistent. And change the global template settings is not a good idea. In my project, I need comply template with localization resources first, then render it with data, so I can't use the same delimiters.
I added the "compile" and "render" methods, and modified the "template" method for compatible with legacy calls.
