### PR TITLE
Optionally call AMD define() to register module

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -56,22 +56,17 @@
       exports = module.exports = _;
     }
     exports._ = _;
-  } else {
-    // Exported as a string, for Closure Compiler "advanced" mode.
-    root['_'] = _;
-
+  } else if (typeof define === 'function' && define.amd) {
     // Register as a module with AMD. Use a named module since underscore
     // can be used in optimization schemes that do not understand anonymous
     // modules, and the if it is used on a page with an AMD loader, a load
-    // error could occur. This work is done in addition to exporting a global
-    // on root since the web page could use an AMD loader to load the module
-    // but still want to use the global reference. Test pages are a good
-    // example.
-    if (typeof define === 'function' && define.amd) {
-      define('underscore', function() {
-        return _;
-      });
-    }
+    // error could occur.
+    define('underscore', function() {
+      return _;
+    });
+  } else {
+    // Exported as a string, for Closure Compiler "advanced" mode.
+    root['_'] = _;
   }
 
   // Current version.


### PR DESCRIPTION
This issue has come up before, in Issue #287. This pull request is different in these two aspects:
- The patch itself is different, doing it optionally as part of the global registration branch.
- I can provide more context on why this is useful to do.
## Patch

It is done as part of the "set global" branch, and it does not interfere with that branch, just optionally calls define if it is available. So this should not cause issues with code that still wants to use underscore as a global even when an AMD loader is on the page.
## Context

In the previous pull/issue there were concerns that a global define not being part of too many useful JS runtimes.

define() is part of the AMD API which is being adopted by a few toolkits like Dojo, MooTools and EmbedJS. jQuery 1.7 will include a very similar opt-in define() call as specified in this patch. define()-based code can run in Node via the requirejs package, and define() can be used in jetpack/add-on SDK add-ons for Firefox. Firebug 1.8+ uses define().

[More reasoning and context for AMD](http://requirejs.org/docs/whyamd.html).
