### PR TITLE
_.delete for objects

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
       A complete <a href="test/test.html">Test &amp; Benchmark Suite</a>
       is included for your perusal.
     </p>
-    
+
     <p>
       You may also read through the <a href="docs/underscore.html">annotated source code</a>.
     </p>
@@ -128,7 +128,7 @@
     </table>
 
     <h2>Table of Contents</h2>
-    
+
     <a href="#styles">Object-Oriented and Functional Styles</a>
 
     <p>
@@ -157,9 +157,9 @@
     <p>
       <b>Functions</b>
       <br />
-      <span class="methods"><a href="#bind">bind</a>, <a href="#bindAll">bindAll</a>, 
-      <a href="#memoize">memoize</a>, <a href="#delay">delay</a>, <a href="#defer">defer</a>, 
-      <a href="#throttle">throttle</a>, <a href="#debounce">debounce</a>, 
+      <span class="methods"><a href="#bind">bind</a>, <a href="#bindAll">bindAll</a>,
+      <a href="#memoize">memoize</a>, <a href="#delay">delay</a>, <a href="#defer">defer</a>,
+      <a href="#throttle">throttle</a>, <a href="#debounce">debounce</a>,
       <a href="#once">once</a>, <a href="#after">after</a>, <a href="#wrap">wrap</a>, <a href="#compose">compose</a></span>
     </p>
 
@@ -167,7 +167,7 @@
       <b>Objects</b>
       <br />
       <span class="methods"><a href="#keys">keys</a>, <a href="#values">values</a>,
-      <a href="#functions">functions</a>, <a href="#extend">extend</a>, <a href="#defaults">defaults</a>, <a href="#clone">clone</a>, <a href="#tap">tap</a>,
+      <a href="#functions">functions</a>, <a href="#extend">extend</a>, <a href="#defaults">defaults</a>, <a href="#clone">clone</a>, <a href="#tap">tap</a>, <a href="#delete">delete</a>,
       <a href="#isEqual">isEqual</a>, <a href="#isEmpty">isEmpty</a>, <a href="#isElement">isElement</a>,
       <a href="#isArray">isArray</a>, <a href="#isArguments">isArguments</a>, <a href="#isFunction">isFunction</a>, <a href="#isString">isString</a>,
       <a href="#isNumber">isNumber</a>, <a href="#isBoolean">isBoolean</a>, <a href="#isDate">isDate</a>, <a href="#isRegExp">isRegExp</a>
@@ -180,8 +180,8 @@
       <b>Utility</b>
       <br />
       <span class="methods"><a href="#noConflict">noConflict</a>,
-      <a href="#identity">identity</a>, <a href="#times">times</a>, 
-      <a href="#mixin">mixin</a>, <a href="#uniqueId">uniqueId</a>, 
+      <a href="#identity">identity</a>, <a href="#times">times</a>,
+      <a href="#mixin">mixin</a>, <a href="#uniqueId">uniqueId</a>,
       <a href="#template">template</a></span>
     </p>
 
@@ -192,7 +192,7 @@
     </p>
 
     <div id="documentation">
-      
+
       <h2 id="styles">Object-Oriented and Functional Styles</h2>
 
       <p>
@@ -431,7 +431,7 @@ _.min(numbers);
       <p id="sortBy">
         <b class="header">sortBy</b><code>_.sortBy(list, iterator, [context])</code>
         <br />
-        Returns a sorted copy of <b>list</b>, ranked by the results of running 
+        Returns a sorted copy of <b>list</b>, ranked by the results of running
         each value through <b>iterator</b>.
       </p>
       <pre>
@@ -600,7 +600,7 @@ _.zip(['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]);
         <br />
         Returns the index at which <b>value</b> can be found in the <b>array</b>,
         or <i>-1</i> if value is not present in the <b>array</b>. Uses the native
-        <b>indexOf</b> function unless it's missing. If you're working with a 
+        <b>indexOf</b> function unless it's missing. If you're working with a
         large array, and you know that the array is already sorted, pass <tt>true</tt>
         for <b>isSorted</b> to use a faster binary search.
       </p>
@@ -685,7 +685,7 @@ jQuery('#underscore_button').bind('click', buttonView.onClick);
         <b class="header">memoize</b><code>_.memoize(function, [hashFunction])</code>
         <br />
         Memoizes a given <b>function</b> by caching the computed result. Useful
-        for speeding up slow-running computations. If passed an optional 
+        for speeding up slow-running computations. If passed an optional
         <b>hashFunction</b>, it will be used to compute the hash key for storing
         the result, based on the arguments to the original function. The default
         <b>hashFunction</b> just uses the first argument to the memoized function
@@ -727,7 +727,7 @@ _.defer(function(){ alert('deferred'); });
       <p id="throttle">
         <b class="header">throttle</b><code>_.throttle(function, wait)</code>
         <br />
-        Returns a throttled version of the function, that, when invoked repeatedly, 
+        Returns a throttled version of the function, that, when invoked repeatedly,
         will only actually call the wrapped function at most once per every <b>wait</b>
         milliseconds. Useful for rate-limiting events that occur faster than you
         can keep up with.
@@ -754,7 +754,7 @@ $(window).resize(lazyLayout);
       <p id="once">
         <b class="header">once</b><code>_.once(function)</code>
         <br />
-        Creates a version of the function that can only be called one time. 
+        Creates a version of the function that can only be called one time.
         Repeated calls to the modified function will have no effect, returning
         the value from the original call. Useful for initialization functions,
         instead of having to set a boolean flag and then check it later.
@@ -769,7 +769,7 @@ initialize();
       <p id="after">
         <b class="header">after</b><code>_.after(count, function)</code>
         <br />
-        Creates a version of the function that will only be run after first 
+        Creates a version of the function that will only be run after first
         being called <b>count</b> times. Useful for grouping asynchronous responses,
         where you want to be sure that all the async calls have finished, before
         proceeding.
@@ -777,7 +777,7 @@ initialize();
       <pre>
 var renderNotes = _.after(notes.length, render);
 _.each(notes, function(note) {
-  note.asyncSave({success: renderNotes}); 
+  note.asyncSave({success: renderNotes});
 });
 // renderNotes is run once, after all notes have saved.
 </pre>
@@ -899,6 +899,19 @@ _([1,2,3,200]).chain().
   value();
 =&gt; [2, 200]
 =&gt; [4, 40000]
+</pre>
+
+      <p id="delete">
+        <b class="header">delete</b><code>_.delete(object, key)</code>
+        <br />
+        Deletes a key from an object, returning the value.
+      </p>
+      <pre>
+var moe = {name: 'moe', age: 35};
+_.delete(moe, 'age');
+=&gt; 35
+moe.age;
+=&gt; undefined
 </pre>
 
       <p id="isEqual">
@@ -1096,7 +1109,7 @@ _(3).times(function(){ genie.grantWish(); });</pre>
         <b class="header">mixin</b><code>_.mixin(object)</code>
         <br />
         Allows you to extend Underscore with your own utility functions. Pass
-        a hash of <tt>{name: function}</tt> definitions to have your functions 
+        a hash of <tt>{name: function}</tt> definitions to have your functions
         added to the Underscore object, as well as the OOP wrapper.
       </p>
       <pre>
@@ -1145,7 +1158,7 @@ _.template(list, {people : ['moe', 'curly', 'larry']});
         You can also use <tt>print</tt> from within JavaScript code.  This is
         sometimes more convenient than using <tt>&lt;%= ... %&gt;</tt>.
       </p>
-      
+
       <pre>
 var compiled = _.template("&lt;% print('Hello ' + epithet); %&gt;");
 compiled({epithet: "stooge"});
@@ -1156,8 +1169,8 @@ compiled({epithet: "stooge"});
         template settings to use different symbols to set off interpolated code.
         Define an <b>interpolate</b> regex, and an (optional) <b>evaluate</b> regex
         to match expressions that should be inserted and evaluated, respectively.
-        If no <b>evaluate</b> regex is provided, your templates will only be 
-        capable of interpolating values. 
+        If no <b>evaluate</b> regex is provided, your templates will only be
+        capable of interpolating values.
         For example, to perform
         <a href="http://github.com/janl/mustache.js#readme">Mustache.js</a>
         style templating:
@@ -1223,10 +1236,10 @@ _([1, 2, 3]).value();
         The <a href="http://github.com/mirven/underscore.lua">source</a> is
         available on GitHub.
       </p>
-      
+
       <p>
         <a href="https://github.com/edtsech/underscore.string">Underscore.string</a>,
-        an Underscore extension that adds functions for string-manipulation: 
+        an Underscore extension that adds functions for string-manipulation:
         <tt>trim</tt>, <tt>startsWith</tt>, <tt>contains</tt>, <tt>capitalize</tt>,
         <tt>reverse</tt>, <tt>sprintf</tt>, and more.
       </p>
@@ -1245,7 +1258,7 @@ _([1, 2, 3]).value();
         <a href="http://osteele.com/sources/javascript/functional/">Functional JavaScript</a>,
         which includes comprehensive higher-order function support as well as string lambdas.
       </p>
-      
+
       <p>
         Michael Aufreiter's <a href="http://substance.io/#michael/data-js">Data.js</a>,
         a data manipulation + persistence library for JavaScript.
@@ -1256,7 +1269,7 @@ _([1, 2, 3]).value();
       </p>
 
       <h2 id="changelog">Change Log</h2>
-      
+
       <p>
         <b class="header">1.1.6</b> &mdash; <small><i>April 18, 2011</i></small><br />
         Added <tt>_.after</tt>, which will return a function that only runs after
@@ -1267,30 +1280,30 @@ _([1, 2, 3]).value();
         <tt>_.extend</tt> no longer copies keys when the value is undefined.
         <tt>_.bind</tt> now errors when trying to bind an undefined value.
       </p>
-      
+
       <p>
         <b class="header">1.1.5</b> &mdash; <small><i>Mar 20, 2011</i></small><br />
         Added an <tt>_.defaults</tt> function, for use merging together JS objects
         representing default options.
         Added an <tt>_.once</tt> function, for manufacturing functions that should
         only ever execute a single time.
-        <tt>_.bind</tt> now delegates to the native ECMAScript 5 version, 
+        <tt>_.bind</tt> now delegates to the native ECMAScript 5 version,
         where available.
         <tt>_.keys</tt> now throws an error when used on non-Object values, as in
         ECMAScript 5.
         Fixed a bug with <tt>_.keys</tt> when used over sparse arrays.
       </p>
-      
+
       <p>
         <b class="header">1.1.4</b> &mdash; <small><i>Jan 9, 2011</i></small><br />
-        Improved compliance with ES5's Array methods when passing <tt>null</tt> 
+        Improved compliance with ES5's Array methods when passing <tt>null</tt>
         as a value. <tt>_.wrap</tt> now correctly sets <tt>this</tt> for the
         wrapped function. <tt>_.indexOf</tt> now takes an optional flag for
         finding the insertion index in an array that is guaranteed to already
         be sorted. Avoiding the use of <tt>.callee</tt>, to allow <tt>_.isArray</tt>
         to work properly in ES5's strict mode.
       </p>
-      
+
       <p>
         <b class="header">1.1.3</b> &mdash; <small><i>Dec 1, 2010</i></small><br />
         In CommonJS, Underscore may now be required with just: <br />
@@ -1302,26 +1315,26 @@ _([1, 2, 3]).value();
         Improved the <b>isType</b> family of functions for better interoperability
         with Internet Explorer host objects.
         <tt>_.template</tt> now correctly escapes backslashes in templates.
-        Improved <tt>_.reduce</tt> compatibility with the ECMA5 version: 
+        Improved <tt>_.reduce</tt> compatibility with the ECMA5 version:
         if you don't pass an initial value, the first item in the collection is used.
         <tt>_.each</tt> no longer returns the iterated collection, for improved
         consistency with ES5's <tt>forEach</tt>.
       </p>
-      
+
       <p>
         <b class="header">1.1.2</b><br />
-        Fixed <tt>_.contains</tt>, which was mistakenly pointing at 
-        <tt>_.intersect</tt> instead of <tt>_.include</tt>, like it should 
+        Fixed <tt>_.contains</tt>, which was mistakenly pointing at
+        <tt>_.intersect</tt> instead of <tt>_.include</tt>, like it should
         have been. Added <tt>_.unique</tt> as an alias for <tt>_.uniq</tt>.
       </p>
-      
+
       <p>
         <b class="header">1.1.1</b><br />
         Improved the speed of <tt>_.template</tt>, and its handling of multiline
-        interpolations. Ryan Tenney contributed optimizations to many Underscore 
+        interpolations. Ryan Tenney contributed optimizations to many Underscore
         functions. An annotated version of the source code is now available.
       </p>
-      
+
       <p>
         <b class="header">1.1.0</b><br />
         The method signature of <tt>_.reduce</tt> has been changed to match
@@ -1330,33 +1343,33 @@ _([1, 2, 3]).value();
         called with no arguments, and preserves whitespace. <tt>_.contains</tt>
         is a new alias for <tt>_.include</tt>.
       </p>
-      
+
       <p>
         <b class="header">1.0.4</b><br />
-        <a href="http://themoell.com/">Andri Möll</a> contributed the <tt>_.memoize</tt> 
-        function, which can be used to speed up expensive repeated computations 
+        <a href="http://themoell.com/">Andri Möll</a> contributed the <tt>_.memoize</tt>
+        function, which can be used to speed up expensive repeated computations
         by caching the results.
       </p>
-      
+
       <p>
         <b class="header">1.0.3</b><br />
         Patch that makes <tt>_.isEqual</tt> return <tt>false</tt> if any property
         of the compared object has a <tt>NaN</tt> value. Technically the correct
         thing to do, but of questionable semantics. Watch out for NaN comparisons.
       </p>
-      
+
       <p>
         <b class="header">1.0.2</b><br />
         Fixes <tt>_.isArguments</tt> in recent versions of Opera, which have
         arguments objects as real Arrays.
       </p>
-      
+
       <p>
         <b class="header">1.0.1</b><br />
-        Bugfix for <tt>_.isEqual</tt>, when comparing two objects with the same 
+        Bugfix for <tt>_.isEqual</tt>, when comparing two objects with the same
         number of undefined keys, but with different names.
       </p>
-      
+
       <p>
         <b class="header">1.0.0</b><br />
         Things have been stable for many months now, so Underscore is now
@@ -1364,15 +1377,15 @@ _([1, 2, 3]).value();
         include <tt>_.isBoolean</tt>, and the ability to have <tt>_.extend</tt>
         take multiple source objects.
       </p>
-      
+
       <p>
         <b class="header">0.6.0</b><br />
-        Major release. Incorporates a number of 
+        Major release. Incorporates a number of
         <a href="http://github.com/ratbeard">Mile Frawley's</a> refactors for
         safer duck-typing on collection functions, and cleaner internals. A new
         <tt>_.mixin</tt> method that allows you to extend Underscore with utility
-        functions of your own. Added <tt>_.times</tt>, which works the same as in 
-        Ruby or Prototype.js. Native support for ECMAScript 5's <tt>Array.isArray</tt>, 
+        functions of your own. Added <tt>_.times</tt>, which works the same as in
+        Ruby or Prototype.js. Native support for ECMAScript 5's <tt>Array.isArray</tt>,
         and <tt>Object.keys</tt>.
       </p>
 
@@ -1430,7 +1443,7 @@ _([1, 2, 3]).value();
         <b class="header">0.5.1</b><br />
         Added an <tt>_.isArguments</tt> function. Lots of little safety checks
         and optimizations contributed by
-        <a href="http://github.com/iamnoah/">Noah Sloan</a> and 
+        <a href="http://github.com/iamnoah/">Noah Sloan</a> and
         <a href="http://themoell.com/">Andri Möll</a>.
       </p>
 

--- a/test/objects.js
+++ b/test/objects.js
@@ -64,6 +64,13 @@ $(document).ready(function() {
     equals(_.last(moe.lucky), 101, 'changes to deep attributes are shared with the original');
   });
 
+  test("objects: delete", function() {
+    var moe = {name : 'moe', color : 'blue'};
+    var color = _.delete(moe, 'color');
+    equals(color, 'blue', 'returns the value for the deleted key');
+    equals(moe.color, undefined, 'removes the key from the object');
+  });
+
   test("objects: isEqual", function() {
     var moe   = {name : 'moe', lucky : [13, 27, 34]};
     var clone = {name : 'moe', lucky : [13, 27, 34]};

--- a/underscore.js
+++ b/underscore.js
@@ -584,6 +584,13 @@
     return obj;
   };
 
+  // Delete a key from an object and return its value
+  _.delete = function(obj, key) {
+    var value = obj[key];
+    delete obj[key];
+    return value;
+  };
+
   // Perform a deep comparison to check if two objects are equal.
   _.isEqual = function(a, b) {
     // Check object identity.


### PR DESCRIPTION
I've wanted JavaScript's `delete` to work like the Ruby version (returning the deleted value in one pass) so I thought _ would be a good fit:

```
function getUser(options) {
  options.url = "/users/" + _.delete(options, 'id');
  $.ajax(options);
}
```
