### PR TITLE
Fix _.each to correctly handle functions

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -29,6 +29,16 @@ $(document).ready(function() {
     answers = 0;
     _.each(null, function(){ ++answers; });
     equal(answers, 0, 'handles a null properly');
+
+    var f = function() {};
+    var keys = [], values = [];
+    f.foo = 'bar';
+    f.bar = 'foo';
+    _.each(f, function(value, key) {
+        keys.push(key);
+        values.push(value);
+    });
+    equal(keys.join(', '), 'foo, bar', 'iterating over functions correctly recognizes keys');
   });
 
   test('map', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -79,7 +79,7 @@
     if (obj == null) return;
     if (nativeForEach && obj.forEach === nativeForEach) {
       obj.forEach(iterator, context);
-    } else if (obj.length === +obj.length) {
+    } else if (obj.length === +obj.length && !_.isFunction(obj)) {
       for (var i = 0, l = obj.length; i < l; i++) {
         if (iterator.call(context, obj[i], i, obj) === breaker) return;
       }


### PR DESCRIPTION
See issue #761. This change updates `_.each` to correctly iterate over properties of functions regardless of the `length` property.
