### PR TITLE
Added isNumeric method

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -459,11 +459,13 @@ $(document).ready(function() {
     ok(_.isNumeric('1.12'), 'numeric float strings *are* numbers');
     ok(_.isNumeric('-1'), 'signed numeric strings *are* numbers');
     ok(_.isNumeric('+1.12'), 'positive signed numeric float strings *are* numbers');
-    ok(!_.isNumeric('+-1.12'), 'double signed numeric float strings aren\'t numbers');
-    ok(!_.isNumeric('-+1.12'), 'double signed numeric float strings aren\'t numbers');
+    ok(!_.isNumeric('+-1.12'), 'double signed numeric float strings are not numbers');
+    ok(!_.isNumeric('-+1.12'), 'double signed numeric float strings are not numbers');
     ok(_.isNumeric('-1.12'), 'signed numeric float strings *are* numbers');
     ok(_.isNumeric('.12'), 'numeric strings without a leading zero *are* numbers');
     ok(_.isNumeric('-.12'), 'signed numeric strings without a leading zero *are* numbers');
+    ok(!_.isNumeric(''), 'empty strings not numbers');
+    ok(!_.isNumeric('-.'), 'signed or floating strings without numerals are not numbers');
   });
 
   test("objects: isBoolean", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -812,7 +812,7 @@
 
   // Is a given value numeric (i.e. a number or a numeric string)?
   _.isNumeric = function(obj) {
-    return _.isNumber(obj) || (_.isString(obj) && !_.isNull(obj.match(/^[\-\+]?\d*\.?\d*$/)));
+    return _.isNumber(obj) || (_.isString(obj) && !_.isNull(obj.match(/^[\-\+]?\d*\.?\d*$/)) && !_.isNull(obj.match(/\d/)));
   };
 
   // Is the given value `NaN`?


### PR DESCRIPTION
Added the _.isNumeric() method, to test if a given object is numeric.
Numeric objects are anything that isNumber() or a string that has a numerical meaning (e.g. '-12.3', '3', '-.2')

![isNumeric tests](https://img.skitch.com/20120216-rx1mrnt9sg266y1f4m399e4ijp.png)
