### PR TITLE
Make groupBy accept array indices as the iterator

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -361,6 +361,14 @@ $(document).ready(function() {
     var grouped = _.groupBy(array);
     equal(grouped['1'].length, 2);
     equal(grouped['3'].length, 1);
+
+    var matrix = [
+      [1,2],
+      [1,3],
+      [2,3]
+    ];
+    deepEqual(_.groupBy(matrix, 0), {1: [[1,2], [1,3]], 2: [[2,3]]})
+    deepEqual(_.groupBy(matrix, 1), {2: [[1,2]], 3: [[1,3], [2,3]]})
   });
 
   test('countBy', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -324,7 +324,8 @@
   // An internal function used for aggregate "group by" operations.
   var group = function(obj, value, context, behavior) {
     var result = {};
-    var iterator = lookupIterator(value || _.identity);
+    // If the iterator is null or undefined it defaults to _.identity.
+    var iterator = lookupIterator(value == null ? _.identity : value);
     each(obj, function(value, index) {
       var key = iterator.call(context, value, index, obj);
       behavior(result, key, value);
@@ -334,6 +335,7 @@
 
   // Groups the object's values by a criterion. Pass either a string attribute
   // to group by, or a function that returns the criterion.
+  // You may also pass in a integer for the array index to group by.
   _.groupBy = function(obj, value, context) {
     return group(obj, value, context, function(result, key, value) {
       (_.has(result, key) ? result[key] : (result[key] = [])).push(value);


### PR DESCRIPTION
## Background

We're using a data format that looks like this:

```
[['type1', 1234], ['type2', 4321], ...]
```

I want to group that data by the first element in each sub array.
## Why it didn't work

Because the iterator defaulted to `_.identity` if the given iterator was
falsy it worked fine with integers != 0 so for example `_.groupBy(data, 1)`
worked fine but `_.groupBy(data, 0)` didn't.
## The fix

I simply changed so that the iterator is only set to the default value
if the given one is `null` or `undefined`.
## Tests

I added two simple tests that group a multi dimensional array using 0
and 1 as the iterator.
## Backwards compatibility

This, of course, breaks backward compatibility but I doubt that anyone
relied on this behaviour.
## Discussion

I think this solution is better than having to cast the integer to a
string seeing as that is "wrong" (array indices are integers, not
strings), please let me know if you disagree.
