### PR TITLE
Add _.if(condition, value_if_true, value_if_false)

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1062,6 +1062,13 @@
     var value = object[property];
     return _.isFunction(value) ? value.call(object) : value;
   };
+  
+  // If Bool is truthy, return This, otherwise return That.
+  // Lets you do stuff like "_.if(foo, 4, 29) * 50".
+  _.if = function(Bool, This, That) {
+		if(Bool) {return This;}
+    else {return That;}
+  }
 
   // Add your own custom functions to the Underscore object.
   _.mixin = function(obj) {


### PR DESCRIPTION
Added _.if(condition, value_if_true, value_if_false). Useful for stuff like "_.if(x<0, -50, 20) \* 200"
Real-world use case: "tileToReturn.yFromTile = function(y) {return _.if(typeof y === 'number', y, tileToReturn.tileY) \* tileHeight;};"

Mixin version:
if(!_.if) {
    _.mixin({"if": function(Bool, This, That) {
        if(Bool) {return This;}
        else {return That;}
    }});
}

The test for this should look something like:
  test("if", function() {
    ok(_.if(true, 1, 2) != _.if(false,1,2), "True and false should return different args.");
  });

But I can't find anywhere where it looks like it should go.

I feel a good if() function is a proper tool in any functional programmer's belt. However, since I am _quite_ new to Javascript in general, I perhaps have just not figured out how to make the if(){}else{} format work inline. Any feedback?
