### PR TITLE
Configured JSHint to look for trouble spots

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,3 @@
+**/node_modules
+**/*[.-]min.js
+test/vendor

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,8 @@
+{
+  "es5": true,
+  "expr": true,
+  "maxerr": 10000,
+  "indent": 2,
+  "eqeqeq": true,
+  "quotmark": true
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "main"          : "underscore.js",
   "version"       : "1.4.4",
   "devDependencies": {
-    "phantomjs": "1.9.0-1"
+    "phantomjs": "1.9.0-1",
+    "jshint": "1.1.0"
   },
   "scripts": {
     "test": "phantomjs test/vendor/runner.js test/index.html?noglobals=true"


### PR DESCRIPTION
[JSHint](http://jshint.com/) is a good way to scan JavaScript code for areas that might lead to bugs and unexpected behavior.

I ran `jslint .` on the latest underscore and saw 1094 lines that could use a bit of improvement. Most of these are trivial to fix, but I thought it would be more respectful to let you guys decide how to resolve them--you can even turn on and off certain JSHint rules in `.jshintrc` to really fit what you care about in your codebase.

Example:

```
$ jshint .
test/arrays.js: line 6, col 76, Mixed double and single quotes.
test/arrays.js: line 7, col 68, Mixed double and single quotes.
test/arrays.js: line 8, col 40, Mixed double and single quotes.
test/arrays.js: line 8, col 75, Mixed double and single quotes.
test/arrays.js: line 9, col 40, Mixed double and single quotes.
test/arrays.js: line 9, col 49, Mixed double and single quotes.
test/arrays.js: line 9, col 79, Mixed double and single quotes.
test/arrays.js: line 10, col 40, Mixed double and single quotes.
test/arrays.js: line 10, col 52, Mixed double and single quotes.
test/arrays.js: line 10, col 82, Mixed double and single quotes.
...
1094 errors
```
