### PR TITLE
Fix for IE7, _.pluck is brittle with jagged data

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -220,8 +220,9 @@
   };
 
   // Convenience version of a common use case of `map`: fetching a property.
+  // Added a conditional to hold IE7's hand past the jagged data :)
   _.pluck = function(obj, key) {
-    return _.map(obj, function(value){ return value[key]; });
+    return _.map(obj, function(value){ if (value && value[key]) return value[key]; });
   };
 
   // Return the maximum element or (element-based computation).


### PR DESCRIPTION
IE7 fails on _.pluck with jagged data.  Added a conditional so it could skip past the undefineds.
