### PR TITLE
Register as AMD module, but still export a global

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -50,19 +50,20 @@
 
   // Export the Underscore object for **Node.js** and **"CommonJS"**, with
   // backwards-compatibility for the old `require()` API. If we're not in
-  // CommonJS, add `_` to the global object.
+  // CommonJS, add `_` to the global object via a string identifier for
+  // the Closure Compiler "advanced" mode, and optionally register as an
+  // AMD module via define().
   if (typeof exports !== 'undefined') {
     if (typeof module !== 'undefined' && module.exports) {
       exports = module.exports = _;
     }
     exports._ = _;
-  } else if (typeof define === 'function' && define.amd) {
-    // Register as a named module with AMD.
-    define('underscore', function() {
-      return _;
-    });
   } else {
-    // Exported as a string, for Closure Compiler "advanced" mode.
+    if (typeof define === 'function' && define.amd) {
+      define('underscore', function() {
+        return _;
+      });
+    }
     root['_'] = _;
   }
 


### PR DESCRIPTION
This is in response to [this commit](https://github.com/documentcloud/underscore/commit/0d4b1247c45083c695cab4242c084a97aa600221), which came out of reports of issues using underscore in an AMD environment. 

From what I have heard, the issues are mainly when trying to also use backbone. Those issues could be resolved by merging [this pull request](https://github.com/documentcloud/backbone/pull/710). 

But in general, if underscore prefers to not get reports of issues with an AMD loader, this pull request also exports a global even if define() is available. This is the same approach that jQuery uses. Ideally this would not be needed, but modular development is just getting bootstrapped on the web, and during this bootstrap period, this approach avoids issues.

If pull requests are not the way you prefer to have this conversation, please let me know what avenue works best.
