### PR TITLE
Get the actual difference between two arrays and introduce array subtraction

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -363,10 +363,14 @@
     });
   };
 
+  // Remove all elements in the second array from the first array
+  _.subtract = function(array, other) {
+    return _.filter(array, function(value){ return !_.include(other, value); }); 
+  }
+
   // Take the difference between one array and another.
-  // Only the elements present in just the first array will remain.
   _.difference = function(array, other) {
-    return _.filter(array, function(value){ return !_.include(other, value); });
+    return _.union(_.subtract(array, other), _.subtract(other, array));
   };
 
   // Zip together multiple lists into a single array -- elements that share


### PR DESCRIPTION
I feel like the current "difference" method is counterintuitive, because I would expect a method call "difference" to show elements which are in array one and not in array two **and** vice versa.

The current "difference" should in stead be called subtract, because the elements of the second array are removed from the first (if present).
