### PR TITLE
A few typo fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -909,10 +909,10 @@ $(window).scroll(throttled);
       </p>
       
       <p>
-        Pass <tt>true</tt> for the <b>immediate</b> parameter to cause 
-        <b>debounce</b> to trigger the function on the leading intead of the 
-        trailing edge of the <b>wait</b> interval. Useful in circumstances like 
-        preventing accidental double-clicks on a "submit" button from firing a 
+        Pass <tt>true</tt> for the <b>immediate</b> parameter to cause
+        <b>debounce</b> to trigger the function on the leading instead of the
+        trailing edge of the <b>wait</b> interval. Useful in circumstances like
+        preventing accidental double-clicks on a "submit" button from firing a
         second time.
       </p>
       
@@ -1375,7 +1375,7 @@ _.result(object, 'stuff');
         variables. If you're writing a one-off, you can pass the <b>data</b>
         object as the second parameter to <b>template</b> in order to render
         immediately instead of returning a template function.  The <b>settings</b> argument
-        should be a hash containing any <tt>_.templateSettings</tt> that should be overriden.
+        should be a hash containing any <tt>_.templateSettings</tt> that should be overridden.
       </p>
 
       <pre>

--- a/underscore.js
+++ b/underscore.js
@@ -321,7 +321,7 @@
     return (n != null) && !guard ? slice.call(array, 0, n) : array[0];
   };
 
-  // Returns everything but the last entry of the array. Especcialy useful on
+  // Returns everything but the last entry of the array. Especially useful on
   // the arguments object. Passing **n** will return all the values in
   // the array, excluding the last N. The **guard** check allows it to work with
   // `_.map`.


### PR DESCRIPTION
The first typo you may not see in the diff because I removed the whitespace at the end of the lines but it is `intead` -> `instead`. Thanks!
