### PR TITLE
Join function for arrays

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -502,6 +502,32 @@
     return results;
   };
 
+  // Produce an array that contains a join of the passed-in arrays.
+  // Last argument is a comparator function to compare keys
+  _.join = function() {
+    var cmp = arguments[arguments.length-1];
+    var join = [];
+    _.each(arguments, function(array) {
+      if(typeof array === "function") return;
+      _.each(array, function(newObj) {
+        var isMerged = false;
+        _.each(join, function(joinObj, joinIndex) {
+          if(cmp(newObj, joinObj)) {
+            _.each(joinObj, function(value, key) {
+              newObj[key] = value;
+            });
+            join[joinIndex] = newObj;
+            isMerged = true;
+          }
+        });
+        if(!isMerged) {
+          join.push(newObj);
+        }
+      });
+    });
+    return join;
+  };
+
   // Converts lists into objects. Pass either a single array of `[key, value]`
   // pairs, or two parallel arrays of the same length -- one of keys, and one of
   // the corresponding values.


### PR DESCRIPTION
Example usage.

```
var list1 = [
    {
        id: 1,
        columnA: "column A"
    },
    {
        id: 2,
        columnA: "column A"
    }
];

var list2 = [
    {
        id: 1,
        columnB: "column B"
    },
    {
        id: 2,
        columnB: "column B"
    }
];

var list3 = [
    {
        id: 1,
        columnC: "column C"
    },
    {
        id: 2,
        columnC: "column C"
    }
];

var join = _.join(list1, list2, list3, function (l1, l2) {
    return l1.id === l2.id;
});

join = [
    {
        id: 1,
        columnA: "column A",
        columnB: "column B",
        columnC: "column C"
    },
    {
        id: 2,
        columnA: "column A",
        columnB: "column B",
        columnC: "column C"
    }
];
```

https://github.com/jashkenas/underscore/issues/1194
