### PR TITLE
Allow for better handling of undefined values in sortBy.

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -270,6 +270,8 @@
       };
     }).sort(function(left, right) {
       var a = left.criteria, b = right.criteria;
+      if (_.isUndefined(a)) return 1;
+      if (_.isUndefined(b)) return -1;
       return a < b ? -1 : a > b ? 1 : 0;
     }), 'value');
   };


### PR DESCRIPTION
The current implementation of sortBy breaks when the result of the iterator call is `undefined`.

```
var obj = [undefined, 4, 1, undefined, 3, 2];
_.sortBy(obj, function(i) { return i; })
=> [undefined, 1, 4, undefined, 2, 3]
```

The attached code collects the `undefined` values at the end of the result.

```
=> [1, 2, 3, 4, undefined, undefined]
```

This also agrees with the standard sort handling of `undefined` as described here:  https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/sort
