### PR TITLE
Adds _.isFile and _.isBlob

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -437,6 +437,16 @@ $(document).ready(function() {
     ok(_.isArray([1, 2, 3]), 'but arrays are');
     ok(_.isArray(iArray), 'even from another frame');
   });
+  
+  test("isFile", function() {
+    ok(_.isFile(new Blob), 'a Blob is a file');
+    ok(!_.isFile(iObject), 'but an object is not');
+    ok(!_.isFile(undefined), 'and not undefined');
+  });
+
+  test("isBlob", function() {
+    ok(_.isBlob(new Blob), 'a Blob object is a Blob');
+  });
 
   test("isString", function() {
     var obj = new String("I am a string object");

--- a/underscore.js
+++ b/underscore.js
@@ -961,14 +961,19 @@
   _.isArray = nativeIsArray || function(obj) {
     return toString.call(obj) == '[object Array]';
   };
+  
+  // Is a given variable a file?
+  _.isFile = function(obj) {
+    return toString.call(obj) == '[object File]' || _.isBlob(obj);
+  }
 
   // Is a given variable an object?
   _.isObject = function(obj) {
     return obj === Object(obj);
   };
 
-  // Add some isType methods: isArguments, isFunction, isString, isNumber, isDate, isRegExp.
-  each(['Arguments', 'Function', 'String', 'Number', 'Date', 'RegExp'], function(name) {
+  // Add some isType methods: isArguments, isFunction, isString, isNumber, isDate, isRegExp, Blob.
+  each(['Arguments', 'Function', 'String', 'Number', 'Date', 'RegExp', 'Blob'], function(name) {
     _['is' + name] = function(obj) {
       return toString.call(obj) == '[object ' + name + ']';
     };


### PR DESCRIPTION
This adds `_.isFile`, which returns true for File and Blob objects, and `_.isBlob`, which only returns true for the latter. Maybe this is too soon, since only IE 10+ seems to support File and Blob, but these have been helpful for me in a couple of projects.

Unfortunately, it doesn't seem possible to create a positive test case for File objects, as I don't believe they can be created in Javascript.
