### PR TITLE
Add _.only(...), which pulls a subset of properties from an object

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -56,10 +56,11 @@ $(document).ready(function() {
     equal(options.word, "word", 'new value is added, first one wins');
   });
 
-  test("objects: only", function() {
+  test("objects: restrict", function() {
     var obj = { one: 1, two: 2, three: 3, four: 4 },
-        filtered = _.only( obj, 'one', 'three', 'five' );
+        filtered = _.restrict( obj, 'one', 'three', 'five' );
     ok( _.isEqual( filtered, {one:1, three:3} ), 'filters down to specified properties' );
+    ok( _.isEqual( _.keys(obj).length, 4 ), 'does not modify original object' );
   });
 
   test("objects: clone", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -655,11 +655,11 @@
     return obj;
   };
 
-  // Return a copy of an object with only the specified properties.
-  _.only = function(obj) {
+  // Return a copy of an object only containing the specified properties.
+  _.restrict = function(obj) {
     var trimmed = {};
     each(slice.call(arguments, 1), function(key) {
-      if( _.has(obj,key) ) trimmed[key] = obj[key];
+      if (key in obj) trimmed[key] = obj[key];
     });
     return trimmed;
   };


### PR DESCRIPTION
For example `_.only( {one:1,two:2,three:3}, 'one', 'three' )` yields `{one:1, three:3}`

This is very useful for sanitizing/filtering input. This seems so useful that I suspect there might be a reason it isn't in underscore already...
