### PR TITLE
Clarify docs: return value of uniqueId

### DIFF
--- a/index.html
+++ b/index.html
@@ -1278,6 +1278,7 @@ _("fabio").capitalize();
         <br />
         Generate a globally-unique id for client-side models or DOM elements
         that need one. If <b>prefix</b> is passed, the id will be appended to it.
+        Without <b>prefix</b>, returns an integer.
       </p>
       <pre>
 _.uniqueId('contact_');


### PR DESCRIPTION
The docs previously were not clear whether `uniqueId` would return a string or integer when called without arguments.
