### PR TITLE
Added default every/all iterator as _.identity for consistency with any/some

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -174,6 +174,7 @@
   // Delegates to **ECMAScript 5**'s native `every` if available.
   // Aliased as `all`.
   _.every = _.all = function(obj, iterator, context) {
+    iterator || (iterator = _.identity);
     var result = true;
     if (obj == null) return result;
     if (nativeEvery && obj.every === nativeEvery) return obj.every(iterator, context);


### PR DESCRIPTION
It struck me as odd that _.all needed an iterator to be defined, but _.any defaulted to identity. It seems to me that these methods should be consistent with one another.
