### PR TITLE
_.rest("*Hello") works well on firefox, chrome but not IE8

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -29,6 +29,7 @@ $(document).ready(function() {
     equal(_.flatten(result).join(','), '2,3,2,3', 'works well with _.map');
     result = (function(){ return _(arguments).drop(); })(1, 2, 3, 4);
     equal(result.join(', '), '2, 3, 4', 'aliased as drop and works on arguments object');
+    equal(_.rest("-string").join(""), 'string', 'rest can works with string object')
   });
 
   test("initial", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -405,7 +405,7 @@
   // the rest N values in the array. The **guard**
   // check allows it to work with `_.map`.
   _.rest = _.tail = _.drop = function(array, n, guard) {
-    return slice.call(array, (n == null) || guard ? 1 : n);
+    return slice.call(_.isString(array) ? array.split("") : array, (n == null) || guard ? 1 : n);
   };
 
   // Trim out all falsy values from an array.


### PR DESCRIPTION
Some people like me can use _.rest method with a String ...

_.rest("*Hello").join("") will return "Hello" on firefox, chrome, safari but return ",,,," in IE8

I just added a little fix for it  with a test.
