### PR TITLE
_.template Uses Concatenation

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -965,7 +965,7 @@
         return "'+\n_.escape(" + unescape(code) + ")+\n'";
       })
       .replace(settings.interpolate || noMatch, function(match, code) {
-        return "'+(\n" + unescape(code) + ")+\n'";
+        return "'+\n(" + unescape(code) + ")+\n'";
       })
       .replace(settings.evaluate || noMatch, function(match, code) {
         return "';\n" + unescape(code) + "\n;__p+='";
@@ -987,7 +987,7 @@
     // Provide the compiled function source as a convenience for build time
     // precompilation.
     template.source = 'function(' + (settings.variable || 'obj') + '){\n' +
-      source + '\n}';
+      source + '}';
 
     return template;
   };


### PR DESCRIPTION
As discussed in #540, using string concatenation instead of Array#join in `_.template` appears to be [roughly twice as fast](http://jsperf.com/template-concat-vs-join) in most browsers (Opera would seem to be the oddball here).  I haven't yet tested IE because github is serving scripts as plain text and IE blocks them.  I'll look for a workaround later today.

_Note: The implementation of `print` was necessarily changed._
