### PR TITLE
Feature: Flatten to a specific depth

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -65,6 +65,7 @@ $(document).ready(function() {
     deepEqual(_.flatten(list, true), [1,2,3,[4,[5]]], 'can shallowly flatten with a boolean');
     deepEqual(_.flatten(list, 1), [1,2,3,[4,[5]]], 'can flatten to a depth of 1');
     deepEqual(_.flatten(list, 2), [1,2,3,4,[5]], 'can flatten to a depth of 2');
+    deepEqual(_.flatten(list, 0), list, 'flatten to a depth of 0 does not flatten');
     var result = (function(){ return _.flatten(arguments); })(1, 2, [3, [4, [5]]]);
     deepEqual(result, [1,2,3,4,5], 'works on an arguments object');
   });

--- a/underscore.js
+++ b/underscore.js
@@ -436,6 +436,7 @@
 
   // Return a completely flattened version of an array.
   _.flatten = function(array, level) {
+    if (level === 0) return array;
     level = level || Infinity;
     return flatten(array, level, []);
   };


### PR DESCRIPTION
This change allows flatten to take an integer as it's second argument
(formerly named "shallow"). I renamed the argument to depth. Backwards-
compatible with previous flatten because true and false are coerced to
1 and 0 respectively. This mimics the behavior of Ruby's Array#flatten.
