### PR TITLE
Add _.pickOwn(object) that returns only own properties

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -90,6 +90,19 @@ $(document).ready(function() {
     ok(_.isEqual(_.omit(new Obj, 'b'), {a:1, c: 3}), 'include prototype props');
   });
 
+  test("pickOwn", function() {
+    var result;
+
+    var Obj = function(){};
+    Obj.prototype = {x: 1, y: 2};
+    var obj = new Obj();
+    obj.a = 3;
+    obj.z = 4;
+
+    result = _.pickOwn(obj);
+    ok(_.isEqual(result, {a:3, z:4}), 'returns only own properties');
+  });
+
   test("defaults", function() {
     var result;
     var options = {zero: 0, one: 1, empty: "", nan: NaN, string: "string"};

--- a/underscore.js
+++ b/underscore.js
@@ -795,6 +795,15 @@
     return copy;
   };
 
+  // Return a copy of the object only containing own properties.
+  _.pickOwn = function(obj) {
+    var copy = {};
+    for (var key in obj) {
+      if (_.has(obj, key)) copy[key] = obj[key];
+    }
+    return copy;
+  };
+
   // Fill in a given object with default properties.
   _.defaults = function(obj) {
     each(slice.call(arguments, 1), function(source) {


### PR DESCRIPTION
This pull request adds `_.pickOwn` method that returns a copy of the object that excludes properties from the prototype.

I believe there may be many use cases when this would be useful. Here's mine: I'm wrapping JSON objects with classes and treating those objects like smart data. For example a class `Person` may have `getFullName` method. When passing such objects to templates I prefer to strip those additional methods by getting copy of the object without any properties from its prototype.
