### PR TITLE
One last addition...

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -196,12 +196,28 @@ $(document).ready(function() {
     var template = _.template('<%=x%>');
     strictEqual(template({x: null}), '');
     strictEqual(template({x: undefined}), '');
+
+    var templateEscaped = _.template('<%-x%>');
+    strictEqual(templateEscaped({x: null}), '');
+    strictEqual(templateEscaped({x: undefined}), '');
+
+    var templateWithProperty = _.template('<%=x.foo%>');
+    strictEqual(templateWithProperty({x: {} }), '');
+    strictEqual(templateWithProperty({x: {} }), '');
+
+    var templateWithPropertyEscaped = _.template('<%-x.foo%>');
+    strictEqual(templateWithPropertyEscaped({x: {} }), '');
+    strictEqual(templateWithPropertyEscaped({x: {} }), '');
   });
 
-  test('interpolate evaluates code only once.', 1, function() {
+  test('interpolate evaluates code only once.', 2, function() {
     var count = 0;
     var template = _.template('<%= f() %>');
     template({f: function(){ ok(!(count++)); }});
+
+    var countEscaped = 0;
+    var templateEscaped = _.template('<%- f() %>');
+    templateEscaped({f: function(){ ok(!(countEscaped++)); }});
   });
 
 });

--- a/underscore.js
+++ b/underscore.js
@@ -962,7 +962,7 @@
         return '\\' + escapes[match];
       })
       .replace(settings.escape || noMatch, function(match, code) {
-        return "'+\n_.escape(" + unescape(code) + ")+\n'";
+        return "'+\n((__t=(" + unescape(code) + "))==null?'':_.escape(__t))+\n'";
       })
       .replace(settings.interpolate || noMatch, function(match, code) {
         return "'+\n((__t=(" + unescape(code) + "))==null?'':__t)+\n'";


### PR DESCRIPTION
This uses braddunbar's `__t=` solution to have `<%- foo %>` work the same as `<%= foo %>`.  Tests updated.
