### PR TITLE
Where .IN. Syntax

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -258,6 +258,11 @@ $(document).ready(function() {
     result = _.where(list, {b: 2});
     equal(result.length, 2);
     equal(result[0].a, 1);
+    result = _.where(list, {b: [3,4]});
+    equal(result.length, 2);
+    equal( true, _.include(_.pluck(result,'b'), 3));
+    equal( true, _.include(_.pluck(result,'b'), 4));
+    equal( false, _.include(_.pluck(result,'b'), 2));
   });
 
   test('max', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -240,7 +240,10 @@
     if (_.isEmpty(attrs)) return [];
     return _.filter(obj, function(value) {
       for (var key in attrs) {
-        if (attrs[key] !== value[key]) return false;
+        if (attrs[key] instanceof Array)
+          return _.include( attrs[key], value[key] );
+        else
+          if (attrs[key] !== value[key]) return false;
       }
       return true;
     });


### PR DESCRIPTION
Basically if an array is provided as the criteria it runs an include instead of an === behavior that's the expected from a where query on a Rails application
