### PR TITLE
Added return value info to _.times docs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1486,7 +1486,8 @@ moe === _.identity(moe);
         <b class="header">times</b><code>_.times(n, iterator, [context])</code>
         <br />
         Invokes the given iterator function <b>n</b> times. Each invocation of
-        <b>iterator</b> is called with an <tt>index</tt> argument.
+        <b>iterator</b> is called with an <tt>index</tt> argument. Produces an
+        array of the returned values.
         <br />
         <i>Note: this example uses the <a href="#chaining">chaining syntax</a></i>.
       </p>


### PR DESCRIPTION
The documentation now mentions the value returned by **_.times**

I removed the changed example and the test case from my previous [pull request](https://github.com/documentcloud/underscore/pull/1043).
