### PR TITLE
Fixed isEqual and added isObject

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -77,6 +77,8 @@ $(document).ready(function() {
     ok(_.isEqual(new Date(100), new Date(100)), 'identical dates are equal');
     ok(_.isEqual((/hello/ig), (/hello/ig)), 'identical regexes are equal');
     ok(!_.isEqual(null, [1]), 'a falsy is never equal to a truthy');
+    ok(_.isEqual({isEqual: function () { return true; }}, {}), 'first object implements `isEqual`');
+    ok(_.isEqual({}, {isEqual: function () { return true; }}), 'second object implements `isEqual`');
     ok(!_.isEqual({x: 1, y: undefined}, {x: 1, z: 2}), 'objects with the same number of undefined keys are not equal');
     ok(!_.isEqual(_({x: 1, y: undefined}).chain(), _({x: 1, z: 2}).chain()), 'wrapped objects are not equal');
     equals(_({x: 1, y: 2}).chain().isEqual(_({x: 1, y: 2}).chain()).value(), true, 'wrapped objects are equal');
@@ -134,6 +136,21 @@ $(document).ready(function() {
     ok(!_.isArguments(_.toArray(args)), 'but not when it\'s converted into an array');
     ok(!_.isArguments([1,2,3]), 'and not vanilla arrays.');
     ok(_.isArguments(iArguments), 'even from another frame');
+  });
+
+  test("objects: isObject", function() {
+    ok(_.isObject(arguments), 'the arguments object is object');
+    ok(_.isObject([1, 2, 3]), 'and arrays');
+    ok(_.isObject($('html')[0]), 'and DOM element');
+    ok(_.isObject(iElement), 'even from another frame');
+    ok(_.isObject(function () {}), 'and functions');
+    ok(_.isObject(iFunction), 'even from another frame');
+    ok(!_.isObject(null), 'but not null');
+    ok(!_.isObject(undefined), 'and not undefined');
+    ok(!_.isObject('string'), 'and not string');
+    ok(!_.isObject(12), 'and not number');
+    ok(!_.isObject(true), 'and not boolean');
+    ok(_.isObject(new String('string')), 'but new String()');
   });
 
   test("objects: isArray", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -600,6 +600,7 @@
     if (b._chain) b = b._wrapped;
     // One of them implements an isEqual()?
     if (a.isEqual) return a.isEqual(b);
+    if (b.isEqual) return b.isEqual(a);
     // Check dates' integer values.
     if (_.isDate(a) && _.isDate(b)) return a.getTime() === b.getTime();
     // Both are NaN?
@@ -639,6 +640,11 @@
   // Delegates to ECMA5's native Array.isArray
   _.isArray = nativeIsArray || function(obj) {
     return toString.call(obj) === '[object Array]';
+  };
+
+  // Is a given variable an object?
+  _.isObject = function(obj) {
+    return obj === Object(obj);
   };
 
   // Is a given variable an arguments object?


### PR DESCRIPTION
Fixed isEqual if second object has isEqual implemented and added isObject method.

Found that isEqual doesn’t work properly if second argument implements isEqual, but first not. I guess, order shouldn’t matter.

Also added useful isObject method, example:
    function addProperty(obj) {
      if (_.isObject(obj)) obj.property = 1;
      console.log(obj.property); // guaranteed to be 1
    }
