### PR TITLE
Fix _.isFunction (IE < 9 and host-functions)

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -479,6 +479,10 @@ $(document).ready(function() {
     ok(_.isFunction(_.isFunction), 'but functions are');
     ok(_.isFunction(iFunction), 'even from another frame');
     ok(_.isFunction(function(){}), 'even anonymous ones');
+    if (window && window.document) {
+      ok(_.isFunction(window.alert), "host-functions are functions (test for IE < 9)");
+      ok(_.isFunction(document.getElementById), "DOM-functions are functions (test for IE < 9)");
+    }
   });
 
   test("isDate", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -975,6 +975,23 @@
     };
   }
 
+  // `isFunction` for IE < 9.
+  // Host-functions (alert, document.getElementById) are always [object Object].
+  if ((typeof root.alert === "object") && (!root.alert.toString)) {
+    _.isFunction = function(obj) {
+        if (typeof obj === "function") {
+            return true;
+        }
+        if (!obj) {
+            return false;
+        }
+        if (typeof obj.toString === "function") {
+            return false;
+        }
+        return ("" + obj).indexOf("[native code]") > 0;
+    };
+  }
+
   // Is a given object a finite number?
   _.isFinite = function(obj) {
     return isFinite(obj) && !isNaN(parseFloat(obj));


### PR DESCRIPTION
In Internet Explorer (< version 9) host-functions is always "object":

typeof alert === "object"

Object.prototype.toString.call(document.getElementById) === "[object Object]".

_.isFunction(alert); // false in IE7,8
_.isFunction(document.getElementById); // false in IE7,8
