### PR TITLE
Adding _.retry method

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -290,4 +290,26 @@ $(document).ready(function() {
     equal(testAfter(0, 0), 1, "after(0) should fire immediately");
   });
 
+  test("retry", function() {
+
+    var retries = 0;
+    var error_final_value;
+    var testFunc = function(param1, cb) {
+      retries++;
+      var err = retries < 5;
+      cb(err, "Callback result value");
+    };
+
+    var retryTest = _.retry(5, testFunc);
+    retryTest("test", function(err, result) {
+      error_final_value = err;
+    });
+
+    var badRetry = _.retry(5,testFunc);
+    raises(function() { badRetry("param", function(err, res){},6); }, Error, "Last argument expected to be a callback");
+
+    equal(error_final_value, false, "retry(N, func) should call the function N times before giving up ");
+
+  });
+
 });


### PR DESCRIPTION
Following the convention that:
- For a giving function, the last argument is a callback 
- And for that callback, the first argument is the error. 
  This function allows us to get our original function to retry itself N times whenever there is failure  (when the first argument of the callback is true) before giving up.
  It overrides the original callback  function in order to test for the value of the first argument until it is false (no error) or the retry cap is reached.

Example:

``` javascript
    var testFunc = function(param1, cb) {
      var result = //service request that tends to be unstable
      var err = result == null;
      cb(err, result);
    };

   //Doing...
   testFunc("test", function(err, result) {
     //Here we'll have to handle the error that happens when the service is unstable
   });

    //But by doing
    var retryTest = _.retry(5, testFunc);
    retryTest("test", function(err, result) {
       //It'll retry 5 times before giving up and calling this callback, if one of those times, the service works, it'll return a valid response instead of the error.
    });
```
