### PR TITLE
isEmpty check for lenght === 0 in any object with lenght property

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -374,6 +374,8 @@ $(document).ready(function() {
     ok(_.isEmpty(), 'undefined is empty');
     ok(_.isEmpty(''), 'the empty string is empty');
     ok(!_.isEmpty('moe'), 'but other strings are not');
+    ok(_.isEmpty(jQuery('#nonexistingelementfdsaf')), 'jQuery object with no matches is empty');
+    ok(!_.isEmpty(jQuery(window)), 'jQuery object with elements is not empty');
 
     var obj = {one : 1};
     delete obj.one;

--- a/underscore.js
+++ b/underscore.js
@@ -827,7 +827,7 @@
   // An "empty" object has no enumerable own-properties.
   _.isEmpty = function(obj) {
     if (obj == null) return true;
-    if (_.isArray(obj) || _.isString(obj)) return obj.length === 0;
+    if (obj.length != null) return obj.length === 0; // Arrays and Strings will check for lenght
     for (var key in obj) if (_.has(obj, key)) return false;
     return true;
   };


### PR DESCRIPTION
Apply some duck typing ruby-style checks, and now isEmpty behavior is more intuitive.

Now you can do things like this (that is not true with the current implementation):

```
matched_elements = jQuery(selector);
if (!_.isEmpty(matched_elements)) {
  do_stuff();
}
```

In general, makes sense to think that anything with length === 0 is empty.
