### PR TITLE
Add limit to shuffle function for shuffling only a few elements of the array

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -288,7 +288,9 @@
   // Shuffle an array.
   _.shuffle = function (obj, limit) {
     if(limit == 0){ return [] }
-    var rand, temp, len = obj.length, shuffled = obj.slice();
+    var shuffled = _.isArray(obj) ? obj.slice() : _.values(obj);
+    var len = shuffled.length;
+    var rand, temp;
     _.some(shuffled, function(value, index) {
       if(index >= limit){ return true }
       rand = index + Math.floor(Math.random() * (len - index) );


### PR DESCRIPTION
add limit for shuffle function, allowing shuffling of only the number of elements needed (for example, only shuffling the 9 cards required for a heads up game of holdem rather than the whole deck).

This is a feature of the Fisher-Yates shuffle that can save time if you only need to pick a few values from a large set.

Returns an array of random elements up to the `limit`...

```
var cards = _.shuffle(deck,9) // returns 9 random cards from the deck
```
