### PR TITLE
_.defaults only overrides `undefined` values

### DIFF
--- a/index.html
+++ b/index.html
@@ -1215,7 +1215,7 @@ _.omit({name : 'moe', age : 50, userid : 'moe1'}, 'userid');
       <p id="defaults">
         <b class="header">defaults</b><code>_.defaults(object, *defaults)</code>
         <br />
-        Fill in null and undefined properties in <b>object</b> with values from the
+        Fill in undefined properties in <b>object</b> with values from the
         <b>defaults</b> objects, and return the <b>object</b>. As soon as the
         property is filled, further defaults will have no effect.
       </p>

--- a/test/objects.js
+++ b/test/objects.js
@@ -92,12 +92,13 @@ $(document).ready(function() {
 
   test("defaults", function() {
     var result;
-    var options = {zero: 0, one: 1, empty: "", nan: NaN, string: "string"};
+    var options = {zero: 0, one: 1, empty: "", nan: NaN, nothing: null};
 
-    _.defaults(options, {zero: 1, one: 10, twenty: 20});
+    _.defaults(options, {zero: 1, one: 10, twenty: 20, nothing: 'str'});
     equal(options.zero, 0, 'value exists');
     equal(options.one, 1, 'value exists');
     equal(options.twenty, 20, 'default applied');
+    equal(options.nothing, null, "null isn't overriden");
 
     _.defaults(options, {empty: "full"}, {nan: "nan"}, {word: "word"}, {word: "dog"});
     equal(options.empty, "", 'value exists');

--- a/underscore.js
+++ b/underscore.js
@@ -800,7 +800,7 @@
     each(slice.call(arguments, 1), function(source) {
       if (source) {
         for (var prop in source) {
-          if (obj[prop] == null) obj[prop] = source[prop];
+          if (obj[prop] === void 0) obj[prop] = source[prop];
         }
       }
     });


### PR DESCRIPTION
As discussed in https://github.com/documentcloud/backbone/pull/2264, `null` is a valid JSON and database value and actually means "nothing" whereas `undefined` means "has yet to be set to a value, whatever it may be". I feel this patch results in the expected behavior.
