### PR TITLE
Shortened version of unzip that doesn't create sparse arrays

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -507,7 +507,7 @@
   // [['a','b','c'],[1,2,3]].
   _.unzip = function(tuples) {
       var maxLen = _.max(_.pluck(tuples, "length"))
-      return _.map(_.range(maxLen), _.partial(_.pluck, tuples));
+      return _.times(maxLen, _.partial(_.pluck, tuples));
   };
 
   // Converts lists into objects. Pass either a single array of `[key, value]`


### PR DESCRIPTION
@jdalton informed me that some browsers have problems with sparse arrays[1](https://github.com/documentcloud/underscore/commit/c3d695313534ad560082380ccd084a199edcccfe#commitcomment-2925557) so I re-wrote `_.unzip` to not create them. In the process I managed to reduce the amount of code and I'm quite pleased with the result :)
