### PR TITLE
Add callEach and callMap

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -460,4 +460,38 @@ $(document).ready(function() {
     equal(_.size(null), 0, 'handles nulls');
   });
 
+  test('callEach', function() {
+    var count = 0;
+
+    function MyClass() {
+      this.someMethod = function() {
+        ok(this == items[count], "The method is called with the correct context");
+        equal(arguments.length, 0);
+        ++count;
+      }
+    }
+
+    var items = [new MyClass(), new MyClass(), {}];
+    var result = _.callEach(items, 'someMethod');
+    equal(count, 2);
+    equal(result, undefined);
+  });
+
+  test('callMap', function() {
+    var count = 0;
+
+    function MyClass() {
+      this.someMethod = function() {
+        ok(this == items[count], "The method is called with the correct context");
+        equal(arguments.length, 0);
+        ++count;
+        return count;
+      }
+    }
+
+    var items = [new MyClass(), new MyClass(), {}];
+    var result = _.callMap(items, 'someMethod');
+    equal(count, 2);
+    equal(result.join(', '), "1, 2, ");
+  });
 });

--- a/underscore.js
+++ b/underscore.js
@@ -89,6 +89,14 @@
     }
   };
 
+  // Iterates over each item in `obj` and calls the method named `property` if
+  // it exists and is a function.
+  _.callEach = function(obj, property) {
+    _.each(obj, function(o) {
+      if (o != null && _.isFunction(o[property])) o[property]();
+    })
+  }
+
   // Return the results of applying the iterator to each element.
   // Delegates to **ECMAScript 5**'s native `map` if available.
   _.map = _.collect = function(obj, iterator, context) {
@@ -100,6 +108,16 @@
     });
     return results;
   };
+
+  // Iterates over each item in `obj` and calls the method named `property` if
+  // it exists and is a function. A array containing the result of each call is
+  // returned. For items that the property doesn't exist or isn't a function
+  // `undefined` is returned.
+  _.callMap = function(obj, property) {
+    return _.map(obj, function(o) {
+      if (o != null && _.isFunction(o[property])) return o[property]();
+    })
+  }
 
   var reduceError = 'Reduce of empty array with no initial value';
 


### PR DESCRIPTION
They will iterate over a collection using _.each and _.map respectivly
calling a function on each item.
## Use case

There are a lot of times I want to invoke a function on each object in a collection, below are some use cases in code.

``` javascript
function Missile() {}
Missile.prototype.fire = function() {
  console.log('The missile has been fired');
}

var missiles = [new Missile(), new Missile()];
// Prints 'The missile has been fire' twice
_.callEach(missiles, 'fire');
```

``` javascript
function Person(name) {
  this.name = name;
}
Missile.prototype.greeting = function() {
  return 'Hello, ' + this.name;
}

var people = [new Person('Jane'), new Missile('John')];
_.mapEach(people, 'greeting') // ['Hello, Jane', 'Hello, John']
```
## Naming

I tried finding a name similar to `pluck` which I feel this is a close to, but I came up short.
