### PR TITLE
Augment _.extend() to also copy over Javascript's getters and setters

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -39,6 +39,14 @@ $(document).ready(function() {
     ok(_.isEqual(result, {x:2, a:'b'}), 'extending from multiple source objects last property trumps');
     result = _.extend({}, {a: void 0, b: null});
     equals(_.keys(result).join(''), 'b', 'extend does not copy undefined values');
+
+    result = _.extend({}, {
+      get getter() { return 'a getter'; },
+      set setter(val) { this.theSetValue = val; }
+    });
+    result.setter = 'set value';
+    equals(result.getter, 'a getter', 'can extend javascript getters');
+    equals(result.theSetValue, 'set value', 'can extend javascript setters');
   });
 
   test("objects: defaults", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -576,7 +576,15 @@
   _.extend = function(obj) {
     each(slice.call(arguments, 1), function(source) {
       for (var prop in source) {
-        if (source[prop] !== void 0) obj[prop] = source[prop];
+        var getter = source.__lookupGetter__(prop)
+        var setter = source.__lookupSetter__(prop);
+
+        if (getter || setter) {
+          if (getter) obj.__defineGetter__(prop, getter);
+          if (setter) obj.__defineSetter__(prop, setter);
+        } else if (source[prop] !== void 0) {
+          obj[prop] = source[prop];
+        }
       }
     });
     return obj;


### PR DESCRIPTION
Javascript has the little know ability to provide getter and setter methods that look like a property.

```
var object = {
  set full_name(value) {
    var split = value.split(" ");
    this.first_name = split[0];
    this.last_name = split[1];
  },
  get full_name() {
    return this.first_name + " " + this.last_name;
  }
}

object.full_name = "John Doe";
object.full_name;              // "John Doe"
object.first_name;             // "John"
```

This tested change makes sure that any getters and setters are copied over to the destination object as well.

More info about these getters and setters can be found at John Resig's post:

http://ejohn.org/blog/javascript-getters-and-setters/
