### PR TITLE
Add an `_.unpluck()` function.

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -222,6 +222,18 @@
     return _.map(obj, function(value){ return value[key]; });
   };
 
+  // Add a new property to every item in a collection.
+  // Pass either an array of new values, or a function that accepts
+  // each item and returns the value to be added.
+  _.unpluck = function(obj, key, val) {
+    var array = (_.isFunction(val) && _.map(obj, val)) || (_.isArray(val) && val) || [];
+    return _.map(obj, function(value, index) {
+      var tmp = {};
+      tmp[key] = array[index];
+      return _.extend(value, tmp);
+    });
+  }
+
   // Return the maximum element or (element-based computation).
   // Can't optimize arrays of integers longer than 65,535 elements.
   // See: https://bugs.webkit.org/show_bug.cgi?id=80797


### PR DESCRIPTION
Proposed function performs the inverse of `_.pluck()`, adding a new property to every item in a collection.  Useful for enriching datasets.  User can either pass an array of new values or a callback that accepts each item and returns the value to be added.

This implementation modifies the original objects inside a `_.map()`, which feels weird.  A different one might drop `_.extend()` in favor of `_.clone()`-ing each object before adding the new property.

Example usage:

<pre><code>var data = [
  {name: 'Sylvia', birthday: new Date(1984, 1, 14)},
  {name: 'Lobo', birthday: new Date(2002, 0, 5)}
];

var today = new Date();
var calculateAge = function(obj) {
  return Math.floor((today - obj.birthday)/(1000*60*60*24*365));
};

_.unpluck(data, 'age', calculateAge);

// results in  [
//   {name: 'Sylvia', birthday: new Date(1984, 1, 14), age: 28},
//   {name: 'Lobo', birthday: new Date(2002, 0, 5), age: 10}
// ];
</code></pre>
