### PR TITLE
Add _.soak for safe navigation - similar to CoffeeScript's `?.` operator

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -555,4 +555,29 @@ $(document).ready(function() {
       value();
     ok(returned == 6 && intercepted == 6, 'can use tapped objects in a chain');
   });
+
+  test("objects: soak", function() {
+    function badfn () { return void 0; }
+    function objfn () { return {c: 42}; }
+    function adder (a, b) { return {c: a+b}; }
+
+    // The trivial behavior of 0 or 1 arguments.
+    ok(_.isUndefined(_.soak()), 'passing no arguments returns undefined');
+    ok(_.isUndefined(_.soak(void 0)), 'undefined as the only argument returns undefined');
+    ok(_.isNull(_.soak(null)), 'null as the only argument returns null');
+    ok(_.isNumber(_.soak(1)), 'number as the only argument returns number');
+    ok(_.isBoolean(_.soak(false)), 'boolean as the only argument returns boolean');
+    ok(_.isNaN(_.soak(NaN)), 'NaN as the only argument returns NaN');
+    ok(_.isObject(_.soak({a:1})), 'object as the only argument returns object');
+    ok(_.isUndefined(_.soak(null, ['a'])), 'should be undefined if both arguments exist and first is null');
+    ok(_.isUndefined(_.soak(void 0, ['a'])), 'should be undefined if both arguments exist and first is undefined');
+    ok(_.isEqual('42', _.soak({a: {b: objfn}}, ['a','b','c','toString'])), 'can navigate properties and simple functions');
+    ok(_.isEqual('4', _.soak({a: {b: adder}}, ['a',['b',2,2],'c','toString'])), 'can navigate n-ary functions');
+    ok(_.isUndefined(_.soak({a: {b: badfn}}, ['a','b','c','toString'])), 'returns undefined if the chain is broken');
+    ok(_.isUndefined(_.soak({a: {b: badfn}}, ['a',['b',2,2],'c','toString'])), 'returns undefined if the chain is broken');
+    ok(_.isUndefined(_.soak({a: 2}, ['a','b'])), 'returns undefined if a slot does not exist');
+    ok(_.isEqual('2', _.soak(2, 'toString')), 'should be able to drop array brackets 1');
+    ok(_.isEqual('2', _.soak({a: 2}, 'a', 'toString')), 'should be able to drop array brackets 2');
+  });
+
 });

--- a/underscore.js
+++ b/underscore.js
@@ -708,6 +708,36 @@
     return obj;
   };
 
+  // Internal reducer for `soak`.
+  function soakreducer (memo, array, index, list) {
+    var fn;
+    if (memo == null) {
+      memo = void 0;
+    }
+    else if (_.isArray(array)) {
+      // A vector, ['a',1,2,3]...
+      fn = memo[array.shift()];
+      memo = _.isFunction(fn) ? fn.apply(memo, array) : fn;
+    }
+    else {
+      // A scalar value, 'a'...
+      fn = memo[array];
+      memo = _.isFunction(fn) ? fn.call(memo) : fn;
+    }
+    return memo;
+  }
+
+  // Returns the final value in a chain of property accesses or 
+  // function invocations; otherwise undefined if the chain is broken in 
+  // cases where an intermediate value is null or undefined.
+  _.soak = function(obj, array) {
+    if (arguments.length <= 1) return obj;
+    if (obj == null) return void 0;
+    var args = slice.call(arguments, 1);
+    array = args.length > 1 ? args : _.isArray(array) ? array : [array];
+    return _.reduce(array, soakreducer, obj);
+  };
+
   // Internal recursive comparison function for `isEqual`.
   function eq(a, b, stack) {
     // Identical objects are equal. `0 === -0`, but they aren't identical.


### PR DESCRIPTION
Add _.soak for safe navigation through a chain of properties and functions.  If the sequence is broken by null or undefined, _.soak returns undefined; otherwise, returns the value of the sequence.

``` JavaScript
var sample1 = {a: {b: function() { return void 0; }}};
sample1.a.b().c; // => throws TypeError
_.soak(sample1, 'a', 'b', 'c'); // => undefined
```

`soak` will pass arguments to functions:

``` JavaScript
var sample2 = {a: {b: function(x,y) { return x === 2 ? void 0 : x+y; }}};
sample2.a.b(2,3).toString() || false; // => throws TypeError
_.soak(sample2, 'a', ['b',2,3], 'toString') || false; // => false
```

`soak` takes the following syntax:

```
_.soak(object, 'a', 'b', ['fn', 1, 2]);  // arguments
_.soak(object, ['a', 'b', ['fn', 1, 2]]); // vector 
```
