### PR TITLE
Link to Underscore.php in docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1257,6 +1257,14 @@ _([1, 2, 3]).value();
       </p>
       
       <p>
+        <a href="http://brianhaveri.github.com/Underscore.php/">Underscore.php</a>,
+        a PHP port of the functions that are applicable in both languages.
+        Includes OOP-wrapping and chaining.
+        The <a href="http://github.com/brianhaveri/Underscore.php">source</a> is
+        available on GitHub.
+      </p>
+      
+      <p>
         <a href="https://github.com/edtsech/underscore.string">Underscore.string</a>,
         an Underscore extension that adds functions for string-manipulation: 
         <tt>trim</tt>, <tt>startsWith</tt>, <tt>contains</tt>, <tt>capitalize</tt>,


### PR DESCRIPTION
Could the Underscore.js docs link to Underscore.php as is done with Underscore.lua?

Underscore.php contains the functions applicable to both languages, plus matching unit tests. I keep Underscore.php up to date with Underscore.js.

Thanks!
