### PR TITLE
Better RegExp equality comparisons

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -164,6 +164,10 @@ $(document).ready(function() {
     ok(!_.isEqual(/Moe/gim, /Curly/gim), "RegExps with different patterns and equivalent flags are not equal");
     ok(!_.isEqual(/(?:)/gi, /(?:)/g), "Commutative equality is implemented for RegExps");
     ok(!_.isEqual(/Curly/g, {source: "Larry", global: true, ignoreCase: false, multiline: false}), "RegExps and RegExp-like objects are not equal");
+    var regexpOne = /bar/g;
+    var regexpTwo = /bar/g;
+    regexpTwo.test("foobar");
+    ok(!_.isEqual(regexpOne, regexpTwo), "RegExps with different lastIndexes are not equal");
 
     // Empty arrays, array-like objects, and object literals.
     ok(_.isEqual({}, {}), "Empty object literals are equal");

--- a/underscore.js
+++ b/underscore.js
@@ -711,12 +711,13 @@
         // millisecond representations. Note that invalid dates with millisecond representations
         // of `NaN` are not equivalent.
         return +a == +b;
-      // RegExps are compared by their source patterns and flags.
+      // RegExps are compared by their source patterns, flags, and lastIndex.
       case '[object RegExp]':
         return a.source == b.source &&
                a.global == b.global &&
                a.multiline == b.multiline &&
                a.ignoreCase == b.ignoreCase &&
+               a.lastIndex == b.lastIndex &&
                a.sticky == b.sticky;
     }
     if (typeof a != 'object' || typeof b != 'object') return false;


### PR DESCRIPTION
I've added a check for 'lastIndex', as well as for Firefox's custom 'sticky' flag. Tests are included for 'lastIndex' -- I wasn't sure how to write an elegant test for the platform-specific 'sticky'.
