### PR TITLE
Add `immediate` flag to `throttle()`

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -183,6 +183,20 @@ $(document).ready(function() {
     }, 96);
   });
 
+  asyncTest("throttle does not trigger leading call when immediate is set to false", 2, function() {
+    var counter = 0;
+    var incr = function(){ counter++; };
+    var throttledIncr = _.throttle(incr, 60, false);
+
+    throttledIncr(); throttledIncr();
+    ok(counter == 0);
+
+    _.delay(function() {
+      ok(counter == 1);
+      start();
+    }, 96);
+  });
+
   asyncTest("debounce", 1, function() {
     var counter = 0;
     var incr = function(){ counter++; };

--- a/underscore.js
+++ b/underscore.js
@@ -639,7 +639,7 @@
 
   // Returns a function, that, when invoked, will only be triggered at most once
   // during a given window of time.
-  _.throttle = function(func, wait) {
+  _.throttle = function(func, wait, immediate) {
     var context, args, timeout, result;
     var previous = 0;
     var later = function() {
@@ -649,6 +649,7 @@
     };
     return function() {
       var now = new Date;
+      if (!previous && immediate === false) previous = now;
       var remaining = wait - (now - previous);
       context = this;
       args = arguments;


### PR DESCRIPTION
As discussed in the issue tagged below, you could change the which edge of the delay your function is called on with a `debounce()` but not with a `throttle()`. This pull request addresses the issue by creating a simple third argument like the one in `debounce()` that if explicitly set to `false` will make sure your function is not called at the leading edge of the delay.

[Addresses #926]
