### PR TITLE
shortcircuit nativeBind evaluation

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -593,7 +593,7 @@
   // available.
   _.bind = function(func, context) {
     var args, bound;
-    if (func.bind === nativeBind && nativeBind) return nativeBind.apply(func, slice.call(arguments, 1));
+    if (nativeBind && func.bind === nativeBind) return nativeBind.apply(func, slice.call(arguments, 1));
     if (!_.isFunction(func)) throw new TypeError;
     args = slice.call(arguments, 2);
     return bound = function() {


### PR DESCRIPTION
For consistency with the other native function evaluations and for short-circuiting purposes.
