### PR TITLE
_.toType and _.conversionPath to introduce a convention for non-native co

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -179,6 +179,43 @@ $(document).ready(function() {
     ok(result instanceof SomeNamespace.SomeClass2, 'SomeNamespace.SomeClass2 was created by constructor function');
   });
 
+  test("objects: isConvertible", function() {
+    window.SomeNamespace || (window.SomeNamespace = {});
+    var instance;
+    
+    SomeNamespace.SuperClass = (function() {
+      function SuperClass() {}
+      return SuperClass;
+    })();
+    
+    SomeSubClass = (function() {
+       __extends(SomeSubClass, SomeNamespace.SuperClass);
+      function SomeSubClass() {}
+      return SomeSubClass;
+    })();
+    
+    SomeUnrelatedClass1 = (function() {
+      function SomeUnrelatedClass1() { this.super_instance = new SomeNamespace.SuperClass(); }
+      SomeUnrelatedClass1.prototype.toSuperClass = function() { return this.super_instance; } 
+      return SomeUnrelatedClass1;
+    })();
+    
+    instance = new SomeNamespace.SuperClass();
+    ok(_.isConvertible(instance, 'SomeNamespace.SuperClass'), 'SomeNamespace.SuperClass can convert to SomeNamespace.SuperClass by string');
+    ok(_.isConvertible(instance, SomeNamespace.SuperClass), 'SomeNamespace.SuperClass can convert to SomeNamespace.SuperClass by constructor');
+    ok(!_.isConvertible(instance, 'SuperClass'), 'SomeNamespace.SuperClass cannot convert to SuperClass by string');
+    
+    instance = new SomeSubClass();
+    ok(_.isConvertible(instance, 'SomeNamespace.SuperClass'), 'SomeSubClass can convert to SomeNamespace.SuperClass by string');
+    ok(_.isConvertible(instance, SomeNamespace.SuperClass), 'SomeSubClass can convert to SomeNamespace.SuperClass by constructor');
+    ok(!_.isConvertible(instance, 'SuperClass'), 'SomeSubClass cannot convert to SuperClass by string');
+    
+    instance = new SomeUnrelatedClass1();
+    ok(_.isConvertible(instance, 'SomeNamespace.SuperClass'), 'SomeUnrelatedClass1 can convert to SomeNamespace.SuperClass by string');
+    ok(_.isConvertible(instance, SomeNamespace.SuperClass), 'SomeUnrelatedClass1 can convert to SomeNamespace.SuperClass by constructor');
+    ok(_.isConvertible(instance, 'SuperClass'), 'SomeUnrelatedClass1 can convert to SuperClass by string (because it has a toSuperClass method)');
+  });
+
   test("objects: toType", function() {
     window.SomeNamespace || (window.SomeNamespace = {});
     var instance, result;

--- a/underscore.js
+++ b/underscore.js
@@ -711,6 +711,11 @@
     return _.CONVERT_NONE;
   };
 
+  // Helper to checks if a conversion is available including being the actual type
+  _.isConvertible = function(obj, key) {
+    return (_.conversionPath(obj, key)>0);
+  };
+
   // Converts from one time to another using a string, keypath or constructor if it can find a conversion path.
   _.toType = function(obj, key) {
     var keypath_components = _.isArray(key) ? key : (_.isString(key) ? key.split('.') : undefined);


### PR DESCRIPTION
_.toType and _.conversionPath to introduce a convention for non-native conversions using is{SomeType}(), to{SomeType}().
