### PR TITLE
Prevent misleading return value from debounce

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -652,7 +652,7 @@
       var context = this, args = arguments;
       var later = function() {
         timeout = null;
-        if (!immediate) result = func.apply(context, args);
+        if (!immediate) func.apply(context, args);
       };
       var callNow = immediate && !timeout;
       clearTimeout(timeout);


### PR DESCRIPTION
Unless this is the desired functionality...

Setting `result` here is misleading. Consider:

``` javascript
var x = 0;
var f = function() { return ++x; };
var g = _.debounce(f, 1000);
console.log(g()); // returns undefined
// f is called, x is incremented, and result is set to 1
setTimeout(function(){ 
  console.log(g()); // returns 1
  console.log(g()); // returns 1
  console.log(g()); // returns 1
}, 1100);
```

It shouldn't set `result` since it returns the previously returned value on the next series of calls.
