### PR TITLE
Deep copying with _.clone(obj, deep)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1057,14 +1057,20 @@ _.defaults(iceCream, {flavor : "vanilla", sprinkles : "lots"});
 </pre>
 
       <p id="clone">
-        <b class="header">clone</b><code>_.clone(object)</code>
+        <b class="header">clone</b><code>_.clone(object, [deep])</code>
         <br />
-        Create a shallow-copied clone of the <b>object</b>. Any nested objects
-        or arrays will be copied by reference, not duplicated.
+        Create a copy of the <b>object</b>. The copy is shallow, unless
+        <b>deep</b> is <tt>true</tt>. This means that nested objects or arrays
+        are copied by reference, not duplicated. Note that the prototype chain
+        <i>is not preserved</i> by this function, unlike
+        <a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/create">Object.create</a>.
       </p>
       <pre>
 _.clone({name : 'moe'});
 =&gt; {name : 'moe'};
+
+_.clone([1, 2, 3]);
+=&gt; [1, 2, 3];
 </pre>
 
       <p id="tap">

--- a/test/objects.js
+++ b/test/objects.js
@@ -68,15 +68,18 @@ $(document).ready(function() {
   test("objects: clone", function() {
     var moe = {name : 'moe', lucky : [13, 27, 34], modified: false };
     var clone = _.clone(moe);
+    var deepClone = _.clone(moe, true);
+
     equal(clone.name, 'moe', 'the clone has the attributes of the original');
 
     clone.name = 'curly';
     ok(clone.name == 'curly' && moe.name == 'moe', 'clones can change shallow attributes without affecting the original');
     moe.modified = true;
-    notEqual(clone.modified, moe.modified, 'original can change shallow attributes without affecting the clone');
+    ok(!clone.modified && moe.modified, 'original can change shallow attributes without affecting the clone');
 
     clone.lucky.push(101);
     equal(_.last(moe.lucky), 101, 'changes to deep attributes are shared with the original');
+    equal(_.last(deepClone.lucky), 34, 'deep attributes can be cloned as well');
 
     equal(_.clone(undefined), void 0, 'non objects should not be changed by clone');
     equal(_.clone(1), 1, 'non objects should not be changed by clone');

--- a/underscore.js
+++ b/underscore.js
@@ -672,13 +672,24 @@
     return obj;
   };
 
-  // Create a (shallow-cloned) duplicate of an object.
-  _.clone = function(obj) {
+  // Create a copy (shallow or deep) of an object.
+  _.clone = function(obj, deep) {
     if (!_.isObject(obj) || _.isFunction(obj)) return obj;
-    if (_.isArray(obj) || _.isArguments(obj)) return slice.call(obj);
     if (_.isDate(obj)) return new Date(obj.getTime());
     if (_.isRegExp(obj)) return new RegExp(obj.source, obj.toString().replace(/.*\//, ""));
-    return _.extend({}, obj);
+    var isArr = (_.isArray(obj) || _.isArguments(obj));
+    if (deep) {
+      var func = function (memo, value, key) {
+        if (isArr)
+          memo.push(_.clone(value, true));
+        else
+          memo[key] = _.clone(value, true);
+        return memo;
+      };
+      return _.reduce(obj, func, isArr ? [] : {});
+    } else {
+      return isArr ? slice.call(obj) : _.extend({}, obj);
+    }
   };
 
   // Invokes interceptor with the obj, and then returns obj.


### PR DESCRIPTION
I sometimes return copies of nested internal data structures, so deep copying is needed to avoid accidental changes by other parts of the program or by loaded plug-ins. See also issue #586 and elsewhere.

Since the _.clone() function didn't support deep copies, I thought it would be fairly straight-forward to add it without breaking the API. Not sure that the implementation is the best though.

Also fixed a few corner cases with Date, Function and RegExp objects being cloned. Not very common scenarios perhaps, but easy enough to handle.
### clone_.clone(object, [deep])

Create a copy of the object. The copy is shallow, unless deep is true. This means that nested objects or arrays are copied by reference, not duplicated. Note that the prototype chain is not preserved by this function, unlike Object.create.

``` javascript
_.clone({name : 'moe'});
=> {name : 'moe'};

_.clone([1, 2, 3]);
=> [1, 2, 3];
```
