### PR TITLE
Cast str to String

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -763,7 +763,7 @@
     var c  = _.templateSettings;
     var tmpl = 'var __p=[],print=function(){__p.push.apply(__p,arguments);};' +
       'with(obj||{}){__p.push(\'' +
-      str.replace(/\\/g, '\\\\')
+      String(str).replace(/\\/g, '\\\\')
          .replace(/'/g, "\\'")
          .replace(c.interpolate, function(match, code) {
            return "'," + code.replace(/\\'/g, "'") + ",'";


### PR DESCRIPTION
For node.js users, you have to cast `fs.readFile()`'s return to a String before passing it into a template.

Considering this function only expects a `String`, there is no harm in casting it straight into a `String`. 

For example, in node.js I often use:

```
_.template(String(fs.readFileSync(file)));
```

vs 

```
_.template(fs.readFileSync(file));
```
