### PR TITLE
Handle null-ish arguments to _.union.

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -121,8 +121,8 @@ $(document).ready(function() {
     result = _.union(args, [2, 30, 1], [1, 40]);
     equal(result.join(' '), '1 2 3 30 40', 'takes the union of a list of arrays');
 
-    result = _.union(null, [1, 2, 3]);
-    deepEqual(result, [null, 1, 2, 3]);
+    deepEqual(_.union(null, [1, 2, 3]), [1, 2, 3]);
+    deepEqual(_.union([1, 2, 3], null), [1, 2, 3]);
   });
 
   test("difference", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -470,7 +470,7 @@
   // Produce an array that contains the union: each distinct element from all of
   // the passed-in arrays.
   _.union = function() {
-    return _.uniq(_.flatten(arguments, true));
+    return _.uniq(_.flatten(_.compact(arguments), true));
   };
 
   // Produce an array that contains every item shared between all the


### PR DESCRIPTION
I think the desired behavior here is to ignore nullish arguments instead of adding them to the result.
