### PR TITLE
Make _.result call methods with surplus arguments

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -204,14 +204,27 @@ $(document).ready(function() {
     var tmpl = _.template('<p>\u2028<%= "\\u2028\\u2029" %>\u2029</p>');
     strictEqual(tmpl(), '<p>\u2028\u2028\u2029\u2029</p>');
   });
-
-  test('result calls functions and returns primitives', function() {
-    var obj = {w: '', x: 'x', y: function(){ return this.x; }};
-    strictEqual(_.result(obj, 'w'), '');
-    strictEqual(_.result(obj, 'x'), 'x');
-    strictEqual(_.result(obj, 'y'), 'x');
-    strictEqual(_.result(obj, 'z'), undefined);
+  
+  test('_.result returns object properties and calls methods with surplus args', function(){
+    var methodcontext, methodargs, returnval = _.uniqueId(), obj = {
+      valprop:_.uniqueId(),
+      objprop:{a:1},
+      emptystring:'',
+      method: function(){
+        methodcontext = this; methodargs = arguments; return returnval;
+      }
+    };
+    // test prop access
+    ok(_.result(obj,"emptystring") === '');
+    ok(_.result(obj,"objprop") === obj.objprop);
+    strictEqual(_.result(obj,"valprop"), obj.valprop);
+    strictEqual(_.result(obj, 'emptystring'), '');
+    strictEqual(_.result(obj, 'nonexistingprop'), undefined);
     strictEqual(_.result(null, 'x'), undefined);
+    // test method call
+    ok(_.result(obj,"method",1,2,3) === returnval);
+    ok(methodcontext === obj);
+    deepEqual(Array.prototype.slice.call(methodargs,0),[1,2,3]);
   });
 
   test('_.templateSettings.variable', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -1083,7 +1083,7 @@
   _.result = function(object, property) {
     if (object == null) return void 0;
     var value = object[property];
-    return _.isFunction(value) ? value.call(object) : value;
+    return _.isFunction(value) ? value.apply(object,slice.call(arguments, 2)) : value;
   };
 
   // Add your own custom functions to the Underscore object.


### PR DESCRIPTION
This pull request adds a small feature to `_.result`; when called with more than two arguments, those arguments are passed to an eventual method on the object:

```
var obj = {method:someFunc, prop:"val"};
_.result(obj,"method",1,2,3); // => returns result from calling someFunc(1,2,3) with obj as context
_.result(obj,"prop",1,2,3); // => returns "val" like before, surplus args 1,2,3 have no effect
```
