### PR TITLE
Added string splitting to each. Maintained performance

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -73,8 +73,14 @@
     if (nativeForEach && obj.forEach === nativeForEach) {
       obj.forEach(iterator, context);
     } else if (_.isNumber(obj.length)) {
-      for (var i = 0, l = obj.length; i < l; i++) {
-        if (i in obj && iterator.call(context, obj[i], i, obj) === breaker) return;
+      try {
+        for (var i = 0, l = obj.length; i < l; i++) {
+          if (i in obj && iterator.call(context, obj[i], i, obj) === breaker) return;
+        }
+      } catch (e) {
+        if (_.isFunction(obj.split)) {
+          each(obj.split(' ').length > 1 ? obj.split(' ') : obj.split(','), iterator, context);
+        } 
       }
     } else {
       for (var key in obj) {


### PR DESCRIPTION
I had previously maintained my own tool-belt and am now abandoning it in favor of yours.  One of the nice interfaces to my version of each that I had was a way that would take in strings without needing an explicit split.  For instance, you could do _.each("one two three", function()) and it would be smart enough to break that up for you.

I was able to add this functionality to your each implementation by using a try/catch block and not introduce any more logic to the if/else statement semantics.  I ran your performance tests with and without the patch on a number of platforms and made the results available here: http://qaa.ath.cx/each-with-strings.txt ... I recorded the jquery each result in a hope to show a reference point between the two test runs included for each platform.
