### PR TITLE
Remove unnecessary code as per #618.

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -213,7 +213,7 @@
   _.invoke = function(obj, method) {
     var args = slice.call(arguments, 2);
     return _.map(obj, function(value) {
-      return (_.isFunction(method) ? method || value : value[method]).apply(value, args);
+      return (_.isFunction(method) ? method : value[method]).apply(value, args);
     });
   };
 


### PR DESCRIPTION
If `method` is a function it's certainly not a falsy value.
