### PR TITLE
Added Curry and Partial Methods

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -210,9 +210,8 @@ $(document).ready(function() {
   });
 
   test("functions: curry", function() {
-    var curriedMin = _.curry(Math.min, null);
-    curriedMin = _.curry(curriedMin, 2, -10);
-    equal(curriedMin(-7), -10, "min should be called with all arguments");
+    var curriedMax = _.curry(Math.max, null, -5);
+    equal(curriedMax(15, 10, 12)(-5, 72)(), 72, "should be called with all arguments");
   });
 
   asyncTest("functions: partialRight", 2, function() {

--- a/underscore.js
+++ b/underscore.js
@@ -476,7 +476,7 @@
   // optionally). Binding with arguments is also known as `curry`.
   // Delegates to **ECMAScript 5**'s native `Function.bind` if available.
   // We check for `func.bind` first, to fail fast when `func` is undefined.
-  _.bind = _.partial = _.curry = function bind(func, context) {
+  _.bind = _.partial = function bind(func, context) {
     var bound, args;
     if (func.bind === nativeBind && nativeBind) return nativeBind.apply(func, slice.call(arguments, 1));
     if (!_.isFunction(func)) throw new TypeError;
@@ -603,6 +603,23 @@
     if (times <= 0) return func();
     return function() {
       if (--times < 1) { return func.apply(this, arguments); }
+    };
+  };
+
+  // Transforms a function that takes multiple arguments in such a way it
+  // can be called as a chain of functions until you call it
+  // without arguments.
+  _.curry = function(func, context) {
+    var acc, args = slice.call(arguments, 2);
+    return acc = function() {
+      if (arguments.length == 0) {
+        return func.apply(context, args);
+      } else {
+        args = args.concat(slice.call(arguments, 0));
+        return function() {
+          return acc.apply(this, arguments);
+        }
+      }
     };
   };
 


### PR DESCRIPTION
`_.curry`, `_.partialRight`, `_.partialAny`, `_.partial` (as `_.bind` alias) covered with tests.

Call curried function without arguments to explisitly call it.
