### PR TITLE
Make _.include/_.contains work with strings.

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -167,7 +167,7 @@ $(document).ready(function() {
     ok(_.include('test this out', 'out'), 'include with a string');
     ok(!_.include('test this out', 'not included'), 'include with a string (false)');
     ok(_.include('1 2 3 4', 3), 'include with a string and number');
-    ok(!_.include(new String('test this'), 'test'), 'works with boxed strings');
+    ok(_.include(new String('test this'), 'test'), 'works with boxed strings');
     ok(_('test this out').include('this'), 'OO-style include with a string');
   });
 

--- a/underscore.js
+++ b/underscore.js
@@ -204,7 +204,7 @@
     var found = false;
     if (obj == null) return found;
     if (nativeIndexOf && obj.indexOf === nativeIndexOf) return obj.indexOf(target) != -1;
-    if (typeof obj == "string") return obj.indexOf(target) != -1;
+    if (_.isString(obj)) return obj.indexOf(target) != -1;
     found = any(obj, function(value) {
       return value === target;
     });


### PR DESCRIPTION
This makes `_.include()` /  `_.contains()` work with strings in addition to collections.

Note `String.contains` is a proposed method for Harmony: http://wiki.ecmascript.org/doku.php?id=harmony:string_extras – also it's really just another indexOf check, so it seems to make sense.

String.indexOf is present in Javascript 1.0, so a method identity check seemed unnecessary.

I wasn't sure where a doc change would go.
