### PR TITLE
Calling folded properties on an object

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -574,4 +574,13 @@ $(document).ready(function() {
      child.prototype = obj;
      ok (_.has(child, "foo") == false, "has() does not check the prototype chain for a property.")
   });
+
+  test("foldedProp", function () {
+    var obj = { foo_a: { foo_b: { foo_c: "folded property value" }}};
+    ok (_.foldedProp(obj, "foo_a.foo_b.foo_c") == "folded property value",
+       "foldedProp() gives access to a folded property");
+    ok (_.isUndefined(_.foldedProp(obj, "foo_a.foo_x.foo_c")),
+       "foldedProp() returns undefined if property within the chain doesn't exist or is empty");
+  });
+
 });

--- a/underscore.js
+++ b/underscore.js
@@ -1019,6 +1019,21 @@
   _.has = function(obj, key) {
     return hasOwnProperty.call(obj, key);
   };
+  
+  // Allows to call folded properties on an object.
+  // Imagine we have this structure: var a = { b: { c: { d: "folded property value" }}}
+  // The following call to this function:
+  //   _.foldedProp(a, "b.c.d");
+  // will return "folded property value" 
+  _.foldedProp = function(obj, property_chain) {
+    var properties = property_chain.split(".");
+    var result = obj;
+    for (i in properties) {
+      result = result[properties[i]];
+      if(_.isUndefined(result)) { return result; };
+    };
+    return result;
+  };
 
   // Utility Functions
   // -----------------


### PR DESCRIPTION
...d

Example:

  var a = { b: { c: { d: "folded property value "}}};
  _.foldedProp(a, "b.c.d"); // => "folded property value"
