### PR TITLE
Add _.exclude(object, *keys)

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,6 +216,7 @@
       <li>- <a href="#object-functions">functions</a></li>
       <li>- <a href="#extend">extend</a></li>
       <li>- <a href="#pick">pick</a></li>
+      <li>- <a href="#exclude">exclude</a></li>
       <li>- <a href="#defaults">defaults</a></li>
       <li>- <a href="#clone">clone</a></li>
       <li>- <a href="#tap">tap</a></li>
@@ -1041,6 +1042,17 @@ _.extend({name : 'moe'}, {age : 50});
       <pre>
 _.pick({name : 'moe', age: 50, userid : 'moe1'}, 'name', 'age');
 =&gt; {name : 'moe', age : 50}
+</pre>
+
+      <p id="exclude">
+        <b class="header">exclude</b><code>_.exclude(object, *keys)</code>
+        <br />
+        Return a copy of the <b>object</b>, filtered to exclude the blacklisted
+        <b>keys</b> (or array of valid keys).
+      </p>
+      <pre>
+_.exclude({name : 'moe', age : 50, userid : 'moe1'}, 'userid');
+=&gt; {name : 'moe1', age : 50}
 </pre>
 
       <p id="defaults">

--- a/test/objects.js
+++ b/test/objects.js
@@ -50,6 +50,18 @@ $(document).ready(function() {
     ok(_.isEqual(result, {a:1, b:2}), 'can restrict properties to those named in mixed args');
   });
 
+  test("objects: exclude", function() {
+    var result;
+    result = _.exclude({a:1, b:2, c:3}, 'b');
+    ok(_.isEqual(result, {a:1, c:3}), 'can exclude a single named property');
+    result = _.exclude({a:1, b:2, c:3}, 'a', 'c');
+    ok(_.isEqual(result, {b:2}), 'can exclude several named properties');
+    result = _.exclude({a:1, b:2, c:3}, ['b', 'c']);
+    ok(_.isEqual(result, {a:1}), 'can exclude properties named in an array');
+    result = _.exclude({a:1, b:2, c:3}, ['a'], 'b');
+    ok(_.isEqual(result, {c:3}), 'can exclude properties to those named in mixed args');
+  });
+
   test("objects: defaults", function() {
     var result;
     var options = {zero: 0, one: 1, empty: "", nan: NaN, string: "string"};

--- a/underscore.js
+++ b/underscore.js
@@ -654,6 +654,12 @@
     return result;
   };
 
+   // Return a copy of the object without the blacklisted properties.
+  _.exclude = function(obj) {
+    var blacklist = _.flatten(slice.call(arguments, 1));
+    return _.pick(obj, _.difference(_.keys(obj), blacklist));
+  };
+
   // Fill in a given object with default properties.
   _.defaults = function(obj) {
     each(slice.call(arguments, 1), function(source) {


### PR DESCRIPTION
Return a copy of the object, filtered to exclude the blacklisted keys (or array
of valid keys).

Similar to _.pick, but using blacklisting instead of whitelisting which can be
more appropriate in some cases.
