### PR TITLE
_.each treats any object with a length property as an array

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -22,6 +22,11 @@ $(document).ready(function() {
     equal(answers.join(", "), 'one, two, three', 'iterating over objects works, and ignores the object prototype.');
     delete obj.constructor.prototype.four;
 
+    answers = [];
+    var box = {length : 2, width : 2, height : 2};
+    _.each(box, function(value, key){ answers.push(key); });
+    equal(answers.join(", "), 'length, width, height', 'objects with a length property treated as objects not arrays');
+
     var answer = null;
     _.each([1, 2, 3], function(num, index, arr){ if (_.include(arr, num)) answer = true; });
     ok(answer, 'can reference the original collection from inside the iterator');

--- a/underscore.js
+++ b/underscore.js
@@ -76,7 +76,7 @@
     if (obj == null) return;
     if (nativeForEach && obj.forEach === nativeForEach) {
       obj.forEach(iterator, context);
-    } else if (obj.length === +obj.length) {
+    } else if (typeof obj.length === 'number' && obj.hasOwnProperty(obj.length - 1)) {
       for (var i = 0, l = obj.length; i < l; i++) {
         if (iterator.call(context, obj[i], i, obj) === breaker) return;
       }


### PR DESCRIPTION
Give the following code:

``` javascript
var box = {
  length: 2,
  width: 2,
  height: 2
};

_.each(box, function (value, prop) {
  console.log(prop, value);
});
```

The expected output would be:

```
length 2
width 2
height 2
```

The actual output is:

```
0 undefined
1 undefined
```

Instead of checking the existence of the length property I check that length - 1 is a property of the object. So Arrays and array-like things are treated as arrays and objects with a length property are treated as objects.
