### PR TITLE
Unescape example has escape instead.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1512,7 +1512,7 @@ _.escape('Curly, Larry &amp; Moe');
         with their unescaped counterparts.
       </p>
       <pre>
-_.escape('Curly, Larry &amp;amp; Moe');
+_.unescape('Curly, Larry &amp;amp; Moe');
 =&gt; "Curly, Larry &amp; Moe"</pre>
 
       <p id="result">


### PR DESCRIPTION
The example for unescape had escape instead.
