### PR TITLE
Fix #670 - Use `value` rather than `variable`.

### DIFF
--- a/index.html
+++ b/index.html
@@ -414,7 +414,7 @@ _.map({one : 1, two : 2, three : 3}, function(num, key){ return num * 3; });
         <b>list</b> of values into a single value. <b>Memo</b> is the initial state
         of the reduction, and each successive step of it should be returned by
         <b>iterator</b>. The iterator is passed four arguments: the <tt>memo</tt>,
-        then the <tt>value</tt> and <tt>index</tt> (or key) of the iteration, 
+        then the <tt>value</tt> and <tt>index</tt> (or key) of the iteration,
         and finally a reference to the entire <tt>list</tt>.
       </p>
       <pre>
@@ -641,7 +641,7 @@ _.size({one : 1, two : 2, three : 3});
 
       <p>
         <i>
-          Note: All array functions will also work on the <b>arguments</b> object. 
+          Note: All array functions will also work on the <b>arguments</b> object.
           However, Underscore functions are not designed to work on "sparse" arrays.
         </i>
       </p>
@@ -946,7 +946,7 @@ $(window).scroll(throttled);
         preview of a Markdown comment, recalculating a layout after the window
         has stopped being resized, and so on.
       </p>
-      
+
       <p>
         Pass <tt>true</tt> for the <b>immediate</b> parameter to cause
         <b>debounce</b> to trigger the function on the leading instead of the
@@ -954,7 +954,7 @@ $(window).scroll(throttled);
         preventing accidental double-clicks on a "submit" button from firing a
         second time.
       </p>
-      
+
       <pre>
 var lazyLayout = _.debounce(calculateLayout, 300);
 $(window).resize(lazyLayout);
@@ -1187,7 +1187,7 @@ _.isArray([1,2,3]);
       <p id="isObject">
         <b class="header">isObject</b><code>_.isObject(value)</code>
         <br />
-        Returns <i>true</i> if <b>value</b> is an Object. Note that JavaScript 
+        Returns <i>true</i> if <b>value</b> is an Object. Note that JavaScript
         arrays and functions are objects, while (normal) strings and numbers are not.
       </p>
       <pre>
@@ -1311,9 +1311,9 @@ _.isNull(undefined);
 </pre>
 
       <p id="isUndefined">
-        <b class="header">isUndefined</b><code>_.isUndefined(variable)</code>
+        <b class="header">isUndefined</b><code>_.isUndefined(value)</code>
         <br />
-        Returns <i>true</i> if <b>variable</b> is <i>undefined</i>.
+        Returns <i>true</i> if <b>value</b> is <i>undefined</i>.
       </p>
       <pre>
 _.isUndefined(window.missingVariable);
@@ -1560,9 +1560,9 @@ _([1, 2, 3]).value();
 </pre>
 
       <h2 id="links">Links &amp; Suggested Reading</h2>
-      
+
       <p>
-        The Underscore documentation is also available in 
+        The Underscore documentation is also available in
         <a href="http://learning.github.com/underscore/">Simplified Chinese</a>.
       </p>
 
@@ -1596,13 +1596,13 @@ _([1, 2, 3]).value();
         aimed at on Perl hashes and arrays, also
         <a href="https://github.com/vti/underscore-perl/">available on GitHub</a>.
       </p>
-      
+
       <p>
         <a href="http://russplaysguitar.github.com/UnderscoreCF/">Underscore.cfc</a>,
         a Coldfusion port of many of the Underscore.js functions,
         <a href="https://github.com/russplaysguitar/underscorecf">available on GitHub</a>.
       </p>
-      
+
       <p>
         <a href="https://github.com/edtsech/underscore.string">Underscore.string</a>,
         an Underscore extension that adds functions for string-manipulation:
@@ -1635,21 +1635,21 @@ _([1, 2, 3]).value();
       </p>
 
       <h2 id="changelog">Change Log</h2>
-      
+
       <p>
         <b class="header">1.3.3</b> &mdash; <small><i>April 10, 2012</i></small><br />
         <ul>
           <li>
-            Many improvements to <tt>_.template</tt>, which now provides the 
+            Many improvements to <tt>_.template</tt>, which now provides the
             <tt>source</tt> of the template function as a property, for potentially
             even more efficient pre-compilation on the server-side. You may now
-            also set the <tt>variable</tt> option when creating a template, 
-            which will cause your passed-in data to be made available under the 
+            also set the <tt>variable</tt> option when creating a template,
+            which will cause your passed-in data to be made available under the
             variable you named, instead of using a <tt>with</tt> statement &mdash;
             significantly improving the speed of rendering the template.
           </li>
           <li>
-            Added the <tt>pick</tt> function, which allows you to filter an 
+            Added the <tt>pick</tt> function, which allows you to filter an
             object literal with a whitelist of allowed property names.
           </li>
           <li>
@@ -1673,7 +1673,7 @@ _([1, 2, 3]).value();
           </li>
           <li>
             The <tt>debounce</tt> function now takes an <tt>immediate</tt>
-            parameter, which will cause the callback to fire on the leading 
+            parameter, which will cause the callback to fire on the leading
             instead of the trailing edge.
           </li>
         </ul>
@@ -1713,8 +1713,8 @@ _([1, 2, 3]).value();
         <b class="header">1.2.4</b> &mdash; <small><i>Jan. 4, 2012</i></small><br />
         <ul>
           <li>
-            You now can (and probably should, as it's simpler) 
-            write <tt>_.chain(list)</tt> 
+            You now can (and probably should, as it's simpler)
+            write <tt>_.chain(list)</tt>
             instead of <tt>_(list).chain()</tt>.
           </li>
           <li>


### PR DESCRIPTION
I find that the term `variable` implies that `isUndefined` is checking for undefined/undeclared variables rather than values that `=== undefined` (it's actual purpose).
