### PR TITLE
lets _.where also take a function

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -224,6 +224,9 @@ $(document).ready(function() {
     result = _.where(list, {b: 2});
     equal(result.length, 2);
     equal(result[0].a, 1);
+    result = _.where(list, {b:function(num) {return num > 3;}});
+    equal(result.length, 1);
+    equal(result[0].b, 4);
   });
 
   test('max', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -235,7 +235,11 @@
     if (_.isEmpty(attrs)) return [];
     return _.filter(obj, function(value) {
       for (var key in attrs) {
-        if (attrs[key] !== value[key]) return false;
+        if (_.isFunction(attrs[key])) {
+          if (! attrs[key](value[key])) return false;
+        } else { 
+          if (attrs[key] !== value[key]) return false;
+        }
       }
       return true;
     });


### PR DESCRIPTION
Hey-

In case you are interested in this sort of thing, I added the ability for where to take in functions as values so you can do:

mayVote = _.where users, citizenship:"USA", age:(age)-> age >= 18

This example is of course is more DRY with livescript or partial-function-application,so it becomes age:(>= 17).

Thanks,
Nate
