### PR TITLE
Minor optimization for _.invoke()

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -224,8 +224,9 @@
   // Invoke a method (with arguments) on every item in a collection.
   _.invoke = function(obj, method) {
     var args = slice.call(arguments, 2);
-    return _.map(obj, function(value) {
-      return (_.isFunction(method) ? method : value[method]).apply(value, args);
+    var isFunc = _.isFunction(method);
+    return _.map(obj, function (value) {
+      return (isFunc ? method : value[method]).apply(value, args);
     });
   };
 


### PR DESCRIPTION
_.isFunction() doesn't need to be called on each iteration in the loop. The result will never change.
