### PR TITLE
Add number formatter

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -211,5 +211,19 @@ $(document).ready(function() {
     var templateEscaped = _.template('<%- f() %>');
     templateEscaped({f: function(){ ok(!(countEscaped++)); }});
   });
+  
+  test("utility: _.format", function() {
+	equal(_.format(9000), "9,000");
+	equal(_.format(9000, 0), "9,000");
+	equal(_.format(90000, 2), "90,000.00");
+	equal(_.format(1000.754), "1,001");
+	equal(_.format(1000.754, 2), "1,000.75");
+	equal(_.format(1000.754, 0, ',', '.'), "1.001");
+	equal(_.format(1000.754, 2, ',', '.'), "1.000,75");
+	equal(_.format(1000000.754, 2, ',', '.'), "1.000.000,75");
+	equal(_.format(1000000000), "1,000,000,000");
+	equal(_.format("not number"), "");
+	equal(_.format(new Number(5000)), "5,000");
+  });
 
 });

--- a/underscore.js
+++ b/underscore.js
@@ -928,6 +928,24 @@
       addToWrapper(name, _[name] = obj[name]);
     });
   };
+  
+  _.format = function(number, dec, dsep, tsep) {
+	if (isNaN(number)) return "";
+	number = number.toFixed(dec || 0);	
+	var pindex = number.indexOf('.'), fnums, decimals, parts = [];
+	if (pindex > -1) {
+		fnums = number.substring(0, pindex).split('');
+		decimals = (dsep || '.') + number.substr(pindex+1);
+	}
+	else {
+		fnums = number.split('');
+		decimals = '';
+	}
+	do {
+		parts.unshift(fnums.splice(-3, 3).join(''));
+	} while (fnums.length);
+	return parts.join(tsep || ',') + decimals;
+  };
 
   // Generate a unique integer id (unique within the entire client session).
   // Useful for temporary DOM ids.


### PR DESCRIPTION
I think it's really useful. This function is a clone of the PHP function `number_format()`
I'm currently using this as a separate function but it would be great to integrate this with the underscore library.
Maybe a few improvements can be made. Let me know what you think.
