### PR TITLE
Add Crockford beget for working with objects

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -634,6 +634,7 @@
   };
 
   // Return a new object whose prototype is the passed-in object.
+  // Based on Crockford's beget method for prototypal inheritance.
   _.beget = function(obj) {
     function F() {}
     F.prototype = obj;


### PR DESCRIPTION
Right along with _.extend, _.defaults, and _.clone, I think _.beget is appropriate.  I was looking for it and didn't find it, so added it myself.  This is very handy when you want to quickly inherit from an object as opposed to a class.  Also, it's the Decorator pattern for free.
