### PR TITLE
Add component.json for Bower support

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,5 +1,5 @@
 {
   "name"          : "underscore",
- 	"version"       : "1.4.2"
+  "version"       : "1.4.2",
   "main"          : "underscore.js"
 }


### PR DESCRIPTION
Since [Bower](http://twitter.github.com/bower/) v5 does not use `package.json`anymore, the bower community needs you to add a `component.json` file to your repo.

Thanks for merging this !
