### PR TITLE
adds a test using multiplication to reduce

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -76,6 +76,9 @@ $(document).ready(function() {
     var sum = _.reduce([1, 2, 3], function(sum, num){ return sum + num; });
     equal(sum, 6, 'default initial value');
 
+    var prod = _.reduce([1, 2, 3, 4], function(prod, num){ return prod * num; });
+    equal(prod, 24, 'can reduce via multiplication');
+
     var ifnull;
     try {
       _.reduce(null, function(){});


### PR DESCRIPTION
The current tests all use the same operation-- addition.  This update adds a test using multiplication to prevent errors such as the following from passing:

``` javascript
var reduce = function(list, iterator, memo) {
    result = memo || 0;
    each(list, function(x) {
      result = iterator(result,x);
    });
    return result;
  };
```
