### PR TITLE
Added return value info to _.times docs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1486,12 +1486,14 @@ moe === _.identity(moe);
         <b class="header">times</b><code>_.times(n, iterator, [context])</code>
         <br />
         Invokes the given iterator function <b>n</b> times. Each invocation of
-        <b>iterator</b> is called with an <tt>index</tt> argument.
+        <b>iterator</b> is called with an <tt>index</tt> argument. Produces an
+        array of the returned values.
         <br />
         <i>Note: this example uses the <a href="#chaining">chaining syntax</a></i>.
       </p>
       <pre>
-_(3).times(function(n){ genie.grantWishNumber(n); });</pre>
+_(4).times(function(n){ return Math.pow(n, 2) });
+=&gt; [0, 1, 4, 9]</pre>
 
       <p id="random">
         <b class="header">random</b><code>_.random(min, max)</code>

--- a/test/utility.js
+++ b/test/utility.js
@@ -49,12 +49,14 @@ $(document).ready(function() {
     var vals = [];
     _.times(3, function (i) { vals.push(i); });
     ok(_.isEqual(vals, [0,1,2]), "is 0 indexed");
+
+    ok(_.isEqual(_.times(4, function(n){ return Math.pow(n, 2) }), [0, 1, 4, 9]), "collects return values");
     //
     vals = [];
     _(3).times(function(i) { vals.push(i); });
     ok(_.isEqual(vals, [0,1,2]), "works as a wrapper");
     // collects return values
-    ok(_.isEqual([0, 1, 2], _.times(3, function(i) { return i; })), "collects return values");
+    ok(_.isEqual([0, 1, 2], _.times(3, _.identity)), "can be used to mimic _.range()");
   });
 
   test("mixin", function() {


### PR DESCRIPTION
Previously there was no mention on the home page that **_.times** returns an array of values.

This is important, because **_.times** is costly when you have a large **n** and you are not going to use the returned value.

I also updated the tests for **_.times** to demonstrate a useful recipe where you pass **_.identity** as an argument into **_.times**. This recipe mimics **_.range**, but it is much more adaptable.
