### PR TITLE
Add a _.maybe function

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -290,4 +290,22 @@ $(document).ready(function() {
     equal(testAfter(0, 0), 1, "after(0) should fire immediately");
   });
 
+
+  test("maybe", 5, function() {
+    var maybeTest = function(value) {
+      var stack = [];
+      var pushStack = _.maybe(function(value){
+        stack.push(value);    
+      });
+      pushStack(value);
+      return stack.length;
+    };
+    
+    equal(maybeTest(null), 0, "maybe should not allow null");
+    equal(maybeTest(undefined), 0, "maybe should not allow undefined");    
+    equal(maybeTest(0), 1, "maybe should allow numbers");
+    equal(maybeTest(""), 1, "maybe should allow strings");   
+    equal(maybeTest({}), 1, "maybe should allow objects");
+  });
+
 });

--- a/underscore.js
+++ b/underscore.js
@@ -743,6 +743,19 @@
     };
   };
 
+  // Returns a function that will only be executed if all of its
+  // arguments are not null or undefined.
+  _.maybe = function(fn) {
+    return function() {
+      var hasNullValue = _.some(arguments, function(value) {
+        return _.isNull(value) || _.isUndefined(value);
+      });
+      if (!hasNullValue) {
+        return fn.apply(this, arguments);
+      }
+    };
+  };
+
   // Object Functions
   // ----------------
 


### PR DESCRIPTION
I've found myself writing several functions where the first thing I do is check to see if the variable passed into the function is not null or undefined. 

``` javascript
function(someValue) {
  if (someValue == null) {
    return;
  }
  // Modify some state...
}
```

I have come across two common use cases for this technique. 
When pulling a value out of local storage that may or may not have previously be set.

When working with `<select>` in a data binding library like knockout. Often I will want to write a function that consumes the current value of a select list. However my select list may have an option with no value that is just used as a caption to prompt the user to select a real option. In this case a maybe function would be useful because I often do not want to perform any action of the caption option is selected.

Using a maybe wrapper would prevent a function from being called if any of the arguments are null or undefined. 

``` javascript
var foo = _.maybe(function(someValue) {
  // someValue is not null or undefined
  // Modify some state...
});

foo(JSON.parse(localStorage.getItem('key')));
```
