### PR TITLE
Change defer timeout to 4ms

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -645,7 +645,7 @@
   // Defers a function, scheduling it to run after the current call stack has
   // cleared.
   _.defer = function(func) {
-    return _.delay.apply(_, [func, 1].concat(slice.call(arguments, 1)));
+    return _.delay.apply(_, [func, 4].concat(slice.call(arguments, 1)));
   };
 
   // Returns a function, that, when invoked, will only be triggered at most once


### PR DESCRIPTION
Changed the timeout in the `defer` method to 4 milliseconds, the standard minimum delay per the HTML5 spec:

https://developer.mozilla.org/en-US/docs/Web/API/window.setTimeout#Minimum.2F_maximum_delay_and_timeout_nesting
