### PR TITLE
break the _.each loop

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -52,6 +52,9 @@
     this._wrapped = obj;
   };
 
+  // allow break the loop, is being used in _.each() callback
+  _.break = breaker;
+
   // Export the Underscore object for **Node.js**, with
   // backwards-compatibility for the old `require()` API. If we're in
   // the browser, add `_` as a global object via a string identifier,


### PR DESCRIPTION
I like `_.each()` operator in compare to `$.each()` one. Sad I can not break it early on condition, `var breaker = {}` is local. 
I suggest to expose the variable to make this possible.
