### PR TITLE
Unreference wrapped function in _.once

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -623,7 +623,9 @@
     return function() {
       if (ran) return memo;
       ran = true;
-      return memo = func.apply(this, arguments);
+      memo = func.apply(this, arguments);
+      func = null;
+      return memo;
     };
   };
 


### PR DESCRIPTION
Assuming we'll never run the wrapped function again on _.once(), we can
assign null to the `func` variable, so function (and all its inherited
scopes) may be collected by GC if needed.
