### PR TITLE
Fix _.bindAll documentation to note that methodNames are required

### DIFF
--- a/index.html
+++ b/index.html
@@ -956,8 +956,7 @@ func();
         <b>methodNames</b>, to be run in the context of that object whenever they
         are invoked. Very handy for binding functions that are going to be used
         as event handlers, which would otherwise be invoked with a fairly useless
-        <i>this</i>. If no <b>methodNames</b> are provided, all of the object's
-        function properties will be bound to it.
+        <i>this</i>. <b>methodNames</b> are required.
       </p>
       <pre>
 var buttonView = {


### PR DESCRIPTION
Underscore currently raises an error in this case
