### PR TITLE
Allow natural multi-line code evaluation in templates.

### DIFF
--- a/test/test.html
+++ b/test/test.html
@@ -18,6 +18,7 @@
 <body>
   <div class="underscore-test">
     <h1 id="qunit-header">Underscore Test Suite</h1>
+    <div id="qunit-testrunner-toolbar"></div>
     <h2 id="qunit-banner"></h2>
     <h2 id="qunit-userAgent"></h2>
     <ol id="qunit-tests"></ol>
@@ -34,6 +35,7 @@
 
     <script type="text/html" id="template">
       <%
+      // a comment
       if (data) { data += 12345; }; %>
       <li><%= data %></li>
     </script>

--- a/test/utility.js
+++ b/test/utility.js
@@ -1,6 +1,14 @@
 $(document).ready(function() {
 
-  module("Utility");
+  var templateSettings = _.templateSettings;
+
+  module("Utility", {
+
+    teardown: function() {
+      _.templateSettings = templateSettings;
+    }
+
+  });
 
   test("utility: noConflict", function() {
     var underscore = _.noConflict();

--- a/underscore.js
+++ b/underscore.js
@@ -905,7 +905,15 @@
   // Within an interpolation, evaluation, or escaping, remove HTML escaping
   // that had been previously added.
   var unescape = function(code) {
-    return code.replace(/\\\\/g, '\\').replace(/\\'/g, "'");
+    return code.replace(/\\(\\|'|r|n|t)/g, function(match, char) {
+      switch (char) {
+        case '\\': return '\\';
+        case "'": return "'";
+        case 'r': return '\r';
+        case 'n': return '\n';
+        case 't': return '\t';
+      }
+    });
   };
 
   // JavaScript micro-templating, similar to John Resig's implementation.
@@ -917,18 +925,18 @@
       'with(obj||{}){__p.push(\'' +
       str.replace(/\\/g, '\\\\')
          .replace(/'/g, "\\'")
-         .replace(c.escape || noMatch, function(match, code) {
-           return "',_.escape(" + unescape(code) + "),'";
-         })
-         .replace(c.interpolate || noMatch, function(match, code) {
-           return "'," + unescape(code) + ",'";
-         })
-         .replace(c.evaluate || noMatch, function(match, code) {
-           return "');" + unescape(code).replace(/[\r\n\t]/g, ' ') + ";__p.push('";
-         })
          .replace(/\r/g, '\\r')
          .replace(/\n/g, '\\n')
          .replace(/\t/g, '\\t')
+         .replace(c.escape || noMatch, function(match, code) {
+           return "',_.escape(" + unescape(code) + "),\n'";
+         })
+         .replace(c.interpolate || noMatch, function(match, code) {
+           return "'," + unescape(code) + ",\n'";
+         })
+         .replace(c.evaluate || noMatch, function(match, code) {
+           return "');" + unescape(code) + ";\n__p.push('";
+         })
          + "');}return __p.join('');";
     var func = new Function('obj', '_', tmpl);
     if (data) return func(data, _);


### PR DESCRIPTION
From the docs:

> Template functions can both interpolate variables, using <%= … %>, as well as execute arbitrary JavaScript code, with <% … %>.

This is not quite true as there are certain restrictions on how arbitrary the code can be.  For instance, the following template will not run as expected:

```
<%
  var foo;
  // some comment
  foo = 15;
%>
...
<%= foo %>
...
```

Since `_.template` joins all lines of evaluated code with a space, a single line comment or a line of code without a terminating semicolon will cause a syntax error when creating the template function.  By escaping `\r`, `\n`, and `\t` earlier, we can unescape them along with backslashes and single quotes allowing for the inclusion of single line comments and code without a terminating semicolon.  This change is backwards compatible in most cases and allows code to be more completely arbitrary.  Furthermore, debugging is made easier since all the code is not on one line.
