### PR TITLE
Optimize _.debounce(fn, 0)

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -233,12 +233,12 @@ $(document).ready(function() {
     _.delay(function(){ equal(counter, 1, "incr was debounced"); start(); }, 96);
   });
 
-  asyncTest("debounce with one argument", 2, function() {
+  asyncTest("deferred function invokes target once", 2, function() {
     var counter = 0;
-    var debouncedIncr = _.debounce(function(){
+    var deferredIncr = _.deferred(function(){
       counter++;
     });
-    _(_.range(2)).each(debouncedIncr);
+    _.times(2, deferredIncr);
     equal(counter, 0, "incr was not called immediately");
     _.defer(function() {
       equal(counter, 1, "incr called only once");
@@ -246,18 +246,18 @@ $(document).ready(function() {
     });
   });
 
-  asyncTest("debounce uses arguments of last invocation", 2, function() {
+  asyncTest("deferred function uses arguments of first invocation", 2, function() {
     var context, args;
-    var debouncedSpy = _.debounce(function(){
+    var deferredSpy = _.deferred(function(){
       context = this;
       args = _.toArray(arguments);
     });
-    debouncedSpy.call({id: 1}, 1);
-    debouncedSpy.call({id: 2}, 2);
+    deferredSpy.call({id: 1}, 1);
+    deferredSpy.call({id: 2}, 2);
 
     _.defer(function() {
-      deepEqual(context, {id: 2});
-      deepEqual(args, [2]);
+      deepEqual(context, {id: 1});
+      deepEqual(args, [1]);
       start();
     });
   });

--- a/underscore.js
+++ b/underscore.js
@@ -637,6 +637,23 @@
     return _.delay.apply(_, [func, 1].concat(slice.call(arguments, 1)));
   };
 
+  // Returns a function that will execute only once using _.defer, no matter how many times
+  // it is invoked before it is executed.  The function will be executed using the context (this)
+  // and arguments of its first invocation.
+  _.deferred = function(func) {
+    var pending = false;
+    return function() {
+      if (!pending) {
+        var context = this, args = arguments;
+        pending = true;
+        _.defer(function() {
+          pending = false;
+          func.apply(context, args);
+        });
+      }
+    };
+  };
+
   // Returns a function, that, when invoked, will only be triggered at most once
   // during a given window of time.
   _.throttle = function(func, wait, immediate) {
@@ -670,7 +687,6 @@
   // N milliseconds. If `immediate` is passed, trigger the function on the
   // leading edge, instead of the trailing.
   _.debounce = function(func, wait, immediate) {
-    var defaultDebounce = function() {
       var timeout, result;
       return function() {
         var context = this, args = arguments;
@@ -684,27 +700,6 @@
         if (callNow) result = func.apply(context, args);
         return result;
       };
-    };
-
-    // optimize _.debounce(fn)
-    var optimizedDebounce = function() {
-      var pending = false;
-      var context;
-      var args;
-      return function () {
-        context = this;
-        args = arguments;
-        if (!pending) {
-          pending = true;
-          _.defer(function() {
-            pending = false;
-            func.apply(context, args);
-          });
-        }
-      };
-    };
-
-    return wait || immediate ? defaultDebounce() : optimizedDebounce();
   };
 
   // Returns a function that will be executed at most one time, no matter how


### PR DESCRIPTION
I find _.debounce immensely useful, but perhaps the most useful application is with a wait of 0.  This simply allows a flood of events to be cascaded into one event handler.  For example:

``` javascript
// a backbone collection with a lot of models
// second argument to _.debounce isn't technically needed 
// (jasmine 1.3.1 mock clock needs it)
collection.on("change", _.debounce(handleChangeEvent, 0));
// models fire a ton of events; handleChangeEvent invoked only once
changeAllOfTheModelsInCollection();
```

The problem is that _.debounce isn't optimized very well for this situation.  Every invocation will call clearTimeout/setTimeout.  To be sure these native methods are fast (at least in Chrome) but the performance hit is not insignificant, as the script below illustrates.

My output from this script:

_.debounce: 609ms
optimized debounce: 4ms

``` javascript
(function() {
    var _ = window._;
    var console = window.console;

    function optimizedDebounce(fn) {
        var pending = false;
        return function () {
            if (!pending) {
                var context = this, args = arguments;
                pending = true;
                setTimeout(function () {
                    pending = false;
                    fn.apply(context, args);
                }, 0);
            }
        };
    }

    function elapsedTime(fn) {
        var start = new Date();
        fn();
        return (new Date().getTime() - start.getTime()) + "ms";
    }

    function speedTest(debounceFn) {
        var invocations = 99999;
        var debounced = debounceFn(_.identity, 0);

        return elapsedTime(function () {
            for (var i = 0; i < invocations; i++) {
                debounced();
            }
        });
    }

    console.info("_.debounce: " + speedTest(_.debounce));
    console.info("optimized debounce: " + speedTest(optimizedDebounce));

}());
```
