### PR TITLE
Add _.paced to rate limit functions that need immediate invocation.

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -115,6 +115,19 @@ $(document).ready(function() {
     increment();
     equals(num, 1);
   });
+  
+  asyncTest("functions: paced", 1, function() {
+    var counter = 0;
+    var incr = function(){ counter++; };
+    var pacedIncr = _.paced(incr, 100);
+    pacedIncr(); pacedIncr(); pacedIncr();
+    setTimeout(pacedIncr, 30);
+    setTimeout(pacedIncr, 60);
+    setTimeout(pacedIncr, 90);
+    setTimeout(pacedIncr, 120);
+    setTimeout(pacedIncr, 150);
+    _.delay(function(){ ok(counter == 2, "incr was paced"); start(); }, 250);
+  });
 
   test("functions: wrap", function() {
     var greet = function(name){ return "hi: " + name; };

--- a/underscore.js
+++ b/underscore.js
@@ -514,6 +514,20 @@
     };
   };
 
+  // Returns a function, that, when invoked, will trigger immediately and then
+  // not trigger until N milliseconds no matter how often you call it. Useful for
+  // rate limiting noisy events that need immediate invocation.
+  _.paced = function(func, wait) {
+    var ran = false;
+    return function() {
+      if(!ran) {
+        ran = true;
+        setTimeout(function(){ ran = false; }, wait);
+        return func.apply(this, arguments);
+      }
+    };
+  };
+
   // Returns the first function passed as an argument to the second,
   // allowing you to adjust arguments, run code before and after, and
   // conditionally execute the original function.


### PR DESCRIPTION
Returns a function, that, when invoked, will trigger immediately and then not trigger until N milliseconds have passed no matter how often you call it. Useful for rate limiting noisy events that need immediate invocation such as user input.
