### PR TITLE
_.combine for creating an object using 2 arrays

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -24,6 +24,15 @@ $(document).ready(function() {
     deepEqual(_.pairs({one: 1, two: 2, length: 3}), [['one', 1], ['two', 2], ['length', 3]], '... even when one of them is "length"');
   });
 
+  test('combine', function() {
+    var names = ['moe', 'larry', 'curly'], ages = [41, 42, 43];
+    var stooges = _.combine(names, ages);
+
+    deepEqual(stooges, {'moe': 41, 'larry': 42, 'curly': 43}, 'merged object');
+    equal(JSON.stringify(stooges), '{"moe":41,"larry":42,"curly":43}', 'stringified');
+    deepEqual(_.size(stooges), names.length, 'output has the same number of elements as input');
+  });
+
   test("invert", function() {
     var obj = {first: 'Moe', second: 'Larry', third: 'Curly'};
     equal(_.keys(_.invert(obj)).join(' '), 'Moe Larry Curly', 'can invert an object');

--- a/underscore.js
+++ b/underscore.js
@@ -766,6 +766,16 @@
     return pairs;
   };
 
+  // Create an object using one array for its keys and another for its values
+  _.combine = function(keys, values) {
+    if (keys.length != values.length) throw new Error("Arrays must have the same number of elements");
+    var c = {};
+    for (var i = 0, l = keys.length; i < l; ++i) {
+      c[keys[i]] = values[i];
+    }
+    return c;
+  };
+
   // Invert the keys and values of an object. The values must be serializable.
   _.invert = function(obj) {
     var result = {};


### PR DESCRIPTION
Functionality is identical to that of array_combine in PHP.  Function accepts 2 arrays and creates an object using the first array for properties and the second array for its values.
