### PR TITLE
_.lambda function shortcut

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -41,14 +41,14 @@ $(document).ready(function() {
   });
 
    test("lambda", function(){
-       var number = 100;
-       var length = _.lambda("toString().length");
-       equal(length(number), 3, "lambda allows compound statements");
+     var number = 100;
+     var length = _.lambda("toString().length");
+     equal(length(number), 3, "lambda allows compound statements");
 
-       // Source is 83 characters
-       var source = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
-       var summarize = _.lambda("substr()", 0, 30);
-       equal(summarize(source).length, 30, "lambda passes arguments to function");
+     // Source is 83 characters
+     var source = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+     var summarize = _.lambda("substr()", 0, 30);
+     equal(summarize(source).length, 30, "lambda passes arguments to function");
    });
 
   test("partial", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -618,21 +618,21 @@
 
     // Create simple handlers that may be passed to Underscore functions
     // Properties may be specified as an array or string, e.g., "toString().toLowerCase().length"
-    _.lambda = function(prop) {
-      var args = slice.call(arguments, 1);
-      if (typeof prop === "string") prop = prop.split(".");
-      return function(obj) {
-        return _.reduce(prop, function (memo, next){
-            if (next.substr(next.length-2) == "()") {
-                var name = next.substr(0, next.length-2);
-                return typeof memo[name] !== "undefined" ? memo[name].apply(memo, args) : null;
-            }
-            else {
-                return typeof memo[next] !== "undefined" ? memo[next] : null;
-            }
-        }, obj);
+  _.lambda = function(prop) {
+    var args = slice.call(arguments, 1);
+    if (typeof prop === "string") prop = prop.split(".");
+    return function(obj) {
+      return _.reduce(prop, function (memo, next){
+        if (next.substr(next.length-2) == "()") {
+          var name = next.substr(0, next.length-2);
+          return typeof memo[name] !== "undefined" ? memo[name].apply(memo, args) : null;
+        }
+        else {
+          return typeof memo[next] !== "undefined" ? memo[next] : null;
+        }
+      }, obj);
       };
-    };
+  };
 
   // Bind all of an object's methods to that object. Useful for ensuring that
   // all callbacks defined on an object belong to it.


### PR DESCRIPTION
I find my self writing a lot of anonymous functions for accessing properties.  `pluck` helps with this a little, but in some cases it's not practical.  This also has the benifit of converting functions to work as Underscore iterator.  Essentially it does the following.

```
// old way
_.map(obj, function(o){ return o.prop.method(); }
// new way
_.map(obj, _.lambda("prop.method()");
```

It also allows adding data, which for ease-of-use is sent to all functions called in the `prop` parameter (this is rarely a problem considering most people will call only one function).

Sorting becomes easier.

```
_.sortBy([
    {score: 50},
    {score: 93},
    {score: 31},
    ], _.lambda('score')
```

Is this really a word?  Remember **i** before **e** except after **c**.

```
var word_tests = [
    /[aeiou]/gi,
    /^[A-Za-z-]+$/,
    /^(?!.*([^c])ei)/
];

var userInput = "pneil";
var verdict = _.all(word_tests, _.lambda("test()", userInput));
```
