### PR TITLE
Allow lazy Object initialization with _.defaults

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -111,6 +111,10 @@ $(document).ready(function() {
     } catch(ex) {}
 
     equal(options.a, 1, 'should not error on `null` or `undefined` sources');
+    
+    options = {};
+    _.defaults(options, { lazy: function() { return 'invoked'; } });
+    equal(options.lazy, 'invoked', 'invoked default value');
   });
 
   test("clone", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -820,7 +820,7 @@
     each(slice.call(arguments, 1), function(source) {
       if (source) {
         for (var prop in source) {
-          if (obj[prop] === void 0) obj[prop] = source[prop];
+          if (obj[prop] === void 0) obj[prop] = _.result(source, prop);
         }
       }
     });


### PR DESCRIPTION
I noticed that if you want to include objects in defaults it doesnt work so well:

``` javascript
var defaults = {
   someObject: new SomeObject()
};

_.defaults(options, defaults);
```

To fix this, defaults should be allowed to have lazy properties:

``` javascript
var defaults = {
   someObject: function() { return new SomeObject() }
};
```

and then we change `_.defaults` to use `_.result`. Use cases would be quickly initializing nested hierarchies of objects for a client-side app. 

``` javascript
new Post({ comments: new Comments() })
new Post()   // comments defaulted to new Comments
```
