### PR TITLE
New error function to quickly extend new JS errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,6 +307,7 @@
       <li>- <a href="#unescape">unescape</a></li>
       <li>- <a href="#result">result</a></li>
       <li>- <a href="#template">template</a></li>
+      <li>- <a href="#error">error</a></li>
     </ul>
 
     <a class="toc_title" href="#chaining">
@@ -1651,6 +1652,40 @@ _.template("Using 'with': <%= data.answer %>", {answer: 'no'}, {variable: 'data'
   JST.project = <%= _.template(jstText).source %>;
 &lt;/script&gt;</pre>
 
+      <p id="error">
+        <b class="header">error</b><code>_.error(errorMessage, [AbstractError])</code>
+        <br />
+        Helps create new JavaScript errors. If an abstract error is not provided, <b>error</b> will extend the generic JavaScript <tt>Error</tt>. 
+      </p>
+
+      <pre>
+var FOO_ERROR = _.error('There was an error with FOO');
+
+var e = new FOO_ERROR();
+
+e instanceof Error
+=> true
+
+e instanceof FOO_ERROR
+=> true
+
+e.message
+=> 'There was an error with FOO'</pre>
+
+      <p>To build a more specific error, provide an <b>AbstractError</b> to extend:</p>
+
+      <pre>
+var FOO_AUTH_ERROR = _.error('FOO could not authenticate', FOO_ERROR);
+
+var e = new FOO_AUTH_ERROR();
+
+e instanceof FOO_ERROR
+=> true
+
+e.message
+=> 'FOO could not authenticate'
+
+throw e;</pre>
 
       <h2 id="chaining">Chaining</h2>
 

--- a/test/utility.js
+++ b/test/utility.js
@@ -267,4 +267,20 @@ $(document).ready(function() {
     strictEqual(template(), '<<\nx\n>>');
   });
 
+  test('error', 6, function(){
+    var errorMsg = 'oh, no!';
+    var MyError = _.error(errorMsg);
+    var error = new MyError();
+    ok(error instanceof Error);
+    ok(error instanceof MyError)
+    ok(error.message === errorMsg);
+
+    var specificErrorMsg = 'this error is even more useful';
+    var SpecificError = _.error(specificErrorMsg, MyError);
+    error = new SpecificError();
+    ok(error instanceof MyError);
+    ok(error instanceof SpecificError);
+    ok(error.message === specificErrorMsg);
+  })
+
 });

--- a/underscore.js
+++ b/underscore.js
@@ -1193,6 +1193,16 @@
     return template;
   };
 
+  // Automate the creation of errors
+  _.error = function(msg, AbstractError){
+    AbstractError || (AbstractError = Error);
+    var E = function(msg){
+      if(msg) this.message = msg;
+    }
+    E.prototype = new AbstractError(msg);
+    return E;
+  }
+
   // Add a "chain" function, which will delegate to the wrapper.
   _.chain = function(obj) {
     return _(obj).chain();


### PR DESCRIPTION
This utility method has been quite handy for me when defining custom errors. Hopefully the underscore community agrees.

Sorry about jumping the gun on writing the docs. I didn't notice the contribution guideline until now.

Thanks @jashkenas for all your hard work on underscore and backbone.
