### PR TITLE
add big objects to speed.js

### DIFF
--- a/test/speed.js
+++ b/test/speed.js
@@ -2,7 +2,9 @@
 
   var numbers = [];
   for (var i=0; i<1000; i++) numbers.push(i);
-  var objects = _.map(numbers, function(n){ return {num : n}; });
+  var objArray = _.map(numbers, function(n){ return {num : n}; });
+  var bigObj = {};
+  _.times(1000, function(n){ bigObj['key' + n] = n; });
   var randomized = _.sortBy(numbers, function(){ return Math.random(); });
   var deep = _.map(_.range(100), function() { return _.range(1000); });
 
@@ -25,15 +27,15 @@
   });
 
   JSLitmus.test('_.map()', function() {
-    return _.map(objects, function(obj){ return obj.num; });
+    return _.map(objArray, function(obj){ return obj.num; });
   });
 
   JSLitmus.test('jQuery.map()', function() {
-    return jQuery.map(objects, function(obj){ return obj.num; });
+    return jQuery.map(objArray, function(obj){ return obj.num; });
   });
 
   JSLitmus.test('_.pluck()', function() {
-    return _.pluck(objects, 'num');
+    return _.pluck(objArray, 'num');
   });
 
   JSLitmus.test('_.uniq()', function() {
@@ -53,11 +55,11 @@
   });
 
   JSLitmus.test('_.keys()', function() {
-    return _.keys(objects);
+    return _.keys(bigObj);
   });
 
   JSLitmus.test('_.values()', function() {
-    return _.values(objects);
+    return _.values(bigObj);
   });
 
   JSLitmus.test('_.intersection()', function() {


### PR DESCRIPTION
As you mentioned in #1214, `_.keys` and `_.values` should be tested on big objects instead of big array of objects.
