### PR TITLE
Make the `property` argument of `_.result` optional

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -214,6 +214,10 @@ $(document).ready(function() {
     strictEqual(_.result(obj, 'y'), 'x');
     strictEqual(_.result(obj, 'z'), undefined);
     strictEqual(_.result(null, 'x'), undefined);
+
+    var fun = function() { return obj; };
+    strictEqual(_.result(obj), obj);
+    strictEqual(_.result(fun), obj);
   });
 
   test('_.templateSettings.variable', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -1082,9 +1082,12 @@
 
   // If the value of the named `property` is a function then invoke it with the
   // `object` as context; otherwise, return it.
+  //
+  // If the `property` argument is omitted, `object` itself is examined instead:
+  // if `object` is a function it is invoked, else it is returned.
   _.result = function(object, property) {
     if (object == null) return void 0;
-    var value = object[property];
+    var value = property == null ? object : object[property];
     return _.isFunction(value) ? value.call(object) : value;
   };
 


### PR DESCRIPTION
The current implementation of `_.result` conflates function invocation and property access (similar to `_.pluck`). This PR adds a single-argument form of `_.result` that can be used for the former without the latter.

If the `property` argument is omitted, the modified `_.result` operates on the `object` argument itself rather than a property of `object`. For example:

```
var str = 'foo';
var fun = function() { return str; }
_.result(str) // --> 'foo'
_.result(fun) // --> 'foo'
```

The original two-argument behaviour of `_.result` is retained.
