### PR TITLE
Add _.restrict(source, *keys)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1016,6 +1016,19 @@ _.extend({name : 'moe'}, {age : 50});
 =&gt; {name : 'moe', age : 50}
 </pre>
 
+      <p id="restrict">
+        <b class="header">restrict</b><code>_.restrict(source, *keys)</code>
+        <br />
+        Return a clone of the <b>source</b> with only the properties with the
+        property names, or arrays of property names, provided in <b>keys</b>.
+      </p>
+      <pre>
+_.restrict({name : 'moe', age: 50, userid : 'moe1'}, 'name', 'age');
+=&gt; {name : 'moe', age : 50}
+_.restrict({name : 'moe', age: 50, userid : 'moe1'}, ['name', 'age']);
+=&gt; {name : 'moe', age : 50}
+</pre>
+
       <p id="defaults">
         <b class="header">defaults</b><code>_.defaults(object, *defaults)</code>
         <br />

--- a/test/objects.js
+++ b/test/objects.js
@@ -41,6 +41,16 @@ $(document).ready(function() {
     equal(_.keys(result).join(''), 'ab', 'extend does not copy undefined values');
   });
 
+  test("objects: restrict", function() {
+    var result;
+    result = _.restrict({a:1, b:2, c:3}, 'a', 'c');
+    ok(_.isEqual(result, {a:1, c:3}), 'can restrict properties to those named');
+    result = _.restrict({a:1, b:2, c:3}, ['b', 'c']);
+    ok(_.isEqual(result, {b:2, c:3}), 'can restrict properties to those named in an array');
+    result = _.restrict({a:1, b:2, c:3}, ['a'], 'b');
+    ok(_.isEqual(result, {a:1, b:2}), 'can restrict properties to those named in mixed args');
+  });
+
   test("objects: defaults", function() {
     var result;
     var options = {zero: 0, one: 1, empty: "", nan: NaN, string: "string"};

--- a/underscore.js
+++ b/underscore.js
@@ -645,6 +645,16 @@
     return obj;
   };
 
+  // Restrict a given object to the properties named
+  _.restrict = function(obj) {
+    if (obj !== Object(obj)) throw new TypeError('Invalid object');
+    var dest = {};
+    each(_.flatten(slice.call(arguments, 1)), function(prop) {
+      if (prop in obj) dest[prop] = obj[prop];
+    });
+    return dest;
+  };
+
   // Fill in a given object with default properties.
   _.defaults = function(obj) {
     each(slice.call(arguments, 1), function(source) {


### PR DESCRIPTION
Return a clone of the source with only the properties named in *keys
(either stings or arrays containing strings).

Especially useful for avoiding mass-assignment vulnerabilities.

```
_.restrict({name : 'moe', age: 50, userid : 'moe1'}, 'name', 'age');
=> {name : 'moe', age : 50}
_.restrict({name : 'moe', age: 50, userid : 'moe1'}, ['name', 'age']);
=> {name : 'moe', age : 50}
```
