### PR TITLE
Added _.unzip as inverse to _.pairs and _.zip

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -129,6 +129,15 @@ $(document).ready(function() {
     equal(String(stooges), 'moe,30,true,larry,40,,curly,50,', 'zipped together arrays of different lengths');
   });
 
+  test('unzip', function() {
+    var stoogesZipped = [['moe',30],['larry',40],['curly',50]];
+    var stoogesUnzipped = _.unzip(stoogesZipped);
+    equal(String(stoogesUnzipped), 'moe,larry,curly,30,40,50', 'unzipped pairs');
+
+    var emptyUnzipped = _.unzip([]);
+    equal(String(emptyUnzipped), ',', 'unzipped empty pairs');
+  });
+
   test('object', function() {
     var result = _.object(['moe', 'larry', 'curly'], [30, 40, 50]);
     var shouldBe = {moe: 30, larry: 40, curly: 50};

--- a/underscore.js
+++ b/underscore.js
@@ -499,6 +499,22 @@
     return results;
   };
 
+  // Internal helper function for `_.unzip`.  Builds arrays out of the 
+  // first and second elements.
+  function constructPair(pair, rests) {
+    return [[_.first(pair)].concat(_.first(rests)),
+            [_.first(_.rest(pair))].concat(_.first(_.rest(rests)))];
+  }
+
+  // The inverse operation to `_.zip`.  That is, takes an array of pairs and 
+  // returns an array of the paired elements split into two left and right
+  // element arrays. For example, `_.unzip` given `[['a',1],['b',2],['c',3]]` 
+  // returns the array [['a','b','c'],[1,2,3]].
+  _.unzip = function(pairs) {
+    if (_.isEmpty(pairs)) return [[],[]];
+    return constructPair(_.first(pairs), _.unzip(_.rest(pairs)));
+  };
+
   // Converts lists into objects. Pass either a single array of `[key, value]`
   // pairs, or two parallel arrays of the same length -- one of keys, and one of
   // the corresponding values.


### PR DESCRIPTION
Very often I've found the need to take an object (often nested) and convert it to an array of pairs via `_.pairs` to perform some sort of tree-walking or sequential operation.  Likewise, I've also found many cases up using `_.zip` to create an array of pairs for processing and eventual object creation via `_.object`.  To support these types of operations I've built a large tool set for processing pairs, sequences and alists (arrays of pairs).  However, there is a link missing in the beautiful symmetry created by `_.zip`, `_.pairs` and `_.object` and that's `_.unzip`.  There is a ticket for something called "unzip" at #41, but it operates differently than I propose.  That is, `_.unzip` is meant to allow one to come full circle from a pair of arrays, to an array of pairs, to an object, back to an array of pairs and finally back to a pair of arrays.  It's action is as follows:

```
var names = ['moe', 'larry', 'curly'], ages = [30, 40, 50];
var zStooges = _.zip (names, ages);              // pairs of stooge data                                              

_.unzip (                                        // put back together                                                 
  _.pairs (                                      // back to pairs                                                     
    _.invert (                                   // swap keys/values                                                  
      _.object (                                 // objectify                                                         
        _.map (zStooges, function (pair) {       // convert the head of the pair to upcase                            
  return [pair [0].toUpperCase (), pair [1]];
})))));
```

Now obviously you'd write this code more beautifully than this, but the example is meant to show that a data structure comes full-circle[^1].  I've found `unzip` highly useful and think it would complete a beautiful relationship between highly useful functions.

_Apologies for the duplicate of #1015. I've been working in Jira for so long that I wasn't prepared for a ticket system that worked well._

[^1]: It almost comes full circle but the call to `_.pairs` for some reason converts the `Object` number keys to strings. :-(  That's a different matter outside the scope of this ticket.
