### PR TITLE
Always pop pushed elements from the stack

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -898,15 +898,17 @@
       var aCtor = a.constructor, bCtor = b.constructor;
       if (aCtor !== bCtor && !(_.isFunction(aCtor) && (aCtor instanceof aCtor) &&
                                _.isFunction(bCtor) && (bCtor instanceof bCtor))) {
-        return false;
+        result = false;
       }
       // Deep compare objects.
-      for (var key in a) {
-        if (_.has(a, key)) {
-          // Count the expected number of properties.
-          size++;
-          // Deep compare each member.
-          if (!(result = _.has(b, key) && eq(a[key], b[key], aStack, bStack))) break;
+      if (result) {
+        for (var key in a) {
+          if (_.has(a, key)) {
+            // Count the expected number of properties.
+            size++;
+            // Deep compare each member.
+            if (!(result = _.has(b, key) && eq(a[key], b[key], aStack, bStack))) break;
+          }
         }
       }
       // Ensure that both objects contain the same number of properties.


### PR DESCRIPTION
Previously the constructor checks returned early which would prevent the most recently pushed elements from being popped from the stacks.

Now result is set to false so the the pop lines are still reached after the constructor checks are done.
