### PR TITLE
_.defer and process.nextTick under node.js

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -46,10 +46,10 @@
   // Create a reference to either process.nextTick, setImmediate or setTimeout,
   // to defer function execution in the most efficient way possible.
   var nativeDefer;
-  if (typeof process !== 'undefined' && typeof process.nextTick === 'function')
-    nativeDefer = process.nextTick;
-  else if (typeof setImmediate !== 'undefined')
+  if (typeof setImmediate !== 'undefined')
     nativeDefer = setImmediate;
+  else if (typeof process !== 'undefined' && typeof process.nextTick === 'function')
+    nativeDefer = process.nextTick;
   else
     nativeDefer = function (func) { return setTimeout(func, 0) };
   


### PR DESCRIPTION
Really simple improvement to use `process.nextTick` instead of `setTimeout` under Node.js. Quick benchmarks show that the incurred overhead of the current implementation (using `setTimeout(fn, 0)`) varies between 600 µs to 1.2 ms. With the current improvement, it varies between 200 µs to 450 µs.

After a few years in production, that could potentially save us 1 or 2 seconds! :)
