### PR TITLE
Create bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,9 @@
+{
+  "name": "underscore",
+  "version": "1.5.1",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jashkenas/underscore.git"
+  },
+  "main": "underscore.js"
+}


### PR DESCRIPTION
Adding a bower.json file with the main path set allows automating the loading of the module using external tools (i.e. Grunt).
This repository is already published on the Bower registry, so it makes sense.

The minified version has been left out, since using this kind of tools often implies a custom minification and concatenation. But it could be included as well.

Notice however that most of the information is already in `package.json`... I think it's possible to tell Bower to look there with a `.bowerrc`.
