### PR TITLE
Tweak _.toArray.

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -330,10 +330,9 @@
 
   // Safely convert anything iterable into a real, live array.
   _.toArray = function(obj) {
-    if (!obj)                                     return [];
-    if (_.isArray(obj))                           return slice.call(obj);
-    if (_.isArguments(obj))                       return slice.call(obj);
-    if (obj.toArray && _.isFunction(obj.toArray)) return obj.toArray();
+    if (!obj)                                 return [];
+    if (_.isArray(obj) || _.isArguments(obj)) return slice.call(obj);
+    if (_.isFunction(obj.toArray))            return obj.toArray();
     return _.values(obj);
   };
 


### PR DESCRIPTION
- Combine _.isArray and _.isArguments type checks.
- _.isFunction will suffice for obj.toArray.
