### PR TITLE
A linear algorithm for _.flatten.

### DIFF
--- a/test/speed.js
+++ b/test/speed.js
@@ -4,6 +4,7 @@
   for (var i=0; i<1000; i++) numbers.push(i);
   var objects = _.map(numbers, function(n){ return {num : n}; });
   var randomized = _.sortBy(numbers, function(){ return Math.random(); });
+  var deep = _.map(_.range(100), function() { return _.range(1000); });
 
   JSLitmus.test('_.each()', function() {
     var timesTwo = [];
@@ -65,6 +66,10 @@
 
   JSLitmus.test('_.range()', function() {
     return _.range(1000);
+  });
+
+  JSLitmus.test('_.flatten()', function() {
+    return _.flatten(deep);
   });
 
 })();

--- a/underscore.js
+++ b/underscore.js
@@ -354,11 +354,16 @@
 
   // Return a completely flattened version of an array.
   _.flatten = function(array, shallow) {
-    return _.reduce(array, function(memo, value) {
-      if (_.isArray(value)) return memo.concat(shallow ? value : _.flatten(value));
-      memo[memo.length] = value;
-      return memo;
-    }, []);
+    return (function recursivelyFlatten(array, flat) {
+      each(array, function(value) {
+        if (_.isArray(value)) {
+          if (shallow) ArrayProto.push.apply(flat, value);
+          else recursivelyFlatten(value, flat);
+        }
+        else flat.push(value);
+      });
+      return flat;
+    })(array, []);
   };
 
   // Return a version of the array that does not contain the specified value(s).


### PR DESCRIPTION
Gives massive speedups on _.flatten for large, deep arrays, see http://jsperf.com/underscore-flatten-quadratic.

The trouble was the .concat call, which constructs a new array each time it's called. Swapping it out for the .push method makes it linear.

I also added a performance test for flatten, to catch this in case this comes up again.
