### PR TITLE
Expanded testing of _.escape() and _.unescape() to cover all conditions

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -73,6 +73,7 @@ $(document).ready(function() {
 
   test("_.escape", function() {
     equal(_.escape("Curly & Moe"), "Curly &amp; Moe");
+    equal(_.escape('<a href="http://moe.com">Curly & Moe\'s</a>'), '&lt;a href=&quot;http:&#x2F;&#x2F;moe.com&quot;&gt;Curly &amp; Moe&#x27;s&lt;&#x2F;a&gt;');
     equal(_.escape("Curly &amp; Moe"), "Curly &amp;amp; Moe");
     equal(_.escape(null), '');
   });
@@ -80,6 +81,7 @@ $(document).ready(function() {
   test("_.unescape", function() {
     var string = "Curly & Moe";
     equal(_.unescape("Curly &amp; Moe"), string);
+    equal(_.unescape('&lt;a href=&quot;http:&#x2F;&#x2F;moe.com&quot;&gt;Curly &amp; Moe&#x27;s&lt;&#x2F;a&gt;'), '<a href="http://moe.com">Curly & Moe\'s</a>');
     equal(_.unescape("Curly &amp;amp; Moe"), "Curly &amp; Moe");
     equal(_.unescape(null), '');
     equal(_.unescape(_.escape(string)), string);


### PR DESCRIPTION
Tests for _.escape() and _.unescape() did not cover all the possible escapable strings, and did not test for multiple replacements of the same substring (e.g. 'Larry & Curly & Moe')

These extra tests are the only thing left from my ill-fated attempt at improving performance of the escape/unescape methods by testing for the necessity of changes using indexOf before escaping ([indexOf is very cheap compared to the regex replace](http://jsperf.com/regexp-vs-indexof))
