### PR TITLE
Make the exception message friendly

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -181,6 +181,22 @@ $(document).ready(function() {
     }
   });
 
+  test('_.template provides the generated function source, when a ReferenceError occurs', function() {
+    try {
+      _.template('<b><%= inexist %></b>', {});
+    } catch (e) {
+      equal(e.name, "ReferenceError", "Exception should be ReferenceError");
+      ok(e.message.indexOf(' >> 1| <b><%= inexist %></b>') > 0);
+    }
+    try {
+      console.log($("#template").html());
+      console.log(_.template($("#template").html(), {}));
+    } catch (e) {
+      equal(e.name, "ReferenceError", "Exception should be ReferenceError");
+      ok(e.message.indexOf(' >> 4|') > 0);
+    }
+  });
+
   test('_.template handles \\u2028 & \\u2029', function() {
     var tmpl = _.template('<p>\u2028<%= "\\u2028\\u2029" %>\u2029</p>');
     strictEqual(tmpl(), '<p>\u2028\u2028\u2029\u2029</p>');

--- a/underscore.js
+++ b/underscore.js
@@ -1121,24 +1121,35 @@
 
     // Compile the template source, escaping string literals appropriately.
     var index = 0;
-    var source = "__p+='";
+    var lineno = 1;
+    var source = "";
     text.replace(matcher, function(match, escape, interpolate, evaluate, offset) {
-      source += text.slice(index, offset)
-        .replace(escaper, function(match) { return '\\' + escapes[match]; });
+      source += "__p+='" + text.slice(index, offset)
+        .replace(escaper, function(match) {
+          lineno++;
+          return '\\' + escapes[match];
+        }) + "';\n";
 
+      source += "__stack.lineno = " + lineno + ";\n";
       if (escape) {
-        source += "'+\n((__t=(" + escape + "))==null?'':_.escape(__t))+\n'";
+        source += "__p+=((__t=(" + escape + "))==null?'':_.escape(__t));\n";
       }
       if (interpolate) {
-        source += "'+\n((__t=(" + interpolate + "))==null?'':__t)+\n'";
+        source += "__p+=((__t=(" + interpolate + "))==null?'':__t);\n";
       }
       if (evaluate) {
-        source += "';\n" + evaluate + "\n__p+='";
+        var lines = evaluate.split('\n');
+        _.forEach(lines, function (line) {
+          source += line + "\n";
+          lineno++;
+          source += "__stack.lineno = " + lineno + ";\n";
+        });
       }
+
       index = offset + match.length;
       return match;
     });
-    source += "';\n";
+    source += "\n";
 
     // If a variable is not specified, place data values in local scope.
     if (!settings.variable) source = 'with(obj||{}){\n' + source + '}\n';
@@ -1146,9 +1157,43 @@
     source = "var __t,__p='',__j=Array.prototype.join," +
       "print=function(){__p+=__j.call(arguments,'');};\n" +
       source + "return __p;\n";
+    function rethrow(err, str, lineno) {
+      var lines = str.split('\n');
+      var start = Math.max(lineno - 3, 0);
+      var end = Math.min(lines.length, lineno + 3);
+
+      // Error context
+      var context = _.map(lines.slice(start, end), function (line, i) {
+        var curr = i + start + 1;
+        return (curr == lineno ? ' >> ' : '    ') + curr + '| ' + line;
+      }).join('\n');
+
+      // Alter exception message
+      err.message = lineno + '\n' + context + '\n\n' + err.message;
+      throw err;
+    }
+
+    var input = text.replace(/\\/g, "\\\\")
+      .replace(/'/g, "\'")
+      .replace(/"/g, "\\\"")
+      .replace(/\n/g, "\\n")
+      .replace(/\u2028/g, "\\\u2028")
+      .replace(/\u2029/g, "\\\u2029");
+
+    var catched = [
+      'var input = "' + input + '";\n',
+      // 'var input = "' + text.replace(/\\/, "\\").replace(/'/g, "\'").replace(/"/g, "\"") + '";\n',
+      'var __stack = {lineno: 1};',
+      rethrow.toString(),
+      'try {',
+        source,
+      '} catch (err) {',
+      '  rethrow(err, input, __stack.lineno);',
+      '}'
+    ].join('\n');
 
     try {
-      var render = new Function(settings.variable || 'obj', '_', source);
+      var render = new Function(settings.variable || 'obj', '_', catched);
     } catch (e) {
       e.source = source;
       throw e;


### PR DESCRIPTION
the template method is small and smarty, but not friendly for debug. this patch can help developers to debug template. It's useful.

```
ReferenceError: 4
    2|     <%
    3|     // a comment
 >> 4|     if (data) { data += 12345; }; %>
    5|     <li><%= data %></li>
    6|   

data is not defined
    at eval (eval at <anonymous> (file://localhost/Users/jacksontian/fork/my_underscore/underscore.js:1196:20), <anonymous>:29:9)
    at Function._.template (file://localhost/Users/jacksontian/fork/my_underscore/underscore.js:1202:22)
    at Object.<anonymous> (file://localhost/Users/jacksontian/fork/my_underscore/test/utility.js:193:21)
```
