### PR TITLE
Make contains/include accept multiple values

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -214,6 +214,8 @@ $(document).ready(function() {
     ok(!_.include([1,3,9], 2), 'two is not in the array');
     ok(_.contains({moe:1, larry:3, curly:9}, 3) === true, '_.include on objects checks their values');
     ok(_([1,2,3]).include(2), 'OO-style include');
+    ok(_.include([1,2,3], 2, 3), 'two and three are in the array');
+    ok(!_.include([1,2,3], 3, 4), 'three and four are not in the array');
   });
 
   test('invoke', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -215,6 +215,8 @@
   // Aliased as `include`.
   _.contains = _.include = function(obj, target) {
     if (obj == null) return false;
+    if (arguments.length > 2)
+      return _.every(slice.call(arguments, 1), function(value) { return _.contains(obj, value); });
     if (nativeIndexOf && obj.indexOf === nativeIndexOf) return obj.indexOf(target) != -1;
     return any(obj, function(value) {
       return value === target;


### PR DESCRIPTION
Extended _.contains() so it accepts multiple values and returns true if all values are contained in the collection:

``` javascript
_.include([1,2,3], 2, 3) // true
_.include([1,2,3], 3, 4) // false
```
