### PR TITLE
Adding _.toInt alternative to parseInt

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -263,4 +263,8 @@ $(document).ready(function() {
     strictEqual(template(), '<<\nx\n>>');
   });
 
+  test('toInt works as expected', function() {
+    equal(_.toInt('4'), 4);
+    equal(_.toInt('08'), 8);
+  });
 });

--- a/underscore.js
+++ b/underscore.js
@@ -1016,6 +1016,11 @@
     return this;
   };
 
+  // Simple wrapper around parseInt that defaults to base 10.
+  _.toInt = function(obj, radix) {
+    return parseInt(obj, radix || 10);
+  };
+
   // Keep the identity function around for default iterators.
   _.identity = function(value) {
     return value;


### PR DESCRIPTION
Now you can use `_.toInt(str)` instead of `parseInt(str, 10)` and not be bitten when you inevitably forget the second argument to parseInt.
