### PR TITLE
Enhancement: use typeof where testing for callable object properties - inspired by issue #504

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -630,7 +630,7 @@
   _.functions = _.methods = function(obj) {
     var names = [];
     for (var key in obj) {
-      if (typeof obj[key] == 'function') names.push(key);
+      if (_.isFunction(obj[key])) names.push(key);
     }
     return names.sort();
   };


### PR DESCRIPTION
This enhancement favors unary `typeof` over the `_.isFunction` alias to `toString.call` for performance gains where checking for callable object properties / functions.

Performance testing:
-  [jsperf comparison of methods for testing for functions](http://jsperf.com/toarray-function-check)
-  A few comparisons using underscore test cases:
  -  http://jsperf.com/invoke-typeof/2
  -  http://jsperf.com/groupby-typeof/2
  -  http://jsperf.com/functions-typeof/2

[Changes pass underscore tests on environments I have access to](http://raymondmayjr.com/underscore/test/test.html).

Please test on edge case environments I may not have access to or may not know about before merging.
