### PR TITLE
_.result calls functions with arguments

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -214,6 +214,11 @@ $(document).ready(function() {
     strictEqual(_.result(null, 'x'), undefined);
   });
 
+  test("result calls functions with arguments", function() {
+    var obj = { echo: function () { return _.toArray(arguments); }};
+    deepEqual([1,2,3], _.result(obj, 'echo', [1,2,3]));
+  });
+
   test('_.templateSettings.variable', function() {
     var s = '<%=data.x%>';
     var data = {x: 'x'};

--- a/underscore.js
+++ b/underscore.js
@@ -1080,10 +1080,10 @@
 
   // If the value of the named `property` is a function then invoke it with the
   // `object` as context; otherwise, return it.
-  _.result = function(object, property) {
+  _.result = function(object, property, args) {
     if (object == null) return void 0;
     var value = object[property];
-    return _.isFunction(value) ? value.call(object) : value;
+    return _.isFunction(value) ? value.apply(object, args) : value;
   };
 
   // Add your own custom functions to the Underscore object.


### PR DESCRIPTION
I thought it'd be handy to be able to pass an array of arguments as the optional third parameter of `_.result`.

It's completely backwards compatible, the existing tests pass, and I've added some more.

``` javascript
var obj = {i: _.identity};
_.result(obj, 'i', ['lol']) === 'lol'
```
