### PR TITLE
Fix #1171 - Simplify some/any.

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -197,8 +197,6 @@ $(document).ready(function() {
   });
 
   test('any', function() {
-    var nativeSome = Array.prototype.some;
-    Array.prototype.some = null;
     ok(!_.any([]), 'the empty set');
     ok(!_.any([false, false, false]), 'all false values');
     ok(_.any([false, false, true]), 'one true value');
@@ -209,7 +207,6 @@ $(document).ready(function() {
     ok(_.any([1], _.identity) === true, 'cast to boolean - true');
     ok(_.any([0], _.identity) === false, 'cast to boolean - false');
     ok(_.some([false, false, true]), 'aliased as "some"');
-    Array.prototype.some = nativeSome;
   });
 
   test('include', function() {
@@ -261,7 +258,7 @@ $(document).ready(function() {
     result = _.where(list, {b: 2});
     equal(result.length, 2);
     equal(result[0].a, 1);
-    
+
     result = _.where(list, {a: 1}, true);
     equal(result.b, 2, "Only get the first object matched.")
     result = _.where(list, {a: 1}, false);

--- a/underscore.js
+++ b/underscore.js
@@ -208,7 +208,7 @@
     if (obj == null) return result;
     if (nativeSome && obj.some === nativeSome) return obj.some(iterator, context);
     each(obj, function(value, index, list) {
-      if (result || (result = iterator.call(context, value, index, list))) return breaker;
+      if (result = iterator.call(context, value, index, list)) return breaker;
     });
     return !!result;
   };


### PR DESCRIPTION
As stated in #1171, if the return of the iterator is ever truthy, the loop exits immediately via `breaker`.  Thus there is no reason for the extra check.

I also noticed that the tests remove the native version of `Array#some`.  This leads to spurious results because `Array#forEach` does not support `breaker`.  I'd speculate that it's likely the reason the extra check was added originally.  It's removed in this patch.
