### PR TITLE
Style change, remove unnecessary semicolon.

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -945,11 +945,11 @@
   var escapes = {
     '\\': '\\',
     "'": "'",
-    'r': '\r',
-    'n': '\n',
-    't': '\t',
-    'u2028': '\u2028',
-    'u2029': '\u2029'
+    r: '\r',
+    n: '\n',
+    t: '\t',
+    u2028: '\u2028',
+    u2029: '\u2029'
   };
 
   for (var p in escapes) escapes[escapes[p]] = p;
@@ -984,7 +984,7 @@
         return "'+\n((__t=(" + unescape(code) + "))==null?'':__t)+\n'";
       })
       .replace(settings.evaluate || noMatch, function(match, code) {
-        return "';\n" + unescape(code) + "\n;__p+='";
+        return "';\n" + unescape(code) + "\n__p+='";
       }) + "';\n";
 
     // If a variable is not specified, place data values in local scope.


### PR DESCRIPTION
I finally got around to precompiling some templates server side for linting purposes, but ran into a small problem.  `_.template` inserts a newline followed by a semicolon after code blocks which creates an unnecessary semicolon.  Since one of the main benefits of precompiled templates is the ability to lint the resultant javascript, it would be nice if this were not required.  Since the newline will always be followed by an identifier the semicolon can be left out safely.

_I feel I must qualify that the motivation for the change has nothing to do with a desire to remove semicolons in general.  Code blocks can still include them or not, I don't care.  I just want to be able to easily lint the compiled source._
