### PR TITLE
Add _.toFunction to convert objects to functions of their keys

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -547,4 +547,14 @@ $(document).ready(function() {
       value();
     ok(returned == 6 && intercepted == 6, 'can use tapped objects in a chain');
   });
+
+  test("toFunction", function() {
+    var a = ["bob", "joe", "tom"];
+    var subset = _.map([0, 2], _.toFunction(a));
+    ok(_.isEqual(subset, ["bob", "tom"]), "array subset from list of indices");
+
+    var obj = {a: "bob", b: "joe", c: "tom"};
+    var objSubset = _.filter(["a", "b", "z"], _.toFunction(obj));
+    ok(_.isEqual(objSubset, ["a", "b"]), "filtered list of keys using object as predicate");
+  });
 });

--- a/underscore.js
+++ b/underscore.js
@@ -765,6 +765,13 @@
     return obj;
   };
 
+  // Return a function of the keys of the object
+  _.toFunction = function(obj) {
+    return function(key) {
+      return obj[key];
+    }
+  }
+
   // Return a copy of the object only containing the whitelisted properties.
   _.pick = function(obj) {
     var copy = {};


### PR DESCRIPTION
_.toFunction returns a function which represents the object as a
function of its keys. For example, it turns an array into a function
of its indices, so:

```
var f = _.toFunction(["zero", "one", "two"]);
f(0); // returns "zero"
```

This is useful in combination with collection methods, like map or
filter, so that objects can be easily converted to map functions or 
predicates, like so:

```
// returns a subset of someArray with only the values at 3 5 and 6
var subset = _.map([3, 5, 6], _.toFunction(someArray));
```
