### PR TITLE
fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1512,7 +1512,7 @@ _.escape('Curly, Larry &amp; Moe');
         with their unescaped counterparts.
       </p>
       <pre>
-_.escape('Curly, Larry &amp;amp; Moe');
+_.unescape('Curly, Larry &amp;amp; Moe');
 =&gt; "Curly, Larry &amp; Moe"</pre>
 
       <p id="result">


### PR DESCRIPTION
Sample code of `_.unescape` has a typo.

before

```
_.escape('Curly, Larry &amp; Moe');
=> "Curly, Larry & Moe"
```

after

```
_.unescape('Curly, Larry &amp; Moe');
=> "Curly, Larry & Moe"
```
