### PR TITLE
added "collect" alias for "map"

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -35,6 +35,9 @@ $(document).ready(function() {
     var doubled = _.map([1, 2, 3], function(num){ return num * 2; });
     equals(doubled.join(', '), '2, 4, 6', 'doubled numbers');
 
+    doubled = _.collect([1, 2, 3], function(num){ return num * 2; });
+    equals(doubled.join(', '), '2, 4, 6', 'aliased as "collect"');
+
     var tripled = _.map([1, 2, 3], function(num){ return num * this.multiplier; }, {multiplier : 3});
     equals(tripled.join(', '), '3, 6, 9', 'tripled numbers with context');
 

--- a/underscore.js
+++ b/underscore.js
@@ -89,7 +89,7 @@
 
   // Return the results of applying the iterator to each element.
   // Delegates to **ECMAScript 5**'s native `map` if available.
-  _.map = function(obj, iterator, context) {
+  _.map = _.collect = function(obj, iterator, context) {
     var results = [];
     if (obj == null) return results;
     if (nativeMap && obj.map === nativeMap) return obj.map(iterator, context);


### PR DESCRIPTION
because other functions also similarly have ruby-like aliases
