### PR TITLE
Add underscore license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,6 @@
   },
   "scripts": {
     "test": "phantomjs test/vendor/runner.js test/index.html?noglobals=true"
-  }
+  },
+  "license"       : "MIT"
 }


### PR DESCRIPTION
NPM spec allows for the underscore license in the package.json. For completeness, I added it in :)

https://npmjs.org/doc/json.html
