### PR TITLE
_.transpose(array)

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -103,6 +103,18 @@ $(document).ready(function() {
     equals(String(result), '1,2,3,A,B,C', 'tranposed arrays to align data of matching indices');
   });
 
+  test('arrays: transpose x2', function() {
+    var arrays = [[1, 'A'], [2, 'B'], [3, 'C']];
+    var result = _.transpose(_.transpose(arrays));
+    equals(String(result), '1,A,2,B,3,C', 'double tranposed arrays to align data of matching indices');
+  });
+
+  test('arrays: transpose uneven arrays', function(){
+    var arrays = [[1, 'A'], [2, 'B', 'Triangle'], [3, 'C']];
+    var result = _.transpose(arrays);
+
+    equals(String(result), '1,2,3,A,B,C,,Triangle,');
+  });
 
   test("arrays: indexOf", function() {
     var numbers = [1, 2, 3];

--- a/underscore.js
+++ b/underscore.js
@@ -381,7 +381,8 @@
 
   _.transpose = function(array){
     var tempArray = [];
-    _.each(_.range(array[0].length), function(i){ tempArray.push(_.pluck(array, i));  });
+    var longest = _.max(array, function(a){ return a.length; }).length;
+    _.each(_.range(longest), function(i){ tempArray.push(_.pluck(array, i));  });
     return tempArray;
   }
 


### PR DESCRIPTION
I recently had a need to flip array indicies, and thought it seemed a simple enough thing that I'd likely find it in backbone - and I didn't. I wrote a quick function, attempted to do so in as similar fashion as the rest of backbone, and tested it with the following:

turning:
[[1, "a"], [2, "b"], [3, "c"]]

into:
[[1,2,3], ["a", "b", "c"]]

A more visual example, flipping it on its side (whilst maintaining original order)
[1,A]
[2,B]
[3,C]

[1,2,3]
[A,B,C]

Hooray, now I can smash arrays together. It's not quite like zip, which didn't allow me to send in an array of arrays. Useful?
