### PR TITLE
Add `_.scan` for returning an array of successive reduced values

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -435,4 +435,17 @@ $(document).ready(function() {
     equal(_.size(null), 0, 'handles nulls');
   });
 
+  test('scan', function() {
+    var result = _.scan([1, 2, 3], 0, function(acc, cur) { return acc + cur; });
+    deepEqual(result, [1, 3, 6], 'returns each accumulator value in sequence');
+
+    result = _.scan(['a', 'b', 'c'], [], function(acc, cur) { return acc.concat(cur); });
+    deepEqual(result,[['a'], ['a', 'b'], ['a', 'b', 'c']], 'allows array value for the accumulator');
+
+    result = _.scan({a: 1, b: 2, c: 3}, '', function(acc, val, key) { return acc + key + val; });
+    deepEqual(result,['a1', 'a1b2', 'a1b2c3'], 'allows iteration with objects');
+
+    result = _.scan([], '', function(acc, cur) { throw 'Should not call me'; });
+    deepEqual(result, [], 'returns empty array for empty collection');
+  });
 });

--- a/underscore.js
+++ b/underscore.js
@@ -368,6 +368,16 @@
     return (obj.length === +obj.length) ? obj.length : _.keys(obj).length;
   };
 
+  // Similar to `_.reduce`, but returns an array of successive reduced values.
+  _.scan = function(obj, initial, iterator) {
+    var result = [];
+    each(obj, function(value, index, list) {
+      initial = iterator(initial, value, index, list);
+      result.push(initial);
+    });
+    return result;
+  };
+
   // Array Functions
   // ---------------
 


### PR DESCRIPTION
I don't know any easy way to do this in FP style with Underscore, and without resorting to recursion: gather the value of each iteration, and pass the last processed value to the next iteration. It's easy to do with an explicit loop, but that looks ugly in a program that is otherwise written in FP style.

It's difficult to use `_.reduce` for this, because you need a way to store the initial value and access the last accumulator value:

```
_.chain(['a', 'b', 'c'])
  .reduce(function(acc, cur) { return acc.concat(_.last(acc) + cur) }, [''])
  .tail()
  .value()
```

The name of the function is taken from Haskell Prelude:
http://hackage.haskell.org/packages/archive/base/latest/doc/html/Prelude.html#v:scanl
