### PR TITLE
_.uniq made O(N) for every case.

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -453,10 +453,13 @@
     }
     var initial = iterator ? _.map(array, iterator, context) : array;
     var results = [];
-    var seen = [];
-    each(initial, function(value, index) {
-      if (isSorted ? (!index || seen[seen.length - 1] !== value) : !_.contains(seen, value)) {
+    var seen = isSorted ? [] : {};
+    _.each(initial, function(value, index) {
+      if (isSorted && (!index || seen[seen.length - 1] !== value)) {
         seen.push(value);
+        results.push(array[index]);
+      } else if (!isSorted && !seen[value]) {
+        seen[value] = true;
         results.push(array[index]);
       }
     });


### PR DESCRIPTION
_.uniq uses an O(N^2) algorithm when the passed array is unsorted. This PR is an optimization to make that algorithm O(N) instead. So basically, there's no difference anymore if the array is sorted or unsorted.

I use a dictionary (object) lookup (O(1)) to check if an element is already inside the results array as opposed to another array and contains. So the memory requirements should be around the same. (One boolean object per entry in the dictionary though).

I ran tests in Chrome, Firefox and Safari and this implementation is roughly 2 orders of magnitude faster than the regular one.

http://jsperf.com/uniq-performance

Also, this works fine for undefined or null entries in the array.

``` javascript
>_.myuniq([ null, null, undefined, undefined ]) => [null, undefined]
> a = {}
> a[undefined] = 1
> a[null] = 1
> a => Object {undefined: 1, null: 1}
> a[null] === 1  > true
```
