### PR TITLE
Cache iterator(obj) in sortedIndex

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -289,10 +289,11 @@
   // an object should be inserted so as to maintain order. Uses binary search.
   _.sortedIndex = function(array, obj, iterator) {
     iterator || (iterator = _.identity);
+    obj = iterator(obj);
     var low = 0, high = array.length;
     while (low < high) {
       var mid = (low + high) >> 1;
-      iterator(array[mid]) < iterator(obj) ? low = mid + 1 : high = mid;
+      iterator(array[mid]) < obj ? low = mid + 1 : high = mid;
     }
     return low;
   };


### PR DESCRIPTION
Rather than recalculate the comparison value of the 'needle' object, `sortedIndex` now calculates it once and reuses the result.
