### PR TITLE
Speed up _.each array iteration on older browsers

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -80,9 +80,8 @@
     if (nativeForEach && obj.forEach === nativeForEach) {
       obj.forEach(iterator, context);
     } else if (obj.length === +obj.length) {
-	  var l = obj.length;
-	  while (l--) {
-	    if (i in obj && iterator.call(context, obj[l], l, obj) === breaker) return;
+	  for (var l = obj.length; l--;) {
+	    if (l in obj && iterator.call(context, obj[l], l, obj) === breaker) return;
 	  }
     } else {
       for (var key in obj) {


### PR DESCRIPTION
On browsers that do not JIT compile their javascript (IE<9), a slight speed increase can often be obtained by using a decreasing while or for loop in place of their increasing equivalents.

By changing the array iteration in the _.each method to use a decreasing for loop, we save a few lookups and can speed up iteration over large arrays. In this implementation, the comparison step of the for loop also post-auto-decrements the iterator, saving steps.

This is equivalent to running:

```
var l = obj.length;
while (l--) {
}
```

and works because 0 is a falsy value in Javascript which will properly terminate the loop.

A for loop was chosen over a while loop for no other reason than the more concise syntax.
