### PR TITLE
update doc to reflect that times passes index to iterator

### DIFF
--- a/index.html
+++ b/index.html
@@ -1347,7 +1347,7 @@ moe === _.identity(moe);
       <p id="times">
         <b class="header">times</b><code>_.times(n, iterator, [context])</code>
         <br />
-        Invokes the given iterator function <b>n</b> times.
+        Invokes the given iterator function <b>n</b> times. Each invocation of <b>iterator</b> is called with an <tt>index</tt> argument.
       </p>
       <pre>
 _(3).times(function(){ genie.grantWish(); });</pre>
@@ -1579,10 +1579,10 @@ _([1, 2, 3]).value();
         chaining.
         (<a href="https://github.com/robb/Underscore.m">source</a>)
       </p>
-      
+
       <p>
-        <a href="http://kmalakoff.github.com/_.m/">_.m</a>, an alternative 
-        Objective-C port that tries to stick a little closer to the original 
+        <a href="http://kmalakoff.github.com/_.m/">_.m</a>, an alternative
+        Objective-C port that tries to stick a little closer to the original
         Underscore.js API.
         (<a href="https://github.com/kmalakoff/_.m">source</a>)
       </p>


### PR DESCRIPTION
I was looking at the source and noticed that _.times passes the index to the iterator but this wasn't reflected in the documentation. This caused some people on our team to use _.range followed by _.each because they needed an index when _.times could have been used all along.
