### PR TITLE
Make groupBy preserve keys when grouping objects.

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -369,6 +369,11 @@ $(document).ready(function() {
     ];
     deepEqual(_.groupBy(matrix, 0), {1: [[1,2], [1,3]], 2: [[2,3]]})
     deepEqual(_.groupBy(matrix, 1), {2: [[1,2]], 3: [[1,3], [2,3]]})
+
+    var obj = {one: 1, two: 1, three: 2, four: 2, five: 3, six: 4};
+    var grouped = _.groupBy(obj, function(num) { return num % 2; }, obj);
+    deepEqual(grouped[0], {three: 2, four: 2, six: 4});
+    deepEqual(grouped[1], {one: 1, two: 1, five: 3});
   });
 
   test('countBy', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -327,7 +327,7 @@
     var iterator = lookupIterator(value == null ? _.identity : value);
     each(obj, function(value, index) {
       var key = iterator.call(context, value, index, obj);
-      behavior(result, key, value);
+      behavior(result, key, value, index);
     });
     return result;
   };
@@ -335,8 +335,11 @@
   // Groups the object's values by a criterion. Pass either a string attribute
   // to group by, or a function that returns the criterion.
   _.groupBy = function(obj, value, context) {
-    return group(obj, value, context, function(result, key, value) {
-      (_.has(result, key) ? result[key] : (result[key] = [])).push(value);
+    return group(obj, value, context, function(result, key, value, index) {
+      if (obj instanceof Array)
+        (_.has(result, key) ? result[key] : (result[key] = [])).push(value);
+      else
+        (_.has(result, key) ? result[key] : (result[key] = {}))[index] = value;
     });
   };
 


### PR DESCRIPTION
I've had this scenario when grouping objects such as

``` javascript
    {
      1363402200: { "values": "1" },
      1363402201: { "values": "5" },
      1363402202: { "values": "17" }
    }
```

and using groupBy doesn't preserve the keys as this becomes

``` javascript
_.groupBy(obj, function(v, k) { return k % 2; })

  {
    "0": [
      { "values": "1" },
      { "values": "17" }
    ],
    "1": [
      { "values": "5" }
    ]
  }
```

And the one I prefer is this which preserves the keys as I need to do additional operations on it.

``` javascript
  {
    "0": {
      "1363402200": { "values": "1" },
      "1363402202": { "values": "17" }
    },
    "1": {
      "1363402201": { "values": "5" }
    }
  }
```

I'm not sure if this is a common use case as I've made "preserve keys" default instead of optional.
