### PR TITLE
Adding Typecast.js to Links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1781,7 +1781,7 @@ _([1, 2, 3]).value();
 
       <p>
         <a href="http://typecastjs.org">Typecast.js</a>,
-        an Underscore extension library that adds alot of mixins and additional helper functions.
+        an Underscore extension library that adds 100s of mixins and additional helper functions.
       </p>
 
       <p>


### PR DESCRIPTION
Hi!

I love underscore and have been lurking on the issues list here for several months. I've gained a good understanding of the development goals of underscore.js.  

They are completely realistic and valuable, but I started to wonder what a library would be like that did not have the common use policy, always used chaining, and tried to sort out the helper functions by input and output types.

Out of that I created Typecast.js and have began working with a few developers who are dedicated to continued expansion of Typecast library. 

I would very much like to become more involved in the discussion about underscore here on Github and how Typecast differs & compliments underscore. So this is my first attempt to reach out to yawl.

I added Typecast to the links section of index.html because it is not a mixin. Typecast is very similar in scope, but is dedicated to maintaining a larger library of helper functions.  It also rearranges the _.is[Type] syntax and always uses chaining, making it an interesting and powerful compliment to underscore.

In appreciation, BishopZ
