### PR TITLE
A shortcut for a shallow flatten

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -65,6 +65,8 @@ $(document).ready(function() {
     deepEqual(_.flatten(list, true), [1,2,3,[[[4]]]], 'can shallowly flatten nested arrays');
     var result = (function(){ return _.flatten(arguments); })(1, [2], [3, [[[4]]]]);
     deepEqual(result, [1,2,3,4], 'works on an arguments object');
+    list = [[1], [2], [3], [[4]]];
+    deepEqual(_.flatten(list, true), [1, 2, 3, [4]], 'can shallowly flatten arrays containing only other arrays');
   });
 
   test("without", function() {

--- a/test/speed.js
+++ b/test/speed.js
@@ -72,4 +72,7 @@
     return _.flatten(deep);
   });
 
+  JSLitmus.test('_.flatten() (shallow)', function() {
+    return _.flatten(deep, true);
+  });
 })();

--- a/underscore.js
+++ b/underscore.js
@@ -424,6 +424,9 @@
 
   // Internal implementation of a recursive `flatten` function.
   var flatten = function(input, shallow, output) {
+    if (shallow && _.every(input, _.isArray)) {
+      return concat.apply(output, input);
+    }
     each(input, function(value) {
       if (_.isArray(value) || _.isArguments(value)) {
         shallow ? push.apply(output, value) : flatten(value, shallow, output);


### PR DESCRIPTION
If calling `_.flatten(x, true)` where `x` is an array containing only other arrays, the entire flatten method can be simplified down to:

``` javascript
return concat.apply(output, x);
```

I added a speed test for the shallow flattening, and it works much faster (~20x)

Before optimisation: ~225-230/s
![](http://tinyurl.com/pl52zts)

After optimisation: ~4900/s
![](http://tinyurl.com/qxxau5p)
