### PR TITLE
Fix memoize example to use memoized function within the scope

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -78,9 +78,9 @@ $(document).ready(function() {
     var fib = function(n) {
       return n < 2 ? n : fib(n - 1) + fib(n - 2);
     };
-    var fastFib = _.memoize(fib);
     equal(fib(10), 55, 'a memoized version of fibonacci produces identical results');
-    equal(fastFib(10), 55, 'a memoized version of fibonacci produces identical results');
+    fib = _.memoize(fib); // Redefine `fib` for memoization
+    equal(fib(10), 55, 'a memoized version of fibonacci produces identical results');
 
     var o = function(str) {
       return str;


### PR DESCRIPTION
Going through the test documentation today I noticed the memoized fibonacci function would only be memoized on the first call and on recursive calls it would use the non-memoized function.
