### PR TITLE
Short Circuit `isEmpty` for null/undefined

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -761,6 +761,7 @@
   // Is a given array, string, or object empty?
   // An "empty" object has no enumerable own-properties.
   _.isEmpty = function(obj) {
+    if (obj == null) return true;
     if (_.isArray(obj) || _.isString(obj)) return obj.length === 0;
     for (var key in obj) if (_.has(obj, key)) return false;
     return true;


### PR DESCRIPTION
Bailing early for `null` and `undefined` values saves two function calls.
