### PR TITLE
Alias value to result

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1043,7 +1043,7 @@
 
   // If the value of the named property is a function then invoke it;
   // otherwise, return it.
-  _.result = function(object, property) {
+  _.result = _.value = function(object, property) {
     if (object == null) return null;
     var value = object[property];
     return _.isFunction(value) ? value.call(object) : value;


### PR DESCRIPTION
Result seems like a confusing name for getting the value of a property on an object. _.value is closer to Backbone's `getValue` (see documentcloud/backbone#1607). Seems to make a little more sense semantically.
