### PR TITLE
Fix for _.template() HTML escaping when using noConflict() and minification.

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -899,8 +899,8 @@
          .replace(/\n/g, '\\n')
          .replace(/\t/g, '\\t')
          + "');}return __p.join('');";
-    var func = new Function('obj', tmpl);
-    return data ? func(data) : func;
+    var func = new Function('obj', '_', tmpl);
+    return data ? func(data, _) : function(data) { return func(data, _) };
   };
 
   // The OOP Wrapper


### PR DESCRIPTION
The method requires access to `_.escape()`, but if you minify the code and call `noConflict()` (or wrap the entire underscore library in a closure, as in my case), `_` ceases to be available and you get a _"_ is undefined"_ error trying to call `_.escape()`.

This fixes it. Tested and confirmed. Easy peasy :)

PS sorry for the crap markdown - new to this.
