### PR TITLE
Removed == comparison in isEqual

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -612,8 +612,6 @@
     // Different types?
     var atype = typeof(a), btype = typeof(b);
     if (atype != btype) return false;
-    // Basic equality test (watch out for coercions).
-    if (a == b) return true;
     // One is falsy and the other truthy.
     if ((!a && b) || (a && !b)) return false;
     // Unwrap any wrapped objects.


### PR DESCRIPTION
First you return true if they are === then you return false if the types don't match then you check with ==.

The doc for == says 
"If the two operands are not of the same type, JavaScript converts the operands then applies strict comparison."
So I dont think you gain anything from doing the == comparison after testing types.

Cheers, 
Tom
