### PR TITLE
Use identity instead of creating a new function

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -408,7 +408,7 @@
 
   // Trim out all falsy values from an array.
   _.compact = function(array) {
-    return _.filter(array, function(value){ return !!value; });
+    return _.filter(array, _.identity);
   };
 
   // Internal implementation of a recursive `flatten` function.


### PR DESCRIPTION
The `compact` function uses a function which casts each member to a Boolean, however this isn't needed since `filter` just checks for truthiness, not `=== true`.

This change reuses the `_.identity` function, which has the same effect and doesn't require creating a new function on each call.
