### PR TITLE
Add a mask function

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -667,7 +667,7 @@
     var args = slice.call(arguments, 1);
     return function() {
       var callargs = arguments;
-      return func.apply(func, _.map(args, function(i) { return callargs[i]; }));
+      return func.apply(this, _.map(args, function(i) { return callargs[i]; }));
     };
   };
 


### PR DESCRIPTION
Description: Add a mask function that takes a function and a variable
number of indices and returns a function that calls the passed function
with the arguments specified by the indices in order.

_.mask(f, 2, 0)(a, b, c, d) is equivalent to f(c, a)

Use case: Mask out and/or rearrange arguments to a callback without a
closure.
