### PR TITLE
in sortedIndex test, rename variables to prevent confusion

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -258,11 +258,11 @@ $(document).ready(function() {
 
   test('collections: sortedIndex', function() {
     var numbers = [10, 20, 30, 40, 50], num = 35;
-    var index = _.sortedIndex(numbers, num);
-    equal(index, 3, '35 should be inserted at index 3');
+    var indexForNum = _.sortedIndex(numbers, num);
+    equal(indexForNum, 3, '35 should be inserted at index 3');
 
-    var index2 = _.sortedIndex(numbers, 30);
-    equal(index2, 2, '30 should be inserted at index 2');
+    var indexFor30 = _.sortedIndex(numbers, 30);
+    equal(indexFor30, 2, '30 should be inserted at index 2');
   });
 
   test('collections: shuffle', function() {


### PR DESCRIPTION
I was confused when I read the second part of the test. The variable name was index2, and "30 should be inserted at index 2". But then I looked a few lines up, and saw that index's number "should be inserted at index 3". I had thought that the '2' at the end of 'index2' meant something it didn't. This renaming prevents that confusion.

This change highlights the repetition in this test. It is possible that a good next step would be to refactor the testing of these two numbers into an each loop. Or perhaps that would make the test unnecessarily complicated. I am not confident enough to make that call, so I'll leave it as it is.
