### PR TITLE
_.resolve: Simple dot & bracket notation parser

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -570,19 +570,13 @@ $(document).ready(function() {
     ok(!_.resolve(obj, null), "requires a path to resolve");
     ok(!_.resolve(obj, "buzz"), "returns undefined for unresolved paths");
     deepEqual(_.resolve(obj, "foo"), obj.foo, "works with single property paths");
-    deepEqual(_.resolve(obj, "[fu]"), obj.fu, "works with single property paths in bracket notation");
-    equal(_.resolve(obj, ".fizz"), obj.fizz, "works with single property paths in dot notation");
-    equal(_.resolve(obj, "foo[bar][0]"), obj.foo.bar[0], "works with nested paths in bracket notation");
+    equal(_.resolve(obj, "foo.bar.0"), obj.foo.bar[0], "works with numbers in dot notation");
     equal(_.resolve(obj, "foo.bar.length"), obj.foo.bar.length, "works with nested paths with dot notation");
-    equal(_.resolve(obj, "fu[1].b"), obj.fu[1].b, "works with paths in mixed dot/bracket notation and supports arrays");
-    equal(_.resolve(obj, "['foo'][\"bar\"]"), obj.foo.bar, "strips any single and double quotes from start and end of bracket contents");
-    strictEqual(_.resolve(obj, "fu[1].a.toString"), Number.prototype.toString, "returns resolved prototype properties");
+    strictEqual(_.resolve(obj, "fu.1.a.toString"), Number.prototype.toString, "returns resolved prototype properties");
     ok(!_.resolve(obj, "foo..bar"), "stops at empty property paths in dot notation");
-    ok(!_.resolve(obj, "foo[]bar"), "stops at empty property paths in bracket notation");
-    ok(!_.resolve(obj, "foo['']bar"), "stops at empty property paths in bracket notation with single quotes");
-    ok(!_.resolve(obj, "foo[\"\"]bar"), "stops at empty property paths in bracket notation with double quotes");
+    ok(!_.resolve(obj, ".foo"), "trailing dots cannot be resolved");
+    ok(!_.resolve(obj, "foo..bar"), "stops at empty property paths in dot notation");
     ok(!_.resolve(obj, "foo.baz.length"), "stops at unresolved properties in dot notation");
-    ok(!_.resolve(obj, "foo[baz].length"), "stops at unresolved properties in bracket notation");
   });
 
   test("has", function () {

--- a/underscore.js
+++ b/underscore.js
@@ -844,15 +844,13 @@
     return obj;
   };
 
-  // Resolves the property path, returning the value of that property.
-  // The path can be a combination of dot and bracket notation.
+  // Resolves the property path in dot notation, returning the value of that property.
   _.resolve = function(obj, path) {
     if (!path) return void 0;
-    var paths = path.replace(/^[\.\[]/g, '').split(/[\.\[]/);
+    var paths = path.split('.');
     var result = obj;
-    var stripper = /(^['"]|['"]?\]$)/g;
     while (result != null && paths.length > 0) {
-      result = result[paths.shift().replace(stripper, '')];
+      result = result[paths.shift()];
     }
     return result;
   };


### PR DESCRIPTION
Recently I've been finding needs for simple evaluation of dot and bracket notation and I've been unable to find a good solution. At one point I considered using `_.template` for this but this seemed like overkill, and the performance and security overhead of using the underlying `Function` constructor (much like evil `eval`) make it very off-putting, at least for this behaviour.

With `_.resolve` you can easily do the following:

``` javascript
var data = { foo: 'bar', fu: [{ baz: 'bingo' }] };

_.resolve(data, 'foo');
// "bar"

_.resolve(data, 'fu[0].baz');
// "bingo"

_.resolve(data, 'fu[1].baz');
// undefined

_.resolve(data, 'foo["length"]');
// 3

_.resolve(data, 'fizz');
// undefined
```

One thing I'd like to note is that, due to the lightweight nature of the code, the following patterns are valid in `_.resolve` but not in JavaScript:

``` javascript
// Only numbers in dot notation would throw "Unexpected number" in JavaScript
_.resolve(data, 'fu.0.baz');
// "bingo"

// Optional quotation marks (single or double) in bracket notation for cleaner/simpler paths
_.resolve(data, '[foo][0]["baz"]');
// "bingo"
```

Before I start copying this code to all my projects I thought it would be best to see if this feature would be welcomed in Underscore. Possible uses:

``` html
<body data-log="style.direction" style="direction: ltr">
  <a href="http://underscorejs.org">Underscore.js</a>
  <script>
    if (_.resolve(myLibrary, 'options.custom.parseLogs')) {
      _.each(document.querySelectorAll('[data-log]'), function (element) {
        console.log(_.resolve(element, element.dataset.log));
      });
    }
  </script>
</body>
```

The idea of parsing either user-defined, untrusted, dynamic, or hard coded (e.g. property paths taken from element attributes or a JSON response value) is obviously the main benefit here as raw JavaScript will clearly out-perform standard usage (i.e. `var value = foo.bar.fu.baz` will be more efficient than `var value = _.resolve(foo, 'bar.fu.baz')`).

Finally, I can see this being a great asset when couple with something like `_.memoize`.
### Update:

Support for bracket notation has been removed in order to optimise dot notation, which is more common and user-friendly.

Also, leading and trailing dots are no longer ignored as it should be up to the user to ensure that the `path` argument isn't malformed.
