### PR TITLE
make _.find return [v, k] when used against object

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -114,6 +114,14 @@ $(document).ready(function() {
     strictEqual(_.find(array, function() { return false; }), void 0, 'should return `undefined` if `value` is not found');
   });
 
+  test('collections(object): find', function() {
+    var obj = {one : 1, two : 2, three : 3};
+    var result = _.find(obj, function(v, k) { return v == 2; });
+    equal(result.join(', '), '2, two', 'should return first found `value`');
+    result = _.find(obj, function(v, k) { return v == 0; });
+    equal(result, void 0, 'should return `undefined` if `value` is not found');
+  });
+
   test('collections: detect', function() {
     var result = _.detect([1, 2, 3], function(num){ return num * 2 == 4; });
     equal(result, 2, 'found the first "2" and broke the loop');

--- a/underscore.js
+++ b/underscore.js
@@ -140,7 +140,11 @@
     var result;
     any(obj, function(value, index, list) {
       if (iterator.call(context, value, index, list)) {
-        result = value;
+        if (_.isObject(obj) && !_.isArray(obj)) {
+          result = [value, index];
+        } else {
+          result = value;
+        }
         return true;
       }
     });


### PR DESCRIPTION
``` javascript
_.find({ a: 1, b: 2 }, function(v, k) { return v == 2 });
  // yields [ 2, "b" ]
```

the current underscore yields 2
