### PR TITLE
_.chunk method for arrays

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -219,4 +219,11 @@ $(document).ready(function() {
     equal(_.range(0, -10, -1).join(' '), '0 -1 -2 -3 -4 -5 -6 -7 -8 -9', 'final example in the Python docs');
   });
 
+  test("chunk", function() {
+    var list = _.chunk([1, 2, 3, 4], 3)
+    equal(list.length, 2, 'chunks the array into a 2 dimensional array')
+    equal(list[0].length, 3, 'splits the target array at the specified interval')
+    equal(list[1].length, 1, 'includes the remaning elements in the returned array')
+  });
+
 });

--- a/underscore.js
+++ b/underscore.js
@@ -574,6 +574,16 @@
     return range;
   };
 
+  // Return a 2 dimensional array from the target array splitting the array at a specified interval.
+  // Any remaining elements will be returned in the array as well.
+  _.chunk = function(array, chunk) {
+    return [].concat.apply([],
+      array.map(function(elem, i) {
+        return i % chunk ? [] : [array.slice(i, i + chunk)];
+      })
+    );
+  };
+
   // Function (ahem) Functions
   // ------------------
 


### PR DESCRIPTION
A method for splitting a target array into a 2 dimensional array of a specified length. If there are remaining elements they are added as the last element in the new array. An example use case would be in chunking and array of object ids for use in url query params as to not hit the url character limit.

Example:
`_.chunk([1, 2, 3, 4], 3)` would return `[[1, 2, 3], [4]]`
