### PR TITLE
Use setTimeout to verify _.delay's behavior in unit test

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -73,8 +73,8 @@ $(document).ready(function() {
   asyncTest("functions: delay", 2, function() {
     var delayed = false;
     _.delay(function(){ delayed = true; }, 100);
-    _.delay(function(){ ok(!delayed, "didn't delay the function quite yet"); }, 50);
-    _.delay(function(){ ok(delayed, 'delayed the function'); start(); }, 150);
+    setTimeout(function(){ ok(!delayed, "didn't delay the function quite yet"); }, 50);
+    setTimeout(function(){ ok(delayed, 'delayed the function'); start(); }, 150);
   });
 
   asyncTest("functions: defer", 1, function() {


### PR DESCRIPTION
Testing _.delay and verifying the behavior with _.delay makes it some kind of axiom. It asserts that _.delay's time counting will never go wrong. In fact, it could be:
- Modify _.delay's source code and change the wait time from `wait` to `wait * 1000`
- Run the unit test again and you will find that
  - _.delay test isn't broken
  - _.throttle and _.debounce tests are broken for no obvious reason

Using setTimeout to verify _.delay's behavior puts setTimeout in the axiom role. If the browser doesn't implement it right, there's nothing we can do about it.
