### PR TITLE
_.isEqual for DOM elements always returns true

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -358,6 +358,23 @@ $(document).ready(function() {
 
     // Objects from another frame.
     ok(_.isEqual({}, iObject));
+
+    // DOM elements
+    var aDom = document.createElement('div'),
+        bDom = document.createElement('span'),
+        $aDom = $(aDom),
+        $bDom = $(bDom),
+        $allDoms = $aDom.add($bDom);
+
+    ok(!_.isEqual(aDom, bDom), 'DOM Elements are not always equal.');
+
+    ok(!_.isEqual($aDom, $bDom), 'jQuery DOM Elements are not always equal.');
+
+    ok(_.isEqual(aDom, aDom), 'Same DOM Elements are equal.');
+
+    ok(_.isEqual($aDom, $aDom), 'Same jQuery DOM Elements are equal.');
+
+    ok(_.isEqual($allDoms, $allDoms), 'Same jQuery Elements are equal.');
   });
 
   test("isEmpty", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -828,6 +828,10 @@
     // Unwrap any wrapped objects.
     if (a instanceof _) a = a._wrapped;
     if (b instanceof _) b = b._wrapped;
+    // Compare DOM elements.
+    if (a && a.nodeName || b && b.nodeName) {
+      return a === b;
+    }
     // Compare `[[Class]]` names.
     var className = toString.call(a);
     if (className != toString.call(b)) return false;


### PR DESCRIPTION
DOM element comparisons always return `true` as the `result` variable is never changed to `false` (in `eq` method).

```
_.isEqual(document.createElement('div'), document.createElement('div')); // => true
```

Added a simple test on the `eq` method to check for the equality of two DOM elements.
