### PR TITLE
Explicit definition of global context for compatibility with Adobe products

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -959,4 +959,4 @@
     return this._wrapped;
   };
 
-})();
+}).call(this);


### PR DESCRIPTION
From comments on issue #355

(function(){...}).**call(this)**;
