### PR TITLE
Fix English in 'debounce()' description

### DIFF
--- a/index.html
+++ b/index.html
@@ -1043,7 +1043,7 @@ $(window).scroll(throttled);
       <p id="debounce">
         <b class="header">debounce</b><code>_.debounce(function, wait, [immediate])</code>
         <br />
-        Creates and returns a new debounced version of the passed function that
+        Creates and returns a new debounced version of the passed function which
         will postpone its execution until after
         <b>wait</b> milliseconds have elapsed since the last time it
         was invoked. Useful for implementing behavior that should only happen


### PR DESCRIPTION
There's an important difference between restrictive ('which') and nonrestrictive relative clauses ('that') in English. 

Since all versions of debounce meet the description given, 'which' is the correct word. 

Additionally this means people who don't know what a debounced function is won't stop reading (currently it implies that some unknown things have a certain behvaior, rather than all unknown things having a certain behavior, ie, right now it's not a definition, with 'which' it would be).  
