### PR TITLE
Add _.startsWith and _.endsWith

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -166,6 +166,38 @@ $(document).ready(function() {
     ok(_([1,2,3]).include(2), 'OO-style include');
   });
 
+  test('collections: startsWith', function () {
+    ok(_.startsWith('a string', 'a str'), 'startsWith');
+    ok(_.startsWith('a string', 'a string'), 'longer startsWith');
+    ok(_.startsWith('a string', ''), 'startsWith empty string');
+    ok(!_.startsWith('a string', 'something else'), 'not startsWith');
+    ok(!_.startsWith('a string', 'a string plus'), 'not startsWith longer');
+    ok(_('a string').startsWith('a s'), 'OO-style startsWith');
+    ok(_.startsWith('1234 test', 1234), 'startsWith coercion');
+    ok(_.startsWith((new String('a string')), 'a string'), 'boxed startsWith');
+    ok(_.startsWith([1, 2, 3, 4, 5], [1, 2]), 'startsWith array');
+    ok(!_.startsWith([1, 2, 3, 4, 5], [1, 3]), 'not startsWith array');
+    ok(_.startsWith([1, 2, 3, 4, 5], []), 'startsWith empty array');
+    ok(!_.startsWith([1, 2, 3, 4], 1), 'startsWith mixed arrays');
+    ok(!_.startsWith({0: 'test'}, {0: 'test'}), 'startsWith objects returns false');
+  });
+
+  test('collections: endsWith', function () {
+    ok(_.endsWith('a string', 'ring'), 'endsWith');
+    ok(_.endsWith('a string', 'a string'), 'longer endsWith');
+    ok(_.endsWith('a string', ''), 'endsWith empty string');
+    ok(!_.endsWith('a string', 'something else'), 'not endsWith');
+    ok(!_.endsWith('a string', 'plus a string'), 'not endsWith longer');
+    ok(_('a string').endsWith('ring'), 'OO-style endsWith');
+    ok(_.endsWith('test 1234', 1234), 'endsWith coercion');
+    ok(_.endsWith((new String('a string')), 'a string'), 'boxed endsWith');
+    ok(_.endsWith([1, 2, 3, 4, 5], [4, 5]), 'endsWith array');
+    ok(!_.endsWith([1, 2, 3, 4, 5], [3, 5]), 'not endsWith array');
+    ok(_.endsWith([1, 2, 3, 4, 5], []), 'endsWith empty array');
+    ok(!_.endsWith([1, 2, 3, 4], 4), 'endsWith mixed arrays');
+    ok(!_.endsWith({0: 'test'}, {0: 'test'}), 'endsWith objects returns false');
+  });
+
   test('collections: invoke', function() {
     var list = [[5, 1, 7], [3, 2, 1]];
     var result = _.invoke(list, 'sort');

--- a/underscore.js
+++ b/underscore.js
@@ -209,6 +209,38 @@
     return found;
   };
 
+  // Determine if the array or string `obj` starts with `prefix`
+  // (either the string is prefixed, or the arrays have equal elements
+  // for the beginning).
+  _.startsWith = function(obj, prefix) {
+    if (_.isString(obj)) return obj.indexOf(prefix) == 0;
+    if (!_.isArray(obj) || (!_.isArray(prefix))) return false;
+    if (obj.length < prefix.length) return false;
+    for (var i=0; i < obj.length && i < prefix.length; i++) {
+      if (obj[i] !== prefix[i]) return false;
+    }
+    return true;
+  };
+
+  // Determine if the array or string `obj` ends with `tail` (either
+  // the string ends with that other string, or the arrays have equal
+  // elements at the end).
+  _.endsWith = function(obj, tail) {
+    if (_.isString(obj)) {
+      tail = tail + '';
+      var index = obj.lastIndexOf(tail);
+      return index >= 0 && index === obj.length - tail.length;
+    }
+    if (!_.isArray(obj) || (!_.isArray(tail))) return false;
+    var objLength = obj.length,
+        tailLength = tail.length;
+    if (objLength < tailLength) return false;
+    for (var i=0; i < tailLength; i++) {
+      if (obj[objLength - 1 - i] !== tail[tailLength - 1 - i]) return false;
+    }
+    return true;
+  };
+
   // Invoke a method (with arguments) on every item in a collection.
   _.invoke = function(obj, method) {
     var args = slice.call(arguments, 2);
@@ -832,7 +864,7 @@
       return toString.call(obj) == '[object ' + name + ']';
     };
   });
-  
+
   // Define a fallback version of the method in browsers (ahem, IE), where
   // there isn't any inspectable "Arguments" type.
   if (!_.isArguments(arguments)) {


### PR DESCRIPTION
This adds `_.startsWith` and `_.endsWith`.  These work with both strings and arrays.

Both methods are proposed on strings in Harmony: http://wiki.ecmascript.org/doku.php?id=harmony:string_extras – extending them to also work on arrays seems natural.

This makes specific tests for arrays, because it only makes sense for ordered collections.  `_.isArray` seems crude and maybe wrong (e.g., why shouldn't it work with childNodes or something array-like), but I'm not sure how better to detect indexable ordered collections.

Also if the types don't work out it returns false.  Should it throw an error?  And there's implicit string coercion, which maybe is okay or maybe not.
