### PR TITLE
Deep clone alternative with _.cloneJSON

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -109,6 +109,45 @@ $(document).ready(function() {
     equal(_.clone(null), null, 'non objects should not be changed by clone');
   });
 
+  test("objects: cloneJSON", function() {
+    function A () {this.name = 'moe';}
+    A.prototype.method = function () {};
+    var date = new Date();
+    var tests = {
+      'number': 42,
+      'string': 'larry',
+      'boolean': true,
+      'array': [1,2,undefined],
+      'object': {name: 'curly'},
+      'arguments': arguments,
+      'function': function () {},
+      'instance': new A(),
+      'date': new Date(),
+      'regexp': /^$/g,
+      'math': Math,
+      'nan': NaN,
+      'null': null,
+      'infinity': Infinity
+    };
+    var clone = _.cloneJSON(tests);
+
+    clone.object.name = 'curly joe';
+    ok(clone.object.name == 'curly joe' && tests.object.name == 'curly', 'changes to deep attributes are not shared with the original');
+
+    console.log(clone['arguments']);
+    ok(_.isObject(clone['arguments']) && _.isEmpty(clone['arguments']), 'arguments are changed to an empty object');
+    ok(_.isObject(clone.regexp) && _.isEmpty(clone.regexp), 'regexps are changed to an empty object');
+    ok(_.isObject(clone.math) && _.isEmpty(clone.math), 'math is changed to an empty object');
+
+    equal(clone.date, tests.date.toISOString(), 'dates are changed to an ISO string');
+    equal(clone.nan, null, 'nan is changed to null');
+    equal(clone.infinity, null, 'infinity is changed to null');
+    equal(clone['function'], undefined, 'functions are changed to undefined');
+    equal(clone.array[2], null, 'undefined is changed to null within an array');
+    equal(clone.instance.method, undefined, 'instances do not retain prototype methods');
+    equal(clone.instance.name, 'moe', 'instances retain attributes');
+  });
+
   test("objects: isEqual", function() {
     function First() {
       this.value = 1;

--- a/underscore.js
+++ b/underscore.js
@@ -755,6 +755,31 @@
     return _.isArray(obj) ? obj.slice() : _.extend({}, obj);
   };
 
+  // Create a deep-cloned duplicate of an object as if calling `JSON.parse(JSON.stringify(obj))`.
+  _.cloneJSON = function(obj) {
+    if (!_.isObject(obj)) {
+      if (_.isNumber(obj)) return _.isFinite(obj) ? obj : null;
+      return obj;
+    } 
+    if (_.isNaN(obj)) return null;
+    if (_.isArguments(obj)) return {};
+    if (_.isDate(obj)) return obj.toISOString();
+    if (_.isFunction(obj)) return undefined;
+    if (_.isArray(obj)) {
+      return _.map(obj, function(val) {
+        var clonedVal = _.cloneJSON(val);
+        return _.isUndefined(clonedVal) ? null : clonedVal;
+      });
+    }
+    var clone = {};
+    _.each(obj, function(val, key) {
+      var clonedVal = _.cloneJSON(val);
+      if (!_.isUndefined(clonedVal)) clone[key] = clonedVal;
+    });
+    return clone;
+  };
+
+
   // Invokes interceptor with the obj, and then returns obj.
   // The primary purpose of this method is to "tap into" a method chain, in
   // order to perform operations on intermediate results within the chain.


### PR DESCRIPTION
The issue of deep cloning comes up frequently and is usually dismissed because its so unclear as to what to do with it. Here's an implementation that doesn't try to do too much and acts predictably by producing the same result as `JSON.parse(JSON.stringify(obj))`. Here is my test object for comparison:

``` js
function A () {this.foo = "bar";}
A.prototype.method = function () {};

function testObj () {
  return {
    "number": 42,
    "string": "foo",
    "boolean": true,
    "array": [1,2,function(){}],
    "object": {foo: "bar"},
    "arguments": arguments,
    "function": function () {},
    "instance": new A(),
    "date": new Date(),
    "regexp": /^$/g,
    "math": Math,
    "nan": NaN,
    "null": null,
    "infinity": Infinity
  };
}
console.log(JSON.stringify(testObj()));
```

Key transformations include: 
- functions are changed to undefined (which means the key is omitted from the object)
- undefined values are changed to null within arrays,
- arguments, regexps, and Math are changed to empty objects
- NaN and Infinity are changed to null
- Dates are changed to ISO strings
- Instances lose their prototypes and methods

http://jsperf.com/json-clone/2

Performance is on par with jQuery's deep extend, but funnily enough, significantly slower than stringifying and parsing the value.

I think this solves the most common (by far) use case of just copying data structures, but I don't know if the performance implications make it worth including. What does everyone think?
