### PR TITLE
Added _.humanJoin method

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -163,12 +163,12 @@ $(document).ready(function() {
     equals(_.range(0, -10, -1).join(' '), '0 -1 -2 -3 -4 -5 -6 -7 -8 -9', 'final example in the Python docs');
   });
 
-  test("arrays: humanJoin", function() {
-      equals(_.humanJoin(['jQuery']), 'jQuery', 'array with a single element')
-      equals(_.humanJoin(['jQuery', 'MooTools']), 'jQuery and MooTools', 'array with two elements');
-      equals(_.humanJoin(['jQuery', 'MooTools', 'Prototype']), 'jQuery, MooTools and Prototype', 'array with three elements');
-      equals(_.humanJoin(['jQuery', 'MooTools', 'Prototype', 'YUI']), 'jQuery, MooTools, Prototype and YUI', 'array with multiple elements');
-      equals(_.humanJoin(['jQuery', 'MooTools', 'Prototype'], ',', ' or '), 'jQuery,MooTools or Prototype', 'handles custom separators');
+  test("arrays: toSentence", function() {
+      equals(_.toSentence(['jQuery']), 'jQuery', 'array with a single element')
+      equals(_.toSentence(['jQuery', 'MooTools']), 'jQuery and MooTools', 'array with two elements');
+      equals(_.toSentence(['jQuery', 'MooTools', 'Prototype']), 'jQuery, MooTools and Prototype', 'array with three elements');
+      equals(_.toSentence(['jQuery', 'MooTools', 'Prototype', 'YUI']), 'jQuery, MooTools, Prototype and YUI', 'array with multiple elements');
+      equals(_.toSentence(['jQuery', 'MooTools', 'Prototype'], ',', ' or '), 'jQuery,MooTools or Prototype', 'handles custom separators');
   });
 
 });

--- a/underscore.js
+++ b/underscore.js
@@ -422,7 +422,7 @@
     return results;
   };
 
-  _.humanJoin = function(array, separator, lastSeparator) {
+  _.toSentence = function(array, separator, lastSeparator) {
       separator || (separator = ', ');
       lastSeparator || (lastSeparator = ' and ');
       var length = array.length, str = '';


### PR DESCRIPTION
Not sure this method will meet the qualifications needed to be merged into the Underscore.js source. But I often find myself in need of this method. Therefor I created and added humanJoin.

It basicially takes an array and joins the elements into a string separated by a arbitrary delimiter with the ability to overwrite the last delimiter. See example below.

``` javascript
_.toSentence(['jQuery', 'MooTools', 'Prototype'], delimiter = ', ', lastDelimiter = ' and ');
// => 'jQuery, MooTools and Prototype'
```
