### PR TITLE
Allow return-value of tap() to replace the current value

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -665,8 +665,13 @@
   // The primary purpose of this method is to "tap into" a method chain, in
   // order to perform operations on intermediate results within the chain.
   _.tap = function(obj, interceptor) {
-    interceptor(obj);
-    return obj;
+    var result = interceptor(obj);
+
+    if (typeof result === 'undefined') {
+      return obj;
+    }
+
+    return result;
   };
 
   // Internal recursive comparison function.


### PR DESCRIPTION
Right now it's possible to replace properties of the passed-in object to tap(), but there's no good way to replace the object itself.

This is useful if you want to use a function in your chain() that you don't want to mixin() (or the function is part of another library, etc).
