### PR TITLE
_.size doesn't check if obj is Object

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -317,7 +317,7 @@
 
   // Return the number of elements in an object.
   _.size = function(obj) {
-    return _.isArray(obj) ? obj.length : _.keys(obj).length;
+    return _.isArray(obj) ? obj.length : _.isObject(obj) ? _.keys(obj).length : 0;
   };
 
   // Array Functions


### PR DESCRIPTION
_.size("foo") will TypeError.
This is a small patch, but it could be extended to check for other type of argument.
In any case, _.size() should return _anything_ instead of crashing.
