### PR TITLE
Added '_.ensureArray' function

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -246,4 +246,11 @@ $(document).ready(function() {
     strictEqual(template(), '<<\nx\n>>');
   });
 
+  test('ensureArray utility function',3,function(){
+    var arr = [1,2,3], obj = {a:1,b:2};
+    equal(_.ensureArray(arr),arr); // arrays should be passed straight through
+    deepEqual(_.ensureArray(obj),[obj]); // non-arrays should be wrapped in an array
+    deepEqual(_.ensureArray(undefined),[]); // falsy values should result in empty array
+  });
+
 });

--- a/underscore.js
+++ b/underscore.js
@@ -1148,6 +1148,13 @@
     return template;
   };
 
+  // utility function for converting non-array values to an array. Arrays are passed
+  // straight through, non-array values will be wrapped in an array, and falsy values
+  // return an empty array.
+  _.ensureArray = function(value){
+    return _.isArray(value) ? value : value ? [value] : [];
+  };
+
   // Add a "chain" function, which will delegate to the wrapper.
   _.chain = function(obj) {
     return _(obj).chain();


### PR DESCRIPTION
This pull request adds a `_.ensureArray` utility function, which we frequently found ourselves `mixin` into underscore. As the name implies, it helps when you want to feed a perhaps-array value into an API that expects an array:

``` javascript
// arrays are passed straight through
_.ensureArray([1,2,3]); // => [1,2,3]

// non-array truthy values are wrapped in an array
_.ensureArray({a:1,b:2}); // => [{a:1,b:2}]
_.ensureArray("foo"); // => ["foo"]
_.ensureArray(432); // => [432]

// falsy values result in an empty array
_.ensureArray(null); // => []
```

Semantically we are perhaps treading a bit too far into the land of `_.toArray` here, but the functions behave very differently since `toArray` always treats the argument as a collection. For the above use cases, here is what `toArray` returns:

``` javascript
_.toArray([1,2,3]); // => cloned array [1,2,3]
_.toArray({a:1,b:2}); // => [1,2]
_.toArray("foo"); // => ["f","o","o"]
_.toArray(432); // => []
```

Only for falsy values do the two functions act the same. 
