### PR TITLE
Replaced isWhatever tests by toString.call(whatever) === "[object Whatever]" when possible.

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -753,17 +753,18 @@
 
   // Is a given value a function?
   _.isFunction = function(obj) {
-    return !!(obj && obj.constructor && obj.call && obj.apply);
+    return toString.call(obj) === '[object Function]';
   };
 
   // Is a given value a string?
   _.isString = function(obj) {
-    return !!(obj === '' || (obj && obj.charCodeAt && obj.substr));
+    return toString.call(obj) === '[object String]';
   };
 
   // Is a given value a number?
+  // Does not include NaN
   _.isNumber = function(obj) {
-    return !!(obj === 0 || (obj && obj.toExponential && obj.toFixed));
+    return obj === obj && toString.call(obj) === '[object Number]';
   };
 
   // Is the given value `NaN`? `NaN` happens to be the only value in JavaScript
@@ -779,12 +780,12 @@
 
   // Is a given value a date?
   _.isDate = function(obj) {
-    return !!(obj && obj.getTimezoneOffset && obj.setUTCFullYear);
+    return toString.call(obj) === '[object Date]';
   };
 
   // Is the given value a regular expression?
   _.isRegExp = function(obj) {
-    return !!(obj && obj.test && obj.exec && (obj.ignoreCase || obj.ignoreCase === false));
+    return toString.call(obj) === '[object RegExp]';
   };
 
   // Is a given value equal to null?


### PR DESCRIPTION
Replaced isWhatever tests by toString.call(whatever) === "[object Whatever]" when possible.

It still does pass all the tests and is most likely what users want. When you check for that, you want to know if some methods are available so you don't care if it is an "object" or a "literal" since it'll have the same properties. But that was also the case with the previous version. The new thing is that now, you can assume it has _all_ the methods. It would be possible to do this too with previous version by checking for all methods but it would make tests very long and inefficient.

I removed every check for a special value since all these types can have an "infinite" number of different values and checking for a particular one isn't really a good idea in the general case, except for booleans that have only two values (in their most used form: literals) so checking for them might might still improve performance (so I didn't remove that test).
I think the tests in booleans could be rewritten like that:
return !!boolean === boolean but I don't know if it is in fact more efficient or not.

I tried to do the same with arguments but it fails in IE 6 at least.
I really feel like checking for a callee property isn't the right way of doing it... but I can't find any other :/

There is also one thing I wondered: Whether isNumber should call isNaN to check for NaN and since it gives better performance, I assumed it shouldn't. If you have some kind of convention on that, please let me know.

I'd have also changed isElement if I could but I doubt it behaves the same everywhere and don't really know how it does behave so I didn't.
