### PR TITLE
Add support for CommonJS implementations that do not support modules.expo

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -54,7 +54,7 @@
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = _;
     _._ = _;
-  } else if (exports !== 'undefined') {
+  } else if (typeof exports !== 'undefined' && exports) {
     exports._ = _;
   } else {
     // Exported as a string, for Closure Compiler "advanced" mode.


### PR DESCRIPTION
Add support for CommonJS implementations that do not support modules.exports. 

In its current state we cannot load underscore as a module in Titanium since we do not support the `module.exports` object. Adding `_` to the standard `exports` object would expose underscore in a similar modular fashion, and could be used in our apps like this:

`var _ = require('underscore')._;`
