### PR TITLE
Added subtract, more versatile than without

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -43,6 +43,15 @@ $(document).ready(function() {
     equals(result.join(', '), '1, 2, 3, 4', 'works on an arguments object');
   });
 
+  test("arrays: subtract", function() {
+    var list = [1, 2, 1, 0, 3];
+    equals(_.subtract(list, [1, 0]).join(', '), '2, 3', 'can remove all instances of an object');
+    equals(_(list).subtract([1, 0]).join(', '), '2, 3', 'can use with OO-style syntax');
+    var result = (function(){ return _.subtract(arguments, [0, 1]); })(1, 2, 1, 0, 3, 1, 4);
+    equals(result.join(', '), '2, 3, 4', 'works on an arguments object');
+    equals(_.subtract(list, [2], [0, 3]).join(', '), '1, 1', 'subtracts multiple lists');
+  });
+
   test("arrays: without", function() {
     var list = [1, 2, 1, 0, 3, 1, 4];
     equals(_.without(list, 0, 1).join(', '), '2, 3, 4', 'can remove all instances of an object');
@@ -53,7 +62,7 @@ $(document).ready(function() {
     ok(_.without(list, {one : 1}).length == 2, 'uses real object identity for comparisons.');
     ok(_.without(list, list[0]).length == 1, 'ditto.');
   });
-
+  
   test("arrays: uniq", function() {
     var list = [1, 2, 1, 3, 1, 4];
     equals(_.uniq(list).join(', '), '1, 2, 3, 4', 'can find the unique values of an unsorted array');

--- a/underscore.js
+++ b/underscore.js
@@ -330,6 +330,13 @@
     var values = slice.call(arguments, 1);
     return _.filter(array, function(value){ return !_.include(values, value); });
   };
+  
+  // Return a version of the array that does not contain any items in the
+  // passed-in arrays.
+  _.subtract = function(array) {
+    var values = _.flatten(slice.call(arguments, 1));
+    return _.filter(array, function(value){ return !_.include(values, value); });
+  };
 
   // Produce a duplicate-free version of the array. If the array has already
   // been sorted, you have the option of using a faster algorithm.


### PR DESCRIPTION
To subtract one array from another using without, you'll basically have to do:

```
_.without.apply(null, [list1].concat(list2));
```

Subtract is inspired by the operator overloaded - (minus) in ruby Enumerable.

```
_(list1).subtract(list2);
```

I also built docs and .min using the rake file, but there seems to be some whitespace issues, so I left them out of the commit. Let me know if you want them added.

Thanks!
