### PR TITLE
get() function for objects

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -991,6 +991,12 @@
     return hasOwnProperty.call(obj, key);
   };
 
+  // Shortcut function for getting the value of a property in an object.
+  _.get = function(obj, key) {
+    if(obj && _.has(obj, key)) return obj[key];
+    return void 0;
+  };
+
   // Utility Functions
   // -----------------
 


### PR DESCRIPTION
A get function that works with chaining without breaking it even if the
the given key does not exist.  E.g., the following code works even if
none of the specified keys exist, without having to check many
conditional:

```
_.chain(obj)  // => object
 .get('key1') // => array
 .first()     // => object
 .get('key2') // => object
 .get('key3') // => array
 .find(function(){...})
 .value();
```
