### PR TITLE
Add _.deep() to provide deep access to tree properties

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -574,4 +574,30 @@ $(document).ready(function() {
      child.prototype = obj;
      ok (_.has(child, "foo") == false, "has() does not check the prototype chain for a property.")
   });
+
+  test("deep", function() {
+    var tree = {one : 1, two : { three: "four", "three.five": "six" }, seven : ["eight", {nine: "ten"}, "eleven"]};
+    equal(_.deep(tree, "one"), 1, 'can get existent values at top level');
+    equal(_.deep(tree, "zero"), undefined, 'non-existent values at top level are undefined');
+    equal(_.deep(tree, "zero.five"), undefined, 'non-existent values at second level are undefined');
+    equal(_.deep(tree, "two.three"), 'four', 'can get existent values with dot notation');
+    equal(_.deep(tree, ["two", "three"]), 'four', 'can get existent values with array');
+    equal(_.deep(tree, ["two", "three.five"]), 'six', 'can use keys with periods');
+    equal(_.deep(tree, "two.six"), undefined, 'miss is undefined');
+    equal(_.deep(tree, ["seven", 0]), "eight", 'Can access arrays');
+    equal(_.deep(tree, ["seven", 1, "nine"]), "ten", 'Can access arrays');
+    equal(_.deep(tree, ["seven", 4]), undefined, 'Array miss is undefined');
+    equal(_.deep(tree, ["seven", 4, "twelve"]), undefined, 'Array deep miss is undefined');
+    equal(_.deep([0, 1, 2], 1), 1, 'Numbers work');
+    equal(_.deep([0, 1, 2], 3), undefined, 'Number hits work');
+    equal(_.deep(tree, null), undefined, "Null properties are undefined");
+    equal(_.deep(tree, {a: 1, b: 2}), undefined, "Object properties are undefined");
+    equal(_.deep(undefined, "alpha.beta.gamma"), undefined, 'Undefined root is undefined');
+    equal(_.deep(42, "alpha.beta.gamma"), undefined, 'Number root is undefined');
+    equal(_.deep("forty-two", "alpha.beta.gamma"), undefined, 'String root is undefined');
+    equal(_.deep(null, "alpha.beta.gamma"), undefined, 'Null root is undefined');
+    equal(_.deep(null), null, 'Null with no properties is null');
+    equal(_.deep(42), 42, 'Number with no properties is null');
+    equal(_.deep("forty-two"), "forty-two", 'String with no properties is null');
+  });
 });

--- a/underscore.js
+++ b/underscore.js
@@ -1020,6 +1020,24 @@
     return hasOwnProperty.call(obj, key);
   };
 
+  // Access deep properties of an object. Properties can be a dot-delimited string
+  // or an array of strings or numbers.
+  _.deep = function(obj, properties) {
+    if (_.isString(properties)) {
+      return _.deep(obj, properties.split("."));
+    } else if (_.isNumber(properties)) {
+      return _.deep(obj, [properties]);
+    } else if (_.isUndefined(properties) || (_.isArray(properties) && properties.length == 0)) {
+      return obj;
+    } else if (!_.isArray(properties) || !_.isObject(obj)) {
+      return undefined;
+    } else if (!_.has(obj, properties[0])) {
+      return undefined;
+    } else {
+      return _.deep(obj[properties[0]], properties.slice(1));
+    }
+  };
+
   // Utility Functions
   // -----------------
 


### PR DESCRIPTION
With large, complicated data structures -- especially ones that come from JSON -- I often find myself writing code to guard against accessing missing parts of a tree-like object, like so:

``` javascript
if (user.profile && user.profile.images && user.profile.images.small) {
    return user.profile.images.small.url;
} else {
    return undefined;
}
```

This is tiring and error-prone and brittle in the face of data-structure changes. (If the `profile` property becomes `account`, you have to change it in 4 places.) Coffeescript handles this problem with the .? operator. The _.deep() function provides deep access to an object and its properties and does the guard automatically:

``` javascript
return _.deep(user, "profile.images.small.url");
```

This will return `undefined` if the `user` object doesn't have an `profile` property, or if `user.profile` doesn't have `images`, or if `user.profile.images` is a number and not an object. Direct access like `user.profile.images.small.url` would cause a `TypeError`.

_.deep() can take a dotted string to find the property, or an array of property names (in case your properties have dots in them!):

``` javascript
return _.deep(user, ["profile", "images", "small", "url"]);
```

It's also nice for templates:

```
<img src="<%= _.deep(user, "profile.images.small.url") || "default.png" %>" />
```

There's a bunch of unit tests for hits and misses as well as extreme cases like `_.deep(null)` and `_.deep({a: 1}, 42)`.
