### PR TITLE
Adding useful function _.transform to modify values of an object / hash / associative array.

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -19,6 +19,11 @@ $(document).ready(function() {
     equal(_.values({one: 1, two: 2, length: 3}).join(', '), '1, 2, 3', '... even when one of them is "length"');
   });
 
+  test("transform", function() {
+    ok(_.isEqual(_.transform({one: 1, two: 2}, function(value) {return value * value;}), {one: 1, two: 4}), 'can transform values of an object');
+    ok(_.isEqual(_.transform({1: 'one', 2: 'two'}, function(value) {return value + ' hundred';}), {1: 'one hundred', 2: 'two hundred'}), '... even using string values');
+  });
+
   test("pairs", function() {
     deepEqual(_.pairs({one: 1, two: 2}), [['one', 1], ['two', 2]], 'can convert an object into pairs');
     deepEqual(_.pairs({one: 1, two: 2, length: 3}), [['one', 1], ['two', 2], ['length', 3]], '... even when one of them is "length"');

--- a/test/speed.js
+++ b/test/speed.js
@@ -32,6 +32,10 @@
     return jQuery.map(objects, function(obj){ return obj.num; });
   });
 
+  JSLitmus.test('_.transform()', function() {
+    return _.transform(objects, function(value){ return value + 1;});
+  });
+
   JSLitmus.test('_.pluck()', function() {
     return _.pluck(objects, 'num');
   });

--- a/underscore.js
+++ b/underscore.js
@@ -101,6 +101,19 @@
     return results;
   };
 
+
+  // transforms values of a object for each key/value pair
+  // returns a new object
+  _.transform = function(obj, func) {
+    var result = {};
+
+    _.each(obj, function(value, key, item) {
+      result[key] = func(value);
+    });
+
+    return result;
+  }
+
   var reduceError = 'Reduce of empty array with no initial value';
 
   // **Reduce** builds up a single result from a list of values, aka `inject`,


### PR DESCRIPTION
Reason:  There are many methods in underscore that transform array data structures, I find quite often I want to transform values of a object, either to prefix or suffix values, convert values or some other kind of uniform transformation on all the values without needing to return a new object and explicitly specify each key.

An example is converting all values of a hash from a string to a currency format, you would do:

``` javascript
var hash = {cost: '55', shipping: '20', total: '75'};
var currency_hash = _.transform(hash, function(value) { return value.toCurrency() });
```

currently you would do the following:

``` javascript
var hash = {cost: '55', shipping: '20', total: '75'};
var currrency_hash = {cost: '55'.toCurrency(), shipping: '20'.toCurrency(), total: '75'.toCurrency()};
```

I originally thought _.map would do this for me.

I originally wrote this also allowing it to transform the keys as well as the values but it was a bit more verbose and it's more common to want to transform the values than the keys.
