### PR TITLE
refactor _.values

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -756,7 +756,7 @@
   _.values = function(obj) {
     return _.map(_.keys(obj), function(key){
       return obj[key];
-    }).concat();
+    });
   };
 
   // Convert an object into a list of `[key, value]` pairs.


### PR DESCRIPTION
use `_.map` and `_.keys` to implement the `_.values` function

the function is shorter, prettier, and runs faster(twice faster) if the native `map` and `Object.keys` exist.
