### PR TITLE
`_.difference` should perform a shallow flatten

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -403,7 +403,7 @@
   // Take the difference between one array and a number of other arrays.
   // Only the elements present in just the first array will remain.
   _.difference = function(array) {
-    var rest = _.flatten(slice.call(arguments, 1));
+    var rest = _.flatten(slice.call(arguments, 1), true);
     return _.filter(array, function(value){ return !_.include(rest, value); });
   };
 


### PR DESCRIPTION
`_.difference([0,1,2],[0],[1,[2]])` should produce `[2]`, not `[]`.
