### PR TITLE
bug in once

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -239,6 +239,13 @@ $(document).ready(function() {
     increment();
     increment();
     equal(num, 1);
+
+    var CustomError = function(message) { this.message = message; };
+    var dofail = _.once(function(){ throw new CustomError("stop"); });
+    var r1, r2;
+    try { dofail(); ok(false, "it should not happen"); } catch(e) { r1 = e; }
+    try { dofail(); ok(false, "it should not happen"); } catch(e) { r2 = e; }
+    strictEqual(r1, r2);
   });
 
   test("wrap", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -699,13 +699,21 @@
   // Returns a function that will be executed at most one time, no matter how
   // often you call it. Useful for lazy initialization.
   _.once = function(func) {
-    var ran = false, memo;
+    var state, memo;
     return function() {
-      if (ran) return memo;
-      ran = true;
-      memo = func.apply(this, arguments);
-      func = null;
-      return memo;
+      if (state===undefined) {
+        try {
+          state = true;
+          memo = func.apply(this, arguments);
+        }
+        catch(e) {
+          state = false;
+          memo = e;
+        }
+        func = null;
+      }
+      if (state) return memo;
+      throw memo;
     };
   };
 


### PR DESCRIPTION
If so there is still a bug! 

Don't set ran to true before calling the wrapped method but just after. But this way the wrapped function will be called more than once.

It claims more attention that the one you had. You closed the pull request to fast. Sorry to insist. Let comment on.
