### PR TITLE
Add a simple, array-compatible _.walk method

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -547,4 +547,19 @@ $(document).ready(function() {
       value();
     ok(returned == 6 && intercepted == 6, 'can use tapped objects in a chain');
   });
+
+  test("walk", function() {
+    var testObject  = {users: [{comments: [{id: 10}]}]};
+    var existent    = _.walk(testObject, 'users', 0, 'comments', 0, 'id');
+    var nonexistent = _.walk(testObject, 'posts', 10, 'authors', 0, 'id');
+    var noArgs      = _.walk();
+    var noPath      = _.walk(testObject);
+    var nonObject   = _.walk(1, 2, 3);
+
+    equal(existent, 10, "returns nested values when they exist");
+    ok(_.isUndefined(nonexistent), "returns undefined when values do not exist");
+    ok(_.isUndefined, noArgs, "returns undefined when no arguments are passed");
+    ok(_.isEqual(noPath, testObject), "returns the original object if no path is passed");
+    equal(nonObject, 1, "returns the first argument if it isn't an object");
+  });
 });

--- a/underscore.js
+++ b/underscore.js
@@ -809,6 +809,19 @@
     return obj;
   };
 
+  // Provides a safe way to access deeply nested object attributes without
+  // existence checks at each step. Aliased as `_.seek`.
+  _.walk = _.seek = function() {
+    var args = slice.call(arguments);
+    var obj  = args.shift();
+    if (!_.isObject(obj)) return obj;
+    while (args.length > 0) {
+      obj = obj[args.shift()];
+      if (_.isUndefined(obj)) break;
+    }
+    return obj;
+  }
+
   // Internal recursive comparison function for `isEqual`.
   var eq = function(a, b, aStack, bStack) {
     // Identical objects are equal. `0 === -0`, but they aren't identical.


### PR DESCRIPTION
This has been previously discussed in issue #813, however I believe this is a much simpler implementation which works for nested arrays too.

I've tentatively aliased it to `_.seek` as `_.walk` could be ambiguous.
