### PR TITLE
Added unit test for _.where with parameter 'first'

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -261,6 +261,11 @@ $(document).ready(function() {
     result = _.where(list, {b: 2});
     equal(result.length, 2);
     equal(result[0].a, 1);
+    
+    result = _.where(list, {a: 1}, true);
+    equal(result.b, 2, "Only get the first object matched.")
+    result = _.where(list, {a: 1}, false);
+    equal(result.length, 3);
   });
 
   test('findWhere', function() {


### PR DESCRIPTION
Added following unit test for `_.where`

``` javascript
    result = _.where(list, {a: 1}, true);
    equal(result.b, 2, "Only get the first object matched.")
    result = _.where(list, {a: 1}, false);
    equal(result.length, 3);
```
