### PR TITLE
Add Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+  "name"          : "documentcloud/underscore",
+  "description"   : "JavaScript's functional programming helper library.",
+  "homepage"      : "http://underscorejs.org",
+  "keywords"      : ["util", "functional", "server", "client", "browser", "component"],
+  "license"       : "MIT",
+  "type"          : "component",
+  "authors"       : [
+    {
+      "name" : "Jeremy Ashkenas",
+      "email" : "jeremy@documentcloud.org"
+    }
+  ],
+  "require": {
+    "robloach/component-installer": "*"
+  }
+}


### PR DESCRIPTION
[Composer](http://getcomposer.org) is a package manager for PHP. This allows Underscore to be downloaded by putting `"documentcloud/underscore"` in your own `composer.json` file.

``` json
{
  "require": {
    "documentcloud/underscore": "1.4.*"
  }
}
```
