### PR TITLE
toArray: only call Array.prototype.slice on actual arrays.

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -418,6 +418,9 @@ $(document).ready(function() {
 
     var numbers = _.toArray({one : 1, two : 2, three : 3});
     equal(numbers.join(', '), '1, 2, 3', 'object flattened into array');
+
+    // _.toArray on a NodeList should not throw.
+    ok(_.isArray(_.toArray(document.childNodes)));
   });
 
   test('size', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -358,7 +358,8 @@
   // Safely convert anything iterable into a real, live array.
   _.toArray = function(obj) {
     if (!obj) return [];
-    if (obj.length === +obj.length) return slice.call(obj);
+    if (_.isArray(obj)) return slice.call(obj);
+    if (obj.length === +obj.length) return _.map(obj, _.identity);
     return _.values(obj);
   };
 


### PR DESCRIPTION
Specifically, this fixes _.toArray on NodeList objects on IE8, which worked in
Underscore 1.3.3 but throws "JScript object expected"  in 1.4.0.
