### PR TITLE
better handling of Collection types

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,6 +270,7 @@
       <li>- <a href="#isArray">isArray</a></li>
       <li>- <a href="#isObject">isObject</a></li>
       <li>- <a href="#isArguments">isArguments</a></li>
+      <li>- <a href="#isArrayLike">isArrayLike</a></li>
       <li>- <a href="#isFunction">isFunction</a></li>
       <li>- <a href="#isString">isString</a></li>
       <li>- <a href="#isNumber">isNumber</a></li>
@@ -1229,6 +1230,18 @@ _.isObject(1);
 (function(){ return _.isArguments(arguments); })(1, 2, 3);
 =&gt; true
 _.isArguments([1,2,3]);
+=&gt; false
+</pre>
+
+      <p id="isArrayLike">
+        <b class="header">isArrayLike</b><code>_.isArrayLike(object)</code>
+        <br />
+        Returns <i>true</i> if <b>object</b> has a <tt>length</tt> property and can be iterated over with the Collection methods.  Currently supported types are Arrays, Arguments, HTMLCollections, NodeLists or jQuery Array-likes.
+      </p>
+      <pre>
+(function(){ return _.isArrayLike(arguments); })(1, 2, 3);
+=&gt; true
+_.isArrayLike({length: 10});
 =&gt; false
 </pre>
 

--- a/test/collections.js
+++ b/test/collections.js
@@ -22,6 +22,12 @@ $(document).ready(function() {
     equal(answers.join(", "), 'one, two, three', 'iterating over objects works, and ignores the object prototype.');
     delete obj.constructor.prototype.four;
 
+    answers = [];
+    obj = {one : 1, two : 2, three : 3, length : 12};
+    _.each(obj, function(value, key){ answers.push(key); });
+    equal(answers.join(", "), 'one, two, three, length', 'iterating over objects with a "length" property works.');
+    delete obj.constructor.prototype.four;
+
     answer = null;
     _.each([1, 2, 3], function(num, index, arr){ if (_.include(arr, num)) answer = true; });
     ok(answer, 'can reference the original collection from inside the iterator');
@@ -388,6 +394,7 @@ $(document).ready(function() {
 
   test('size', function() {
     equal(_.size({one : 1, two : 2, three : 3}), 3, 'can compute the size of an object');
+    equal(_.size({length : 12}), 1, 'can compute the size of an object with an arbitrary "length" property');
     equal(_.size([1, 2, 3]), 3, 'can compute the size of an array');
 
     var func = function() {

--- a/test/objects.js
+++ b/test/objects.js
@@ -428,6 +428,18 @@ $(document).ready(function() {
     ok(_.isArray(iArray), 'even from another frame');
   });
 
+  test("isArrayLike", function() {
+    ok(_.isArrayLike(arguments), 'the arguments object is array-like');
+    ok(_.isArrayLike([1, 2, 3]), 'and arrays');
+    ok(_.isArrayLike(iArray), 'even from another frame');
+    ok(_.isArrayLike(document.images), 'and HTMLCollections');
+    if (document.querySelectorAll) {
+      ok(_.isArrayLike(document.querySelectorAll('#map-test *')), 'and NodeLists')
+    }
+    ok(_.isArrayLike($('#map-test').children()), 'and jQuery Array-likes');
+    ok(!_.isArrayLike({length: 10}), 'but not objects with "length" properties');
+  });
+
   test("isString", function() {
     ok(!_.isString(document.body), 'the document body is not a string');
     ok(_.isString([1, 2, 3].join(', ')), 'but strings are');


### PR DESCRIPTION
When working on [Backbone-Nested](https://github.com/afeld/backbone-nested) I noticed that I wasn't able to iterate over an object with a `length` property set to an arbitrary value, which is present in [the Backbone tests](https://github.com/documentcloud/backbone/blob/0.9.2/test/model.js#L20).

``` javascript
_.each({length: 20}, function(){ /* never reached */ });
```

`_.each()` and `_.size()` were handing this case incorrectly, and `_.isEmpty()` was additionally giving incorrect results for Arguments, HTMLCollections, NodeLists and jQuery Array-likes.  I have added `_.isArrayLike()` so that these methods (which all depend on `.length`) can detect the types in a central place.

Tests are green in Chrome 22, FF 15 and Safari 6.0.  I did some testing in various IE versions as I went but used up my [Browserstack](http://www.browserstack.com/) limit, so if others wouldn't mind verifying (particularly v6-8), that would be appreciated.  Thanks!
