### PR TITLE
Aliases `_.take()` to `_.first()` and `_.head()`

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -12,6 +12,8 @@ $(document).ready(function() {
     equal(result, 4, 'works on an arguments object.');
     result = _.map([[1,2,3],[1,2,3]], _.first);
     equal(result.join(','), '1,1', 'works well with _.map');
+    result = (function() { return _.take([1,2,3], 2); })();
+    equal(result.join(','), '1,2', 'aliased as take');
   });
 
   test("arrays: rest", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -316,9 +316,9 @@
   // ---------------
 
   // Get the first element of an array. Passing **n** will return the first N
-  // values in the array. Aliased as `head`. The **guard** check allows it to work
-  // with `_.map`.
-  _.first = _.head = function(array, n, guard) {
+  // values in the array. Aliased as `head` and `take`. The **guard** check
+  // allows it to work with `_.map`.
+  _.first = _.head = _.take = function(array, n, guard) {
     return (n != null) && !guard ? slice.call(array, 0, n) : array[0];
   };
 


### PR DESCRIPTION
Although I understand that adding a third name for the same function is pushing the limits of going overboard, I've aliased `_.take()` to `_.first()` and `_.head()` in order to gain some convenience via consistency with other languages.

The following examples all return `[1, 2, 3]`:

Haskell:
`take 3 [1..10]`

Ruby:
`1.upto(10).take(3)`

Clojure:
`(take 3 (range 1 11))`

And now JavaScript with Underscore.js:
`var arr = _.range(1, 11);`
`_(arr).take(3);`
