### PR TITLE
While Loop is faster then For Loop implementation

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -387,7 +387,8 @@
       return array[i] === item ? i : -1;
     }
     if (nativeIndexOf && array.indexOf === nativeIndexOf) return array.indexOf(item);
-    for (i = 0, l = array.length; i < l; i++) if (array[i] === item) return i;
+    var o,i=0;
+    while( o = array[i++] ) if (o === item) return i-1;
     return -1;
   };
 


### PR DESCRIPTION
Using a while loop is faster then using a for loop.  In fact the while loop is even faster then the native implementation, but I didn't propose in changing that.  You could probably avoid introducing a new variable if you did some trickery.

You can run the speed tests here, I found the results shocking even on a large array. :D

http://jsperf.com/js-for-loop-vs-array-indexof/10
