### PR TITLE
Move conditional outside of map (_.invoke)

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -225,10 +225,15 @@
   // Invoke a method (with arguments) on every item in a collection.
   _.invoke = function(obj, method) {
     var args = slice.call(arguments, 2);
-    var isFunc = _.isFunction(method);
-    return _.map(obj, function(value) {
-      return (isFunc ? method : value[method]).apply(value, args);
-    });
+    if (_.isFunction(method)) {
+      return _.map(obj, function(value) {
+        return method.apply(value, args);
+      });
+    } else {
+      return _.map(obj, function(value) {
+        return value[method].apply(value, args);
+      });
+    }
   };
 
   // Convenience version of a common use case of `map`: fetching a property.


### PR DESCRIPTION
Moving `invoke`'s `isFunc` conditional outside of the map function is a
minor optimization. Since `isFunc` never changes, the correct path can be determined before the map operation is done, saving a few cycles.
