### PR TITLE
Allow to use a string as iterator of _.sortBy()

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -235,6 +235,10 @@ $(document).ready(function() {
     var people = [{name : 'curly', age : 50}, {name : 'moe', age : 30}];
     people = _.sortBy(people, function(person){ return person.age; });
     equal(_.pluck(people, 'name').join(', '), 'moe, curly', 'stooges sorted by age');
+
+    var list = ["one", "two", "three", "four", "five"];
+    var sorted = _.sortBy(list, 'length');
+    equal(sorted.join(' '), 'one two four five three', 'sorted by length');
   });
 
   test('collections: groupBy', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -262,7 +262,8 @@
   };
 
   // Sort the object's values by a criterion produced by an iterator.
-  _.sortBy = function(obj, iterator, context) {
+  _.sortBy = function(obj, val, context) {
+    var iterator = _.isFunction(val) ? val : function(obj) { return obj[val]; };
     return _.pluck(_.map(obj, function(value, index, list) {
       return {
         value : value,


### PR DESCRIPTION
If the iterator is a string instead of a function, sorts by the property named by the iterator on each of the values, as _.groupBy() does.

e.g.)
_.sortBy(["one", "two", "three", "four", "five"], 'length');
=> ["one", "two", "four", "five", "three"]
