### PR TITLE
this function prevents me from breaking my chaining in certain situations.

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -19,6 +19,10 @@ $(document).ready(function() {
     equals(_.values({one : 1, two : 2}).join(', '), '1, 2', 'can extract the values from an object');
   });
 
+  test("objects: kv", function() {
+    equals(true,_.isEqual(_.kv({one : 1, two : 2}),[['one', 1],['two', 2]]), 'can extract the key value pairs from an object');
+  });
+
   test("objects: functions", function() {
     var obj = {a : 'dash', b : _.map, c : (/yo/), d : _.reduce};
     ok(_.isEqual(['b', 'd'], _.functions(obj)), 'can grab the function names of any passed-in object');

--- a/underscore.js
+++ b/underscore.js
@@ -616,6 +616,11 @@
   _.values = function(obj) {
     return _.map(obj, _.identity);
   };
+  
+  // Retrieve the keys and values of an object's properties.
+  _.kv = function(obj) {
+    return _.zip(_.keys(obj),_.values(obj));
+  };
 
   // Return a sorted list of the function names available on the object.
   // Aliased as `methods`


### PR DESCRIPTION
a key value function that takes in an object and returns [[key,value]...] list.
this is useful for dealing with groupBy and any other situation where toArray()'s removal of keys is problematic.
