### PR TITLE
Add `_.softExtend` function

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -798,6 +798,20 @@
     return obj;
   };
 
+  // Extend a given object with properties in passed-in object(s), without overwriting existing properties
+  _.softExtend = function(obj){
+    each(slice.call(arguments, 1), function(source) {
+      if (source) {
+        for (var prop in source) {
+          if(! _.has(obj, prop)){
+            obj[prop] = source[prop];            
+          }
+        }
+      }
+    });
+    return obj;
+  };
+  
   // Return a copy of the object only containing the whitelisted properties.
   _.pick = function(obj) {
     var copy = {};


### PR DESCRIPTION
Same as extend, but does not overwrite properties in the target object if they already exist.
