### PR TITLE
doc for bind: currying vs partial application

### DIFF
--- a/index.html
+++ b/index.html
@@ -715,7 +715,7 @@ _.range(0);
         Bind a <b>function</b> to an <b>object</b>, meaning that whenever
         the function is called, the value of <i>this</i> will be the <b>object</b>.
         Optionally, bind <b>arguments</b> to the <b>function</b> to pre-fill them,
-        also known as <b>currying</b>.
+        also known as <b>partial application</b>.
       </p>
       <pre>
 var func = function(greeting){ return greeting + ': ' + this.name };


### PR DESCRIPTION
The documentation for bind conflates currying with partial application. These concepts are closely related, but not the same thing:

http://en.wikipedia.org/wiki/Currying#Contrast_with_partial_function_application

I think partial application is the more correct term here. Also, I think it's more appropriate because the term "partial application" is more descriptive of what bind does than "currying" to someone unfamiliar with these terms previously.
