### PR TITLE
Adding _.isZero Following Fixnum.zero?

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -537,5 +537,6 @@ $(document).ready(function() {
     ok(!_.isZero(null))
     ok(!_.isZero("0"))
     ok(_.isZero(0))
+    ok(_.isZero(new Object(0)))
   });
 });

--- a/underscore.js
+++ b/underscore.js
@@ -670,7 +670,7 @@
   };
   
   _.isZero = function(obj){
-    return obj === 0;
+   return _.isNumber(obj) && 0 === parseInt(obj, 10);
   }
 
   // Internal recursive comparison function.


### PR DESCRIPTION
Hey Guys!

I don't know if this method makes sense, but I added _.isZero following [Fixnum.zero?](http://ruby-doc.org/core-1.9.3/Fixnum.html#method-i-zero-3F).

The idea is to use

   if(_.isZero(val))

instead of

   if(val == 0)

Cheers
