### PR TITLE
Adding flip function to flip the order of a functions arguments

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -282,4 +282,10 @@ $(document).ready(function() {
     equal(testAfter(0, 0), 1, "after(0) should fire immediately");
   });
 
+  test("flip", function() {
+    var func = function(x, y) { return [x, y]; };
+    var flipped = _.flip(func);
+
+    deepEqual(flipped(1, 2), [2, 1], 'can flip a functions argument order');
+  });
 });

--- a/underscore.js
+++ b/underscore.js
@@ -732,6 +732,13 @@
     };
   };
 
+  // Returns a function with the argument order of the first function flipped.
+  _.flip = function(func) {
+    return function() {
+      return func.apply(this, slice.call(arguments, 0).reverse());
+    };
+  };
+
   // Object Functions
   // ----------------
 


### PR DESCRIPTION
I find this a useful function to have when I want to partially apply functions, especially when mapping across an array.

Is it something that might fit in with core underscore?
