### PR TITLE
Fix for #478 - any and every should be consistent about casting result to boolean

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -180,7 +180,7 @@
     each(obj, function(value, index, list) {
       if (!(result = result && iterator.call(context, value, index, list))) return breaker;
     });
-    return result;
+    return !!result;
   };
 
   // Determine if at least one element in the object matches a truth test.


### PR DESCRIPTION
To be consistent with ECMAScript's Array::every, _.every casts result to boolean.
