### PR TITLE
Bug fix. Array.prototype.indexOf does not accept a boolean as its 2nd argument.

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -543,7 +543,7 @@
         return array[i] === item ? i : -1;
       }
     }
-    if (nativeIndexOf && array.indexOf === nativeIndexOf) return array.indexOf(item, isSorted);
+    if (nativeIndexOf && array.indexOf === nativeIndexOf) return array.indexOf(item);
     for (; i < l; i++) if (array[i] === item) return i;
     return -1;
   };


### PR DESCRIPTION
See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf
