### PR TITLE
Add support for escaping values in templates

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -733,6 +733,11 @@
     for (var i = 0; i < n; i++) iterator.call(context, i);
   };
 
+  // Escape string for HTML
+  _.escape = function(string) {
+    return (''+string).replace(/&(?!\w+;|#\d+;|#x[\da-f]+;)/gi, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#x27;').replace(/\//g,'&#x2F;');
+  };
+
   // Add your own custom functions to the Underscore object, ensuring that
   // they're correctly added to the OOP wrapper as well.
   _.mixin = function(obj) {
@@ -753,7 +758,8 @@
   // following template settings to use alternative delimiters.
   _.templateSettings = {
     evaluate    : /<%([\s\S]+?)%>/g,
-    interpolate : /<%=([\s\S]+?)%>/g
+    interpolate : /<%=([\s\S]+?)%>/g,
+    encode      : /<%==([\s\S]+?)%>/g
   };
 
   // JavaScript micro-templating, similar to John Resig's implementation.
@@ -765,6 +771,9 @@
       'with(obj||{}){__p.push(\'' +
       str.replace(/\\/g, '\\\\')
          .replace(/'/g, "\\'")
+         .replace(c.encode, function(match, code) {
+           return "',_.escape(" + code.replace(/\\'/g, "'") + "),'";
+         })
          .replace(c.interpolate, function(match, code) {
            return "'," + code.replace(/\\'/g, "'") + ",'";
          })


### PR DESCRIPTION
To prevent XSS and to display values containing special characters properly, it would be nice to have a short syntax to automatically escape values.

This commit adds a new `<%== ... %>` syntax that uses a new `_.escape()` function (taken from Backbone.js' escapeHTML). I'm not quite sure about that syntax, but I couldn't think of anything nicer.

I actually think its better to escape values by default (with `<%= ... %>`), as it should be done 90% of the time, and add some other syntax for adding raw HTML - but it'll break backward compatibility. 
