### PR TITLE
Fixed docs for every/all to show iterator is optional

### DIFF
--- a/index.html
+++ b/index.html
@@ -537,7 +537,7 @@ var odds = _.reject([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
 </pre>
 
       <p id="every">
-        <b class="header">every</b><code>_.every(list, iterator, [context])</code>
+        <b class="header">every</b><code>_.every(list, [iterator], [context])</code>
         <span class="alias">Alias: <b>all</b></span>
         <br />
         Returns <i>true</i> if all of the values in the <b>list</b> pass the <b>iterator</b>


### PR DESCRIPTION
The documentation for every/all was out of date, and didn't show that the iterator argument is optional.  This pull request fixes that.
