### PR TITLE
Add merge, a la Ruby's Hash#merge

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -644,6 +644,23 @@
     });
     return obj;
   };
+  
+  //Returns a modified originalObject that merges in the contents of otherObject.  If no function is specified,
+  //the value for entries with duplicate keys will be that of other_object.  Otherwise the value for each
+  //duplicate key is determined by calling the block with the key, its value in originalObject and its value in
+  //otherObject.
+  _.merge = function(originalObject, otherObject, mergeFunction) {
+    var originalKeys = _.keys(originalObject);
+    var otherKeys = _.keys(otherObject);
+    _.each(_.without(otherKeys, originalKeys), function(newKey) {
+      originalObject[newKey] = otherObject[newKey];
+    });
+    _.each(_.intersection(originalKeys, otherKeys), function(collisionKey) {
+      originalObject[collisionKey] = (_.isFunction(mergeFunction)) ? mergeFunction(collisionKey, originalObject[collisionKey], otherObject[collisionKey]) : otherObject[collisionKey];
+    });
+
+    return originalObject;
+  };
 
   // Return a copy of the object only containing the whitelisted properties.
   _.pick = function(obj) {


### PR DESCRIPTION
This adds in a _.merge() function that works just like Ruby's Hash#merge (http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-merge).  This handles more general cases than the very useful _.extend() and _.defaults().

Given:

```
var originalRecord = { name: 'Kevin', highestScore: 50 };
var otherRecord = { name: 'Kevin', highestScore: 70 };
```

When:

```
_.merge(originalRecord, otherRecord, function(key, original, other) {
    if (key === 'highestScore') return Math.max(original, other);
    return other;
});
```

Then:

```
_.isEqual(originalRecord, { name: 'Kevin', highestScore: 70 }) === true
```
