### PR TITLE
Fix #556 - interpolate coerces null/undefined to ''.

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -192,4 +192,16 @@ $(document).ready(function() {
     ok(!_.templateSettings.variable);
   });
 
+  test('#556 - undefined template variables.', function() {
+    var template = _.template('<%=x%>');
+    strictEqual(template({x: null}), '');
+    strictEqual(template({x: undefined}), '');
+  });
+
+  test('interpolate evaluates code only once.', 1, function() {
+    var count = 0;
+    var template = _.template('<%= f() %>');
+    template({f: function(){ ok(!(count++)); }});
+  });
+
 });

--- a/underscore.js
+++ b/underscore.js
@@ -965,7 +965,7 @@
         return "'+\n_.escape(" + unescape(code) + ")+\n'";
       })
       .replace(settings.interpolate || noMatch, function(match, code) {
-        return "'+\n(" + unescape(code) + ")+\n'";
+        return "'+\n((__t=(" + unescape(code) + "))==null?'':__t)+\n'";
       })
       .replace(settings.evaluate || noMatch, function(match, code) {
         return "';\n" + unescape(code) + "\n;__p+='";
@@ -974,8 +974,8 @@
     // If a variable is not specified, place data values in local scope.
     if (!settings.variable) source = 'with(obj||{}){\n' + source + '}\n';
 
-    source = "var __p='';" +
-      "var print=function(){__p+=Array.prototype.join.call(arguments, '')};\n" +
+    source = "var __t,__p='',__j=Array.prototype.join," +
+      "print=function(){__p+=__j.call(arguments,'')};\n" +
       source + "return __p;\n";
 
     var render = new Function(settings.variable || 'obj', '_', source);


### PR DESCRIPTION
With an extra variable (`__t`) we can check for `null` and `undefined` inline and keep the performance improvements gained by using string concatenation.
