### PR TITLE
string starts with hyphen reverses _.sortBy

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -324,6 +324,24 @@ $(document).ready(function() {
     });
 
     deepEqual(actual, collection, 'sortBy should be stable');
+
+    list = [
+      {a: 2, '-b': 2, '\\c': 2},
+      {a: 3, '-b': 3, '\\c': 3},
+      {a: 1, '-b': 1, '\\c': 1}
+    ];
+    sorted = _.sortBy(list, 'a');
+    deepEqual(_.pluck(sorted, 'a'), [1, 2, 3]);
+    sorted = _.sortBy(list, '-a');
+    deepEqual(_.pluck(sorted, 'a'), [3, 2, 1], 'hyphen reverses the order');
+    sorted = _.sortBy(list, '\\-b');
+    deepEqual(_.pluck(sorted, '-b'), [1, 2, 3], "'-prop' needs backslash escaping");
+    sorted = _.sortBy(list, '--b');
+    deepEqual(_.pluck(sorted, '-b'), [3, 2, 1], 'hyphen reverses the order');
+    sorted = _.sortBy(list, '\\c');
+    deepEqual(_.pluck(sorted, '\\c'), [1, 2, 3]);
+    sorted = _.sortBy(list, '-\\c');
+    deepEqual(_.pluck(sorted, '\\c'), [3, 2, 1], 'hyphen reverses the order');
   });
 
   test('groupBy', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -296,6 +296,15 @@
 
   // Sort the object's values by a criterion produced by an iterator.
   _.sortBy = function(obj, value, context) {
+    var reverse = false;
+    if (_.isString(value)) {
+      if (value.substr(0, 2) === '\\-') {
+        value = value.substr(1);
+      } else if (value.charAt(0) === '-') {
+        reverse = true;
+        value = value.substr(1);
+      }
+    }
     var iterator = lookupIterator(value);
     return _.pluck(_.map(obj, function(value, index, list) {
       return {
@@ -307,8 +316,8 @@
       var a = left.criteria;
       var b = right.criteria;
       if (a !== b) {
-        if (a > b || a === void 0) return 1;
-        if (a < b || b === void 0) return -1;
+        if (a > b || a === void 0) return reverse ? -1 : 1;
+        if (a < b || b === void 0) return reverse ? 1 : -1;
       }
       return left.index < right.index ? -1 : 1;
     }), 'value');


### PR DESCRIPTION
See [backbone#1968](https://github.com/documentcloud/backbone/pull/1968).

This PR enables `_.sortBy` to sort a collection in descending order by giving hyphen-starting string as 2nd argument.

``` js
_.sortBy(['aaa', 'b', 'cc'], 'length'); //=> ['b', 'cc', 'aaa']
_.sortBy(['aaa', 'b', 'cc'], '-length'); //=> ['aaa', 'cc', 'b']
```

Note that backward compatibility is broken a bit: properties start with '-' need backslash escaping. I think such names are really rare.

``` js
list =_.sortBy([{'-a': 2}, {'-a': 3}, {'-a': 1}], '\\-a');
_.pluck(list, '-a') // => [1, 2, 3];
list =_.sortBy([{'-a': 2}, {'-a': 3}, {'-a': 1}], '--a');  // two hyphens
_.pluck(list, '-a') // => [3, 2, 1];
```
