### PR TITLE
_.pluck extended to support fetching multiple properties

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -251,6 +251,7 @@ $(document).ready(function() {
   test('pluck', function() {
     var people = [{name : 'moe', age : 30}, {name : 'curly', age : 50}];
     equal(_.pluck(people, 'name').join(', '), 'moe, curly', 'pulls names out of objects');
+    equal(_.pluck(people, ['name', 'age']).join(' '), 'moe,30 curly,50', 'allow key argument to be an array');
   });
 
   test('where', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -232,9 +232,13 @@
     });
   };
 
-  // Convenience version of a common use case of `map`: fetching a property.
-  _.pluck = function(obj, key) {
-    return _.map(obj, function(value){ return value[key]; });
+  // Convenience version of a common use case of `map`: fetching a single or multiple properties.
+  _.pluck = function(obj, keys) {
+    return _.map(obj, function(value) { 
+      return !_.isArray(keys) ? value[keys] : _.map(keys, function(key) {
+        return value[key];
+      });
+    });
   };
 
   // Convenience version of a common use case of `filter`: selecting only objects


### PR DESCRIPTION
This seems like an intuitive functionality. Example:

``` js
var people = [{first : 'moe', last: 'doe', age : 30}, {first : 'curly', last: 'brackets', age : 50}];
_.pluck(people, 'first'); // returns ['moe', 'curly']
_.pluck(people, ['first', 'last']); // returns [ ['moe', 'doe'], ['curly', 'brackets'] ]
```

Performance impact: 20% slower
