### PR TITLE
Alias `reject` as `remove`

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -178,7 +178,7 @@
   };
 
   // Return all the elements for which a truth test fails.
-  _.reject = function(obj, iterator, context) {
+  _.remove = _.reject = function(obj, iterator, context) {
     return _.filter(obj, function(value, index, list) {
       return !iterator.call(context, value, index, list);
     }, context);


### PR DESCRIPTION
In the Clojure world, the opposite of filter is known as remove:

https://github.com/clojure/clojure/blob/c6756a8bab137128c8119add29a25b0a88509900/src/clj/clojure/core.clj#L2538

The collect/inject/reject name trio is cute, but I (and many) would appreciate this alias just as well.

Victor
