### PR TITLE
Handle \u2028 & \u2029 in _.template.

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -160,4 +160,9 @@ $(document).ready(function() {
     equal(templateWithNull({planet : "world"}), "a null undefined world", "can handle missing escape and evaluate settings");
   });
 
+  test('_.template handles \\u2028 & \\u2029', function() {
+    var tmpl = _.template('<p>\u2028<%= "\\u2028\\u2029" %>\u2029</p>');
+    strictEqual(tmpl(), '<p>\u2028\u2028\u2029\u2029</p>');
+  });
+
 });

--- a/underscore.js
+++ b/underscore.js
@@ -905,13 +905,15 @@
   // Within an interpolation, evaluation, or escaping, remove HTML escaping
   // that had been previously added.
   var unescape = function(code) {
-    return code.replace(/\\(\\|'|r|n|t)/g, function(match, char) {
+    return code.replace(/\\(\\|'|r|n|t|u2028|u2029)/g, function(match, char) {
       switch (char) {
         case '\\': return '\\';
         case "'": return "'";
         case 'r': return '\r';
         case 'n': return '\n';
         case 't': return '\t';
+        case 'u2028': return '\u2028';
+        case 'u2029': return '\u2029';
       }
     });
   };
@@ -928,6 +930,8 @@
          .replace(/\r/g, '\\r')
          .replace(/\n/g, '\\n')
          .replace(/\t/g, '\\t')
+         .replace(/\u2028/g, '\\u2028')
+         .replace(/\u2029/g, '\\u2029')
          .replace(c.escape || noMatch, function(match, code) {
            return "',_.escape(" + unescape(code) + "),\n'";
          })


### PR DESCRIPTION
Since \u2028 and \u2029 are valid [ES5 line terminators](http://es5.github.com/#x7.3) they should be escaped/unescaped along with \r and \n.
