### PR TITLE
_.escape should handle null and undefined values

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -46,9 +46,9 @@ $(document).ready(function() {
   });
 
   test("utility: _.escape", function() {
-    var test_vars = {a:null};
-    equal(_.escape(test_vars.a), "");
-    equal(_.escape(test_vars['b']), "");
+    equal(_.escape(null), "");
+    equal(_.escape(undefined), "");
+    equal(_.escape(123), "123");
     equal(_.escape("Curly & Moe"), "Curly &amp; Moe");
     equal(_.escape("Curly &amp; Moe"), "Curly &amp;amp; Moe");
   });

--- a/underscore.js
+++ b/underscore.js
@@ -930,7 +930,7 @@
 
   // Escape a string for HTML interpolation.
   _.escape = function(string) {
-    return _.isEmpty(string) ? '' : ('' + string).replace(htmlEscaper, function(match) {
+    return _.isNull(string) || _.isUndefined(string) ? '' : ('' + string).replace(htmlEscaper, function(match) {
       return htmlEscapes[match];
     });
   };


### PR DESCRIPTION
Added two failing tests to demonstrate the problem, and added fix to _.escape (check parameter with _.isEmpty before string coercion).

Basically I'm running into a case where json objects coming out of a database are valid as null, but being escaped as "null", a string. The preferable string representation of a null value is an empty string. Undefined comes along as a freebie (same problem, same solution).
