### PR TITLE
Add deep comparison support for _.where

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -251,13 +251,16 @@ $(document).ready(function() {
   });
 
   test('where', function() {
-    var list = [{a: 1, b: 2}, {a: 2, b: 2}, {a: 1, b: 3}, {a: 1, b: 4}];
+    var list = [{a: 1, b: 2}, {a: 2, b: 2}, {a: 1, b: 3}, {a: 1, b: 4}, {a: {b: 3}}];
     var result = _.where(list, {a: 1});
     equal(result.length, 3);
     equal(result[result.length - 1].b, 4);
     result = _.where(list, {b: 2});
     equal(result.length, 2);
     equal(result[0].a, 1);
+    result = _.where(list, {a: {b: 3}});
+    equal(result.length, 1);
+    deepEqual(result[0].a, {b: 3});
   });
 
   test('max', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -241,7 +241,7 @@
     if (_.isEmpty(attrs)) return [];
     return _.filter(obj, function(value) {
       for (var key in attrs) {
-        if (attrs[key] !== value[key]) return false;
+        if (!_.isEqual(attrs[key], value[key])) return false;
       }
       return true;
     });


### PR DESCRIPTION
Sometimes I have nested resources in my API responses and I often find myself trying to search with a whole embedded resource. For example, take a response similar to this:

``` javascript
[
  {"id": 1, "rel": {"id": 1}},
  {"id": 2, "rel": {"id": 2}},
  {"id": 3, "rel": {"id": 1}}
]
```

I would often do `_.where(response, {rel: {id: 1}})`. Maybe someone else has similar use-cases and would like to use it that way too.

This, however, has the drawback of slowing `_.where` down. jsPerf doesn't load for me at the moment, when it does I will post one showing the speed diff for searching just plain values.
