### PR TITLE
Juggle arguments in `_.uniq` to allow an argument signature of `array, iterator, context`

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -91,6 +91,8 @@ $(document).ready(function() {
     var iterator = function(value) { return value.name; };
     equal(_.map(_.uniq(list, false, iterator), iterator).join(', '), 'moe, curly, larry', 'can find the unique values of an array using a custom iterator');
 
+    equal(_.map(_.uniq(list, iterator), iterator).join(', '), 'moe, curly, larry', 'can find the unique values of an array using a custom iterator without specifying whether array is sorted');
+
     var iterator = function(value) { return value +1; };
     var list = [1, 2, 2, 3, 4, 4];
     equal(_.uniq(list, true, iterator).join(', '), '1, 2, 3, 4', 'iterator works with sorted array');

--- a/underscore.js
+++ b/underscore.js
@@ -439,6 +439,11 @@
   // been sorted, you have the option of using a faster algorithm.
   // Aliased as `unique`.
   _.uniq = _.unique = function(array, isSorted, iterator, context) {
+    if (_.isFunction(isSorted)) {
+      context = iterator;
+      iterator = isSorted;
+      isSorted = false;
+    }
     var initial = iterator ? _.map(array, iterator, context) : array;
     var results = [];
     var seen = [];


### PR DESCRIPTION
Issue 832: Juggle arguments in `_.uniq` to allow an argument signature of `array, iterator, context`

Keep in mind that this is the first attempt in my life trying to contribute code to an open-source project. If anyone doesn't like it, I would appreciate it if they explain why.
