### PR TITLE
_.transform Applies a function to perform transformation on the object

### DIFF
--- a/test/chaining.js
+++ b/test/chaining.js
@@ -56,4 +56,17 @@ $(document).ready(function() {
     equal(numbers.join(', '), "34, 10, 8, 6, 4, 2, 10, 10", 'can chain together array functions.');
   });
 
+  test("groupBy/sortBy/first/passthru", function() {
+      var result = _.chain($('td'))
+          .groupBy('cellIndex')
+          .sortBy(function(__, key) { return Number(key) })
+          .first()
+          .passthru($)
+          .value()
+
+      var passthru = _.chain({}).passthru
+
+      equal(result instanceof $, true, 'able to pass jQuery thru to object inside chain')
+      notEqual(passthru, _.passthru, 'passthru should only exist on the chain object')
+  })
 });

--- a/test/objects.js
+++ b/test/objects.js
@@ -563,20 +563,6 @@ $(document).ready(function() {
     ok(returned == 6 && intercepted == 6, 'can use tapped objects in a chain');
   });
 
-  test("transform", function() {
-    var obj = {};
-    var num = 1;
-
-    equal(obj, _.transform(obj, _.identity));
-    equal(2, _.transform(num, function(num) {
-      return num + 1;
-    }));
-    equal(3, _.transform(num, function(num) {
-      return 2 + 1;
-    }));
-
-  });
-
   test("has", function () {
      var obj = {foo: "bar", func: function () {} };
      ok (_.has(obj, "foo"), "has() checks that the object has a property.");

--- a/underscore.js
+++ b/underscore.js
@@ -846,12 +846,6 @@
     return obj;
   };
 
-  // Applies the function on the object and return
-  // the result of the function return
-  _.transform = function(obj, func) {
-    return func(obj)
-  };
-
   // Internal recursive comparison function for `isEqual`.
   var eq = function(a, b, aStack, bStack) {
     // Identical objects are equal. `0 === -0`, but they aren't identical.
@@ -1250,6 +1244,14 @@
     // Extracts the result from a wrapped and chained object.
     value: function() {
       return this._wrapped;
+    },
+
+    // Applies the function on the object and return
+    // the result of the function return
+    passthru: function(func) {
+      var args = [this._wrapped];
+      push.apply(args, arguments);
+      return result.call(this, func.apply(_, args));
     }
 
   });


### PR DESCRIPTION
The goal is to supply a function to work with the object itself. Most underscore functions work with collections and treats objects as only associative array. #1068 may be related, but that pull request still work the object as an associative array.

The main use case is during chaining that you'll want to apply a certain function to the wrapped object.

``` javascript
// The goal of this snippet is to select cells in table,
// do filter on them, then wrap it back as a jQuery object
_.chain($('td')) // One of the great thing about underscore is
                     // that it work with any array-like object
  .groupBy('cellIndex')
  .sortBy(function(__, key) {
    return Number(key)
  })
  .first()
  .transform($)
  .value()
  .css('background-color', 'red')
```

Alternative solution without `_.transform` may be ugly because it disrupts the structure flow.

``` javascript
$(_.chain($('td'))
  .groupBy('cellIndex')
  .sortBy(function(__, key) {
    return Number(key)
  })
  .first())
  .value()
  .css('background-color', 'red')
```

Naming-wise, it may be more appropriate to call it `apply`. But since the `_` object is itself a function and we don't want to override `Function.prototype.apply`, I came up with the `transform` alternative. 

Alternatively, the functionality may be merged with either `_.chain().value(function)` or `_.tap(function)` by making the chain returns tap's function return value if it does return something. Something like this

``` javascript
_.tap = function(obj, inter) {
  return inter(obj) || obj
}
```
