### PR TITLE
Using closure to compile underscore-min.js

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,20 @@
-desc "Use Uglify JS to compress Underscore.js"
+require 'rubygems'
+
+HEADER = /((^\s*\/\/.*\n)+)/
+
+desc "rebuild the underscore-min.js files for distribution"
 task :build do
-  sh "uglifyjs underscore.js -c -m -o underscore-min.js"
+  begin
+    require 'closure-compiler'
+  rescue LoadError
+    puts "closure-compiler not found.\nInstall it by running 'gem install closure-compiler'"
+    exit
+  end
+  source = File.read 'underscore.js'
+  header = source.match(HEADER)
+  File.open('underscore-min.js', 'w+') do |file|
+    file.write header[1].squeeze(' ') + Closure::Compiler.new.compress(source)
+  end
 end
 
 desc "Build the docco documentation"


### PR DESCRIPTION
It's basically a copy of backbonejs' Rakefile.
I saw that @jashkenas changed it on the last release but uglifyjs was always outputting the result, so, in order to make it as smooth as backbone's building process i copied it. Plus, there was a -m option in the uglifyjs command which i couldn't find its purpose.
This is more like a polite request than a change/fix. I tried to find previous versions where it happened or old tickets about the process but found nothing. Sorry if i missed something and went back in time with something already discussed and closed.

Cheers.
