### PR TITLE
Add isDefined method

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -980,6 +980,11 @@
   _.isNull = function(obj) {
     return obj === null;
   };
+  
+  // Is a given varialbe not undefined?
+  _.isDefined = function(obj) {
+    return false === (obj === void 0);
+ 	};
 
   // Is a given variable undefined?
   _.isUndefined = function(obj) {


### PR DESCRIPTION
The method _.isDefined is the good brother of _.isUndefined. IMHO it results in a more understandable code if you directly see what a check really mean. So i think its better to use 

```
if (_.isDefined(foo)) { .... }
```

instead of

```
if( false === _.isUndefined(foo)){ ... }
```

Both means **is something defined?** Well, it looks maybe a little obviously, but  could improve readability of code.
