### PR TITLE
missing index on _.rest function example

### DIFF
--- a/index.html
+++ b/index.html
@@ -644,7 +644,7 @@ _.last([5, 4, 3, 2, 1]);
         to return the values of the array from that index onward.
       </p>
       <pre>
-_.rest([5, 4, 3, 2, 1]);
+_.rest([5, 4, 3, 2, 1], 0);
 =&gt; [4, 3, 2, 1]
 </pre>
 


### PR DESCRIPTION
was confused for a second, how did you get the rest of the array without saying where to start!!?
