### PR TITLE
Allow `_.result` to be passed arguments

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -6,7 +6,7 @@
   <script src="vendor/jquery.js"></script>
   <script src="vendor/qunit.js"></script>
   <script src="vendor/jslitmus.js"></script>
-  <script src="../underscore-min.js"></script>
+  <script src="../underscore.js"></script>
 
   <script src="collections.js"></script>
   <script src="arrays.js"></script>

--- a/test/utility.js
+++ b/test/utility.js
@@ -196,6 +196,11 @@ $(document).ready(function() {
     strictEqual(_.result(null, 'x'), null);
   });
 
+  test('result can be passed arguments', function() {
+    var obj = {fn: function(arg) { return arg; }};
+    strictEqual(_.result(obj, 'fn', 1), 1);
+  });
+
   test('_.templateSettings.variable', function() {
     var s = '<%=data.x%>';
     var data = {x: 'x'};

--- a/underscore.js
+++ b/underscore.js
@@ -1053,10 +1053,10 @@
 
   // If the value of the named property is a function then invoke it;
   // otherwise, return it.
-  _.result = function(object, property) {
-    if (object == null) return null;
-    var value = object[property];
-    return _.isFunction(value) ? value.call(object) : value;
+  _.result = function(obj, key) {
+    if (obj == null) return null;
+    var val = obj[key];
+    return _.isFunction(val) ? val.apply(obj, slice.call(arguments, 2)) : val;
   };
 
   // Add your own custom functions to the Underscore object.


### PR DESCRIPTION
I also changed the test file to include the uncompressed underscore, seemed odd that it was using the minified version...
