### PR TITLE
Added two function methods _.curry and _.attach (+ tests)

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -209,4 +209,39 @@ $(document).ready(function() {
     equal(testAfter(0, 0), 1, "after(0) should fire immediately");
   });
 
+  test("functions: curry", function() {
+    var greet = function(greeting, name){ return greeting + ': ' + name; };
+    var second = _.curry(greet, 'hi');
+    equal(second('moe'), 'hi: moe', 'curried the saluation function');
+
+    var func = function(first, second, last){ return first+','+second+','+last; };
+    var func = _.curry(_.curry(func, 'first'), 'second');
+    equal(func('last'), 'first,second,last', 'curried two levels deep');
+
+    var empty = function(only){ return only; };
+    var empty = _.curry(empty);
+    equal(empty('only'), 'only', 'curry is too dry');
+  });
+
+  test("functions: attach", function() {
+    var curly = {nick : 'curly'}
+      , moe = {
+          name    : 'moe',
+          getName : function() { return 'name: ' + this.name + ', ' + this.nick; }
+        };
+
+    equal(moe.getName(), 'name: moe, undefined', 'context is the current object');
+
+    equal(_.attach(moe.getName, curly)(), 'name: '+window.name+', curly', "object's method loses it's original context, in this case window becomes current context.");
+
+    equal(_.attach(moe.getName, moe, curly)(), 'name: moe, curly', 'put original context back to the function.');
+
+    curly.getName = moe.getName;
+
+    equal(curly.getName(), 'name: undefined, curly', 'function is still bound to current object');
+
+    equal(_.attach(curly.getName)(), 'name: , undefined', '_.attach with no properties puts window as current context (in this case)');
+
+  });
+
 });

--- a/underscore.js
+++ b/underscore.js
@@ -606,6 +606,35 @@
     };
   };
 
+  // Curries (burns in) arguments to a function, returning a new function
+  // that when called with call the original passing in the curried arguments
+  // inspired by prototypejs
+  _.curry = function(func)
+  {
+    var args = _.rest(arguments, 1);
+    if (!args.length) return func;
+    return function()
+    {
+      return func.apply(this, args.concat(_.rest(arguments, 0)));
+    }
+  };
+
+  // Attaches new properties to the context of the call
+  // in other words
+  // Extends passed object(s) with 'this' and makes it context
+  _.attach = function(func)
+  {
+    var obj = _.reduce(_.rest(arguments, 1), function(obj, arg)
+      {
+        return _.extend(obj, arg);
+      }, {});
+    return function()
+    {
+      var thisArg = _.extend(_.clone(this), obj);
+      return func.apply(thisArg, _.rest(arguments, 0));
+    };
+  };
+
   // Object Functions
   // ----------------
 


### PR DESCRIPTION
- `_.curry` – Curries (burns in) arguments to a function, without forcing new context (inspired by prototypejs).

Difference between  `_.curry` and `_.bind`: http://jsfiddle.net/CqG7n/
- `_.attach` – Attaches new properties to the context of the call, in other words it extends passed object(s) with 'this' and makes it context.

To illustrate my use case I modified example from flatiron/director

```
// api.js
  function helloWorld(route) {
    this.res.writeHead(200, { 'Content-Type': 'text/plain' })
    this.res.end('hello world from (' + route + ')');
  }

// router.js
  var router = new director.http.Router({
    '/hello': {
      get: helloWorld
    }
  });
```

And I want to provided to my handlers stuff like db-resourse, application home path, etc.,
without expanding list of function parameters, but rather adding to the context.

Using `_.attach`

```
// api.js
  function helloWorld(route) {
    fs.readFile(this.apphome+'/etc/passwd', function (err, data) {
      this.res.writeHead(200, { 'Content-Type': 'text/plain' })
      this.res.end(data);
    });
  }

// router.js
  var apphome = '/var/www';
  var router = new director.http.Router({
    '/hello': {
      get: _.attach(helloWorld, {apphome: apphome})
    }
  });
```
