### PR TITLE
Make ._bind have the behavior of the native bind function when using the new operator

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -29,6 +29,14 @@ $(document).ready(function() {
     _.bind(func, 0, 0, 'can bind a function to `0`')();
     _.bind(func, '', '', 'can bind a function to an empty string')();
     _.bind(func, false, false, 'can bind a function to `false`')();
+     
+    // These tests are only meaningful when using a browser without a native bind function
+    // To test this with a modern browser, set underscore's nativeBind to undefined
+    var F = function () { return this; };
+    var Boundf = _.bind(F, {hello: "moe curly"});
+
+    equal(new Boundf().hello, undefined, "function should not be bound to the context, to comply with ECMAScript 5");
+    equal(Boundf().hello, "moe curly", "When called without the new operator, it's OK to be bound to the context");
   });
 
   test("functions: bindAll", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -438,10 +438,15 @@
   // We check for `func.bind` first, to fail fast when `func` is undefined.
   _.bind = function(func, obj) {
     if (func.bind === nativeBind && nativeBind) return nativeBind.apply(func, slice.call(arguments, 1));
-    var args = slice.call(arguments, 2);
-    return function() {
-      return func.apply(obj, args.concat(slice.call(arguments)));
+    var aArgs = slice.call(arguments, 2),
+    fNOP = function () {},
+    fBound = function () {
+        return func.apply(this instanceof fNOP ? this : obj, aArgs.concat(slice.call(arguments)));
     };
+
+    fNOP.prototype = func.prototype;
+    fBound.prototype = new fNOP();
+    return fBound;
   };
 
   // Bind all of an object's methods to that object. Useful for ensuring that


### PR DESCRIPTION
This commit fixes #280 if decided it needs to be fixed.
