### PR TITLE
Improve Spotify app compatibility

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -52,11 +52,16 @@
   // backwards-compatibility for the old `require()` API. If we're in
   // the browser, add `_` as a global object via a string identifier,
   // for Closure Compiler "advanced" mode.
+  // If we're in a Spotify app then just export _ for Spotify's require.
   if (typeof exports !== 'undefined') {
     if (typeof module !== 'undefined' && module.exports) {
       exports = module.exports = _;
     }
-    exports._ = _;
+    if (typeof getSpotifyApi === 'function') {
+      exports = _;
+    } else {
+      exports._ = _;
+    }
   } else {
     root['_'] = _;
   }


### PR DESCRIPTION
Instead of exports._ = _, we now do exports = _ in a Spotify app.
This allows e.g. Backbone to require underscore also in Spotify.
