### PR TITLE
Add varname to _.templateSettings.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1335,7 +1335,7 @@ _.result(object, 'stuff');
 =&gt; "nonsense"</pre>
 
       <p id="template">
-        <b class="header">template</b><code>_.template(templateString, [context])</code>
+        <b class="header">template</b><code>_.template(templateString, [data], [settings])</code>
         <br />
         Compiles JavaScript templates into functions that can be evaluated
         for rendering. Useful for rendering complicated bits of HTML from JSON
@@ -1343,10 +1343,11 @@ _.result(object, 'stuff');
         <tt>&lt;%= &hellip; %&gt;</tt>, as well as execute arbitrary JavaScript code, with
         <tt>&lt;% &hellip; %&gt;</tt>. If you wish to interpolate a value, and have
         it be HTML-escaped, use <tt>&lt;%- &hellip; %&gt;</tt> When you evaluate a template function, pass in a
-        <b>context</b> object that has properties corresponding to the template's free
-        variables. If you're writing a one-off, you can pass the <b>context</b>
+        <b>data</b> object that has properties corresponding to the template's free
+        variables. If you're writing a one-off, you can pass the <b>data</b>
         object as the second parameter to <b>template</b> in order to render
-        immediately instead of returning a template function.
+        immediately instead of returning a template function.  The <b>settings</b> argument
+        should be a hash containing any <tt>_.templateSettings</tt> that should be overriden.
       </p>
 
       <pre>
@@ -1397,25 +1398,23 @@ template({name : "Mustache"});
       <p>
         By default, <b>template</b> places the values from your data in the local scope
         via the <tt>with</tt> statement.  However, you can specify a single variable name
-        with the <b>varname</b> setting.
+        with the <b>variable</b> setting.
       </p>
 
       <pre>
-_.templateSettings.varname = 'data';
-var template = _.template("<%= data.hasWith %>");
-template({hasWith: 'no'});
+_.template("<%= data.hasWith %>", {hasWith: 'no'}, {variable: 'data'});
 =&gt; "no"</pre>
 
       <p>
         Precompiling your templates can be a big help when debugging errors you can't
         reproduce.  This is because precompiled templates can provide line numbers and
         a stack trace, something that is not possible when compiling templates on the client.
-        <b>template</b> provides the <b>compiled</b> property on the compiled template
+        <b>template</b> provides the <b>source</b> property on the compiled template
         function for easy precompilation.
       </p>
 
       <pre>&lt;script&gt;
-  JST.project = <%= _.template(jstText).compiled %>;
+  JST.project = <%= _.template(jstText).source %>;
 &lt;/script&gt;</pre>
 
 

--- a/test/utility.js
+++ b/test/utility.js
@@ -178,11 +178,11 @@ $(document).ready(function() {
     strictEqual(_.result(null, 'x'), null);
   });
 
-  test('_.templateSettings.varname', function() {
+  test('_.templateSettings.variable', function() {
     var s = '<%=data.x%>';
     var data = {x: 'x'};
-    strictEqual(_.template(s, data, {varname: 'data'}), 'x')
-    _.templateSettings.varname = 'data';
+    strictEqual(_.template(s, data, {variable: 'data'}), 'x')
+    _.templateSettings.variable = 'data';
     strictEqual(_.template(s)(data), 'x')
   });
 

--- a/underscore.js
+++ b/underscore.js
@@ -951,13 +951,13 @@
   // JavaScript micro-templating, similar to John Resig's implementation.
   // Underscore templating handles arbitrary delimiters, preserves whitespace,
   // and correctly escapes quotes within interpolated code.
-  _.template = function(source, data, settings) {
+  _.template = function(text, data, settings) {
     settings = _.extend(_.templateSettings, settings);
 
     // Compile the template source, taking care to escape characters that
     // cannot be included in a string literal and then unescape them in code
     // blocks.
-    var compiled = "__p.push('" + source
+    var source = "__p.push('" + text
       .replace(escaper, function(match) {
         return '\\' + escapes[match];
       })
@@ -971,13 +971,13 @@
         return "');\n" + unescape(code) + "\n;__p.push('";
       }) + "');\n";
 
-    // If no varname is specified, place data values in local scope.
-    if (!settings.varname) compiled = 'with(obj||{}){\n' + compiled + '}\n';
+    // If a variable is not specified, place data values in local scope.
+    if (!settings.variable) source = 'with(obj||{}){\n' + source + '}\n';
 
-    compiled = 'var __p=[],print=function(){__p.push.apply(__p,arguments);};\n' +
-      compiled + "return __p.join('');\n";
+    source = 'var __p=[],print=function(){__p.push.apply(__p,arguments);};\n' +
+      source + "return __p.join('');\n";
 
-    var render = new Function(settings.varname || 'obj', '_', compiled);
+    var render = new Function(settings.variable || 'obj', '_', source);
     if (data) return render(data, _);
     var template = function(data) {
       return render.call(this, data, _);
@@ -985,8 +985,8 @@
 
     // Provide the compiled function source as a convenience for build time
     // precompilation.
-    template.compiled = 'function(' + (settings.varname || 'obj') + '){\n' +
-      compiled + '\n}';
+    template.source = 'function(' + (settings.variable || 'obj') + '){\n' +
+      source + '\n}';
 
     return template;
   };


### PR DESCRIPTION
- Leave out the with statement when using varname.
- Rename source to compiled.
- Comments, comments, comments.

This is an attempt to improve `_.template` with ideas from doT.js as described in #483.
