### PR TITLE
Don't call iterable.toArray in _.toArray if not a function

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -257,8 +257,8 @@ $(document).ready(function() {
 
   test('collections: shuffle', function() {
     var numbers = _.range(10);
-	var shuffled = _.shuffle(numbers).sort();
-	notStrictEqual(numbers, shuffled, 'original object is unmodified');
+    var shuffled = _.shuffle(numbers).sort();
+    notStrictEqual(numbers, shuffled, 'original object is unmodified');
     equal(shuffled.join(','), numbers.join(','), 'contains the same members before and after shuffle');
   });
 
@@ -271,6 +271,14 @@ $(document).ready(function() {
 
     var numbers = _.toArray({one : 1, two : 2, three : 3});
     equal(numbers.join(', '), '1, 2, 3', 'object flattened into array');
+    
+    var objectWithToArrayFunction = {toArray: function() {
+        return [1, 2, 3];
+    }};
+    equal(_.toArray(objectWithToArrayFunction).join(', '), '1, 2, 3', 'toArray method used if present');
+    
+    var objectWithToArrayValue = {toArray: 1};
+    equal(_.toArray(objectWithToArrayValue).join(', '), '1', 'toArray property ignored if not a function');
   });
 
   test('collections: size', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -301,7 +301,7 @@
   // Safely convert anything iterable into a real, live array.
   _.toArray = function(iterable) {
     if (!iterable)                return [];
-    if (iterable.toArray)         return iterable.toArray();
+    if (iterable.toArray && _.isFunction(iterable.toArray)) return iterable.toArray();
     if (_.isArray(iterable))      return slice.call(iterable);
     if (_.isArguments(iterable))  return slice.call(iterable);
     return _.values(iterable);


### PR DESCRIPTION
At the moment, _.toArray unconditionally calls iterable.toArray if it is present, even if it's not a function. I've added a check that iterable.toArray is a function, and added the appropriate test case (and also one for the normal case of iterable.toArray being a function).
