### PR TITLE
_.indexOf and _.lastIndexOf proper sparse array support.

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -432,7 +432,7 @@
       return array[i] === item ? i : -1;
     }
     if (nativeIndexOf && array.indexOf === nativeIndexOf) return array.indexOf(item);
-    for (i = 0, l = array.length; i < l; i++) if (!_.isUndefined(array[i]) && array[i] === item) return i;
+    for (i = 0, l = array.length; i < l; i++) if (i in array && array[i] === item) return i;
     return -1;
   };
 
@@ -441,7 +441,7 @@
     if (array == null) return -1;
     if (nativeLastIndexOf && array.lastIndexOf === nativeLastIndexOf) return array.lastIndexOf(item);
     var i = array.length;
-    while (i--) if (!_.isUndefined(array[i]) && array[i] === item) return i;
+    while (i--) if (i in array && array[i] === item) return i;
     return -1;
   };
 


### PR DESCRIPTION
Like in [other projects](https://github.com/jashkenas/coffee-script/issues/1771) underscore.js needs to fix its `_.indexOf` and `_.lastIndexOf` fallbacks to properly support sparse arrays. This affects browsers like IE < 9.
