### PR TITLE
Remove native bind guard.

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -40,8 +40,7 @@
     nativeIndexOf      = ArrayProto.indexOf,
     nativeLastIndexOf  = ArrayProto.lastIndexOf,
     nativeIsArray      = Array.isArray,
-    nativeKeys         = Object.keys,
-    nativeBind         = FuncProto.bind;
+    nativeKeys         = Object.keys;
 
   // Create a safe reference to the Underscore object for use below.
   var _ = function(obj) {
@@ -578,7 +577,6 @@
   // optionally). Delegates to **ECMAScript 5**'s native `Function.bind` if
   // available.
   _.bind = function(func, context) {
-    if (func.bind === nativeBind && nativeBind) return nativeBind.apply(func, slice.call(arguments, 1));
     var args = slice.call(arguments, 2);
     return function() {
       return func.apply(context, args.concat(slice.call(arguments)));


### PR DESCRIPTION
Previous discussion on this topic is in ce3d1aec306999aa94926a42cad1daf7eb87a36f.

If we're going to drop support for certain features of `_.bind` in browsers that do not support `Function#bind`, I think we should do so across the board.  The features in question (e.g. binding constructor functions) are not nearly as important as supporting or not supporting them consistently.
