### PR TITLE
Add _.sample(array, number) functionality to underscore.js

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -424,7 +424,7 @@ $(document).ready(function() {
     all_sampled = _.sample(numbers, 20).sort();
     equal(all_sampled.join(','), numbers.join(','), 'also works when sampling more objects than are present');
     ok(_.contains(numbers, _.sample(numbers)), 'sampling a single element returns something from the array');
-    strictEqual(_.sample([]), null, 'sampling empty array with no number returns null');
+    strictEqual(_.sample([]), undefined, 'sampling empty array with no number returns undefined');
     notStrictEqual(_.sample([], 5), [], 'sampling empty array with a number returns an empty array');
     notStrictEqual(_.sample([1, 2, 3], 0), [], 'sampling an array with 0 picks returns an empty array');
     throws(function() { _.sample([], -1); }, 'cannot sample a negative number of picks');

--- a/underscore.js
+++ b/underscore.js
@@ -292,9 +292,8 @@
         throw new Error('sample cannot be called with a negative number of picks');
       }
       return _.shuffle(obj).slice(0, number);
-    } else {
-      return obj.length > 0 ? obj[_.random(obj.length - 1)] : null;
     }
+    return obj[_.random(obj.length - 1)];
   };
 
   // Shuffle an array.


### PR DESCRIPTION
Ruby's [Array#sample](http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-sample) method is extremely useful to me, at least as useful as shuffle.

I've replicated that functionality here in underscore and added a test. One thing I'm not sure if I should have done was make this work with javascript objects as well as arrays. Most of ujs' functions work across they keys/values of arbitrary objects, and I wasn't sure if it was right to do that here, or what exactly that should look like if I did.

Please advise if this is up to scratch, and thanks for the great library.
