### PR TITLE
Make _.each skip holes in sparse arrays

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -77,7 +77,9 @@
       obj.forEach(iterator, context);
     } else if (obj.length === +obj.length) {
       for (var i = 0, l = obj.length; i < l; i++) {
-        if (iterator.call(context, obj[i], i, obj) === breaker) return;
+        if (i in obj && // Skip holes in sparse arrays.
+            iterator.call(context, obj[i], i, obj) === breaker)
+          return;
       }
     } else {
       for (var key in obj) {
@@ -805,10 +807,14 @@
   // An "empty" object has no enumerable own-properties.
   _.isEmpty = function(obj) {
     if (obj == null) return true;
-    if (_.isArray(obj) || _.isString(obj)) return obj.length === 0;
-    for (var key in obj) if (_.has(obj, key)) return false;
-    return true;
+    if (_.isString(obj))
+      return obj.length === 0;
+    if (_.isArray(obj) && obj.length === 0)
+      return true;
+    return !any(obj, alwaysTrue);
   };
+
+  function alwaysTrue() { return true }
 
   // Is a given value a DOM element?
   _.isElement = function(obj) {


### PR DESCRIPTION
Most immediately, this change is necessary to match the behavior of the native `forEach` method. To see what I mean, try doing the following:

```
[0,,2].forEach(function(elem, i) {
  console.log(elem, "at index", i);
});
```

The changes to `_.isEmpty` seemed necessary to fulfill the promises of this comment: "An 'empty' object has no enumerable own-properties."

In general, wherever we bother to skip non-own object properties using `_.has`, we should be careful to skip array holes as well.
