### PR TITLE
Modify type of `dependencies` at package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "keywords"      : ["util", "functional", "server", "client", "browser"],
   "author"        : "Jeremy Ashkenas <jeremy@documentcloud.org>",
   "contributors"  : [],
-  "dependencies"  : [],
   "repository"    : {"type": "git", "url": "git://github.com/documentcloud/underscore.git"},
   "main"          : "underscore.js",
   "version"       : "1.2.4"


### PR DESCRIPTION
When I installed module(such as [js2coffee](https://github.com/rstacruz/js2coffee)) that using `underscore` as dependencies,
npm puts following warning message:

``` sh
npm WARN underscore@1.2.4 dependencies field should be hash of <name>:<version-range> pairs 
```

Versions:
- node v0.6.7
- npm 1.1.0-beta-10

I modified type of dependencies at `package.json`.
