### PR TITLE
Allow _.groupBy to create dictionaries for O(n) lookups

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -261,7 +261,7 @@ $(document).ready(function() {
     result = _.where(list, {b: 2});
     equal(result.length, 2);
     equal(result[0].a, 1);
-    
+
     result = _.where(list, {a: 1}, true);
     equal(result.b, 2, "Only get the first object matched.")
     result = _.where(list, {a: 1}, false);
@@ -377,6 +377,13 @@ $(document).ready(function() {
     ];
     deepEqual(_.groupBy(matrix, 0), {1: [[1,2], [1,3]], 2: [[2,3]]})
     deepEqual(_.groupBy(matrix, 1), {2: [[1,2]], 3: [[1,3], [2,3]]})
+
+    var stooges = [{name: 'Larry'}, {name: 'Curly'}, {name: 'Moe'}];
+    deepEqual(_.groupBy(stooges, 'name', true), {
+      'Larry': stooges[0],
+      'Curly': stooges[1],
+      'Moe': stooges[2]
+    }, 'creates a dictionary with when a property is given');
   });
 
   test('countBy', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -335,8 +335,13 @@
 
   // Groups the object's values by a criterion. Pass either a string attribute
   // to group by, or a function that returns the criterion.
-  _.groupBy = function(obj, value, context) {
+  _.groupBy = function(obj, value, dict, context) {
+    if (!_.isBoolean(dict)) {
+      context = dict;
+      dict = false;
+    }
     return group(obj, value, context, function(result, key, value) {
+      if (dict) return result[key] = value;
       (_.has(result, key) ? result[key] : (result[key] = [])).push(value);
     });
   };


### PR DESCRIPTION
This is very useful for speeding up operations like finding by a property and `intersection` (which should also get some hash lookup love #1194).

``` js
// email is unique
var userByEmail = _.object(users.models, 'email');
userByEmail['john@example.com'];
userByEmail['jane@example.com'];

// which is going to be much faster than

users.findWhere({email: 'john@example.com'});
users.findWhere({email: 'jane@example.com'});
```

This complements the idea in #1194. Using dictionaries for intersection when it's possible is magnitudes faster than simple arrays.
