### PR TITLE
Add an optional index argument to _.last()

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -30,6 +30,8 @@ $(document).ready(function() {
     equals(_.last([1,2,3], 2).join(', '), '2, 3', 'can pass an index to last');
     var result = (function(){ return _(arguments).last(); })(1, 2, 3, 4);
     equals(result, 4, 'works on an arguments object');
+    result = _.map([[1,2,3],[1,2,3]], _.last);
+    equals(result.join(','), '3,3', 'works well with _.map');
   });
 
   test("arrays: compact", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -307,9 +307,9 @@
   };
 
   // Get the last element of an array. Passing **n** will return the last N
-  // values in the array.
-  _.last = function(array, n) {
-    return (n != null) ? slice.call(array, array.length - n) : array[array.length - 1];
+  // values in the array. The **guard** check allows it to work with `_.map`.
+  _.last = function(array, n, guard) {
+    return (n != null) && !guard ? slice.call(array, array.length - n) : array[array.length - 1];
   };
 
   // Trim out all falsy values from an array.


### PR DESCRIPTION
This makes _.last() behave the same as _.first().  Passing an optional
second argument n will return the last n elements of the array.
