### PR TITLE
Fix #839 :  _.difference([],[1,2,3]) == [] : not [1,2,3]

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -119,6 +119,12 @@ $(document).ready(function() {
     var result = _.difference([1, 2, 3], [2, 30, 40]);
     equal(result.join(' '), '1 3', 'takes the difference of two arrays');
 
+    var result = _.difference([], [1 ,2 ,3 ]);
+    equal(result.join(' '), '1 2 3', 'takes the difference of two arrays, first array is empty');
+
+    var result = _.difference([1 ,2 ,3 ], []);
+    equal(result.join(' '), '1 2 3', 'takes the difference of two arrays, second array is empty');
+
     var result = _.difference([1, 2, 3, 4], [2, 30, 40], [1, 11, 111]);
     equal(result.join(' '), '3 4', 'takes the difference of three arrays');
   });

--- a/underscore.js
+++ b/underscore.js
@@ -472,7 +472,9 @@
   // Only the elements present in just the first array will remain.
   _.difference = function(array) {
     var rest = concat.apply(ArrayProto, slice.call(arguments, 1));
-    return _.filter(array, function(value){ return !_.contains(rest, value); });
+    if(array.length == 0) return rest;
+    if(rest.length == 0) return array;
+    return  _.filter(array, function(value){ return !_.contains(rest, value); });
   };
 
   // Zip together multiple lists into a single array -- elements that share


### PR DESCRIPTION
It may also be marginally faster.
