### PR TITLE
templates, evaluate blocks, "Unexpected identifier" 

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -776,7 +776,7 @@
          })
          .replace(c.evaluate || null, function(match, code) {
            return "');" + code.replace(/\\'/g, "'")
-                              .replace(/[\r\n\t]/g, ' ') + "__p.push('";
+                              .replace(/[\r\n\t]/g, ' ') + "; __p.push('";
          })
          .replace(/\r/g, '\\r')
          .replace(/\n/g, '\\n')


### PR DESCRIPTION
some evaluate blocks like begining of 'for' might not have semicolon at the end so error "Unexpected identifier" occurs
