### PR TITLE
optimize _.mixin and _.wrap

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -646,7 +646,8 @@
   // conditionally execute the original function.
   _.wrap = function(func, wrapper) {
     return function() {
-      var args = [func].concat(slice.call(arguments, 0));
+      var args = [func];
+      push.apply(args, arguments);
       return wrapper.apply(this, args);
     };
   };
@@ -999,8 +1000,8 @@
     each(_.functions(obj), function(name){
       var func = _[name] = obj[name];
       _.prototype[name] = function() {
-        var args = slice.call(arguments);
-        args.unshift(this._wrapped);
+        var args = [this._wrapped];
+        push.apply(args, arguments);
         return result.call(this, func.apply(_, args));
       };
     });


### PR DESCRIPTION
push.apply is faster than slice/unshift or slice/concat. see [push-apply-ftw](http://jsperf.com/push-apply-ftw) and [underscore-wrap](http://jsperf.com/underscore-wrap).
