### PR TITLE
_.template allows a custom buffer.

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -1,6 +1,14 @@
 $(document).ready(function() {
 
-  module("Utility");
+  var templateSettings = _.templateSettings;
+
+  module("Utility", {
+
+    teardown: function() {
+      _.templateSettings = templateSettings;
+    }
+
+  });
 
   test("utility: noConflict", function() {
     var underscore = _.noConflict();
@@ -150,6 +158,26 @@ $(document).ready(function() {
 
     var templateWithNull = _.template("a null undefined {{planet}}");
     equal(templateWithNull({planet : "world"}), "a null undefined world", "can handle missing escape and evaluate settings");
+  });
+
+  test("Using a custom `__p` in a template function.", function() {
+    var s = _.template('<% this.wrap(function(){ %>content<% }); %>').call({
+      __p: [],
+      wrap: function(f){
+        this.__p.push('<p>');
+        f.call(this);
+        this.__p.push('</p>');
+      }
+    });
+    strictEqual(s, '<p>content</p>');
+  });
+
+  test("Nested templates using the same `__p`", function() {
+    var s = _.template('1<% this.tmpl.call(this, {value: 2}); %>3').call({
+      __p: [],
+      tmpl: _.template('<%= value %>')
+    });
+    strictEqual(s, '123');
   });
 
 });

--- a/underscore.js
+++ b/underscore.js
@@ -913,7 +913,8 @@
   // and correctly escapes quotes within interpolated code.
   _.template = function(str, data) {
     var c  = _.templateSettings;
-    var tmpl = 'var __p=[],print=function(){__p.push.apply(__p,arguments);};' +
+    var tmpl = 'var __p=this.__p||[],' +
+      'print=function(){__p.push.apply(__p,arguments);};' +
       'with(obj||{}){__p.push(\'' +
       str.replace(/\\/g, '\\\\')
          .replace(/'/g, "\\'")


### PR DESCRIPTION
By allowing a custom buffer in `_.template`, we can accomplish things that are not possible with the current implementation.  For instance:

``` javascript
_.template('<% wrap(function(){ %>content<% }); %>').call({
  __p: [],
  wrap: function(f) {
    this.__p.push('<p>');
    f.call(this);
    this.__p.push('</p>');
  }
});
```

will produce `<p>content</p>`.
