### PR TITLE
Reject and Select should not destroy Collections indexes

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -258,8 +258,8 @@ $(document).ready(function() {
 
   test('collections: shuffle', function() {
     var numbers = _.range(10);
-	var shuffled = _.shuffle(numbers).sort();
-	notStrictEqual(numbers, shuffled, 'original object is unmodified');
+    var shuffled = _.shuffle(numbers).sort();
+    notStrictEqual(numbers, shuffled, 'original object is unmodified');
     equal(shuffled.join(','), numbers.join(','), 'contains the same members before and after shuffle');
   });
 

--- a/underscore.js
+++ b/underscore.js
@@ -151,7 +151,7 @@
   // Delegates to **ECMAScript 5**'s native `filter` if available.
   // Aliased as `select`.
   _.filter = _.select = function(obj, iterator, context) {
-    var results = _.isArray(obj) ? [] : {};
+    var results  = createNewResultSet(obj);
     if (obj == null) return results;
     each(obj, function(value, index, list) {
       if (iterator.call(context, value, index, list)) append(results, value, index);
@@ -161,7 +161,7 @@
 
   // Return all the elements for which a truth test fails.
   _.reject = function(obj, iterator, context) {
-    var results = _.isArray(obj) ? [] : {};
+    var results  = createNewResultSet(obj);
     if (obj == null) return results;
     each(obj, function(value, index, list) {
       if (!iterator.call(context, value, index, list)) append(results, value, index);
@@ -1006,4 +1006,9 @@
     return this._wrapped;
   };
 
+  // Private function. returns an empty object or array
+  // depending on whether the passed in obj is an array or object
+  var createNewResultSet = function(obj) {
+    return _.isArray(obj) ? [] : {};
+  }
 }).call(this);


### PR DESCRIPTION
Allo all,

Was talking with [Justin Searls](https://twitter.com/#!/Searlsware/status/164860983876136960) regarding how odd it is that when we use the underscore reject/select methods on 'maps.'

I've provided a set of commits which solve this issue, but I'm not happy with the implementation. For instance, there are several array methods(i.e. without) that work on the arguments object which I've now had to convert the object to an array to prevent side effects.

It is my opinion that without, etc. should also return the type of thing they were called with, but I would like your opinion on this before I move forward.

Zee
