### PR TITLE
Make `_.escape` not escape `>` anymore, as it’s not needed

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -102,7 +102,7 @@ $(document).ready(function() {
 
     var template = _.template("<i><%- value %></i>");
     var result = template({value: "<script>"});
-    equal(result, '<i>&lt;script&gt;</i>');
+    equal(result, '<i>&lt;script></i>');
 
     var stooge = {
       name: "Moe",

--- a/underscore.js
+++ b/underscore.js
@@ -912,17 +912,18 @@
   };
 
   // List of HTML entities for escaping.
+  // Note that there's no need to escape `>`:
+  // http://mths.be/notes/ambiguous-ampersands (see "semi-related fun fact")
   var htmlEscapes = {
     '&': '&amp;',
     '<': '&lt;',
-    '>': '&gt;',
     '"': '&quot;',
     "'": '&#x27;',
     '/': '&#x2F;'
   };
 
   // Regex containing the keys listed immediately above.
-  var htmlEscaper = /[&<>"'\/]/g;
+  var htmlEscaper = /[&<"'\/]/g;
 
   // Escape a string for HTML interpolation.
   _.escape = function(string) {


### PR DESCRIPTION
More info: http://mathiasbynens.be/notes/ambiguous-ampersands (see "semi-related fun fact").

Lo-Dash has this optimization too.
