### PR TITLE
speed up _.each

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -84,7 +84,7 @@
     } else {
       var keys = _.keys(obj);
       for (var i = 0, length = keys.length; i < length; i++) {
-        if (iterator.call(context, obj[keys[i]], keys[i], obj) === breaker) return ;
+        if (iterator.call(context, obj[keys[i]], keys[i], obj) === breaker) return;
       }
     }
   };


### PR DESCRIPTION
use `_.keys` instead of `for .. in ..` loop and `hasOwnProperty` check. Like we did in #1224 and #1223
