### PR TITLE
Add index.html and underscore-min.js to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,5 @@ test/
 Rakefile
 docs/
 raw/
+index.html
+underscore-min.js


### PR DESCRIPTION
Since Underscore is a dependency of so many Node.js modules, it would help a lot to reduce the size of it.
