### PR TITLE
allow null values in `list` parameter of _.object

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -163,6 +163,10 @@ $(document).ready(function() {
     ok(_.isEqual(_.object(_.pairs(stooges)), stooges), 'an object converted to pairs and back to an object');
 
     ok(_.isEqual(_.object(null), {}), 'handles nulls');
+
+    result = _.object([['one', 1], ['two', 2], null, ['three', 3]]);
+    shouldBe = {one: 1, two: 2, three: 3};
+    ok(_.isEqual(result, shouldBe), "null value as pair doesn't get added to object");
   });
 
   test("indexOf", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -512,7 +512,10 @@
       if (values) {
         result[list[i]] = values[i];
       } else {
-        result[list[i][0]] = list[i][1];
+        var listI = list[i];
+        if (listI != null) {
+          result[listI[0]] = listI[1];
+        }
       }
     }
     return result;


### PR DESCRIPTION
Previously _.object([['a', 'b'], null]) would crash. Now it will
ignore the null value and just give {'a': 'b'}. This is especially
convenient if you are chaining it with _.map and you want to
remove some values from an object:

> _.object(_.map({'a': 100, 'b': 150}, function(v, k) {
>   return v > 120 ? [k, v] : null
>   }))
>   { b: 150 }
