### PR TITLE
fixed _.each for iterating over properties attached to functions

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -74,7 +74,7 @@
     if (obj == null) return;
     if (nativeForEach && obj.forEach === nativeForEach) {
       obj.forEach(iterator, context);
-    } else if (obj.length === +obj.length) {
+    } else if (!_.isFunction(obj) && obj.length === +obj.length) {
       for (var i = 0, l = obj.length; i < l; i++) {
         if (i in obj && iterator.call(context, obj[i], i, obj) === breaker) return;
       }


### PR DESCRIPTION
function f(){}
f.foo = "bar";

_.each(f, function(val, key){ console.log(key); });

This did nothing before, now it does what you would expect and prints "foo".  Functions are objects too, but they have a completely unrelated "length" property, which is where the error crept in.  Thanks for the great library.
