### PR TITLE
Add clarity to documentation of _invoke

### DIFF
--- a/index.html
+++ b/index.html
@@ -517,7 +517,7 @@ _.include([1, 2, 3], 3);
       <p id="invoke">
         <b class="header">invoke</b><code>_.invoke(list, methodName, [*arguments])</code>
         <br />
-        Calls the method named by <b>methodName</b> on each value in the <b>list</b>.
+        Calls the method named by <b>methodName</b> for each value in the <b>list</b> as <i>this</i>.
         Any extra arguments passed to <b>invoke</b> will be forwarded on to the
         method invocation.
       </p>


### PR DESCRIPTION
It wasn't obvious to me at first glance that the values were passed in as the 'this' pointer. Trying to clear that up.
