### PR TITLE
Updated _.isFinite to match ES5 and ES6 spec

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -485,7 +485,9 @@ $(document).ready(function() {
     ok(!_.isFinite(NaN), 'NaN is not Finite');
     ok(!_.isFinite(Infinity), 'Infinity is not Finite');
     ok(!_.isFinite(-Infinity), '-Infinity is not Finite');
-    ok(!_.isFinite('12'), 'Strings are not numbers');
+    ok(_.isFinite('12'), 'Numeric strings are numbers');
+    ok(!_.isFinite('1a'), 'Non numeric strings are not numbers');
+    ok(!_.isFinite(''), 'Empty strings are not numbers');
     var obj = new Number(5);
     ok(_.isFinite(obj), 'Number instances can be finite');
     ok(_.isFinite(0), '0 is Finite');

--- a/underscore.js
+++ b/underscore.js
@@ -951,7 +951,7 @@
 
   // Is a given object a finite number?
   _.isFinite = function(obj) {
-    return _.isNumber(obj) && isFinite(obj);
+    return isFinite( obj ) && !isNaN( parseFloat(obj) );
   };
 
   // Is the given value `NaN`? (NaN is the only number which does not equal itself).


### PR DESCRIPTION
The EcmaScript 5 and 6 specs define isFinite as returning false only if ToNumber(object) is NaN, Infinity or -Infinity (a very short and clear read: http://es5.github.com/#x15.1.2.5)

The current implementation of _.isFinite acts as if ToNumber('42') === NaN, and returns false on _.isFinite('42').

This was originally [done to combat an "issue"](https://github.com/documentcloud/underscore/pull/524#issuecomment-4695186) with EcmaScript's ToNumber, which returns true for empty strings (or strings full of nothing but spaces). The problem is that the fix was overzealous, and negates all argument coercion - which is the very heart of isFinite - and acts exactly the opposite of the spec and of the browsers' implementation.

This commit fixes it, while also catching the special gotcha in the spec for empty strings.

``` javascript
// before :
isFinite('12') !== _.isFinite('12') // true !== false
// now:
isFinite('12') === _.isFinite('12') // true === true
// didn't change:
isFinite('')   !== _.isFinite('')   // true !== false
```

It's also much faster than the current implementation.
