### PR TITLE
use isArray or +length？

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -374,7 +374,7 @@
   // Return the number of elements in an object.
   _.size = function(obj) {
     if (obj == null) return 0;
-    return (obj.length === +obj.length) ? obj.length : _.keys(obj).length;
+    return _.isArray(obj) ? obj.length : _.keys(obj).length;
   };
 
   // Array Functions


### PR DESCRIPTION
When I read the source file, I found that when i write code as follow, it will not correct.

``` js
    var obj = {
        'heght': 2,
        'width': 3,
        'length': 4
    };
    var result = _.size(obj);
```

the size() function is:

``` js
  // Return the number of elements in an object.
  _.size = function(obj) {
    if (obj == null) return 0;
    return (obj.length === +obj.length) ? obj.length : _.keys(obj).length;
  };
```

so, i think maybe this is a better way, isn't it?

``` js
  // Return the number of elements in an object.
  _.size = function(obj) {
    if (obj == null) return 0;
    return _.isArray(obj) ? obj.length : _.keys(obj).length;
  };
```
