### PR TITLE
Tweak whitespace in reference variable declaration

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -21,11 +21,12 @@
   var ArrayProto = Array.prototype, ObjProto = Object.prototype, FuncProto = Function.prototype;
 
   // Create quick reference variables for speed access to core prototypes.
-  var push             = ArrayProto.push,
-      slice            = ArrayProto.slice,
-      concat           = ArrayProto.concat,
-      toString         = ObjProto.toString,
-      hasOwnProperty   = ObjProto.hasOwnProperty;
+  var
+    push             = ArrayProto.push,
+    slice            = ArrayProto.slice,
+    concat           = ArrayProto.concat,
+    toString         = ObjProto.toString,
+    hasOwnProperty   = ObjProto.hasOwnProperty;
 
   // All **ECMAScript 5** native function implementations that we hope to use
   // are declared here.


### PR DESCRIPTION
Make the "quick reference variable" declaration section match up with
the style used in the ECMAScript 5 variable declaration section below.

Super nitpicky, I know, but the difference between the whitespace styling bugged me ;).
