### PR TITLE
Changes null and guard check in _.initial to make style cohesive

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -388,7 +388,7 @@
   // allows it to work with `_.map`.
   _.first = _.head = _.take = function(array, n, guard) {
     if (array == null) return void 0;
-    return (n != null) && !guard ? slice.call(array, 0, n) : array[0];
+    return (n == null) || guard ? array[0] : slice.call(array, 0, n);
   };
 
   // Returns everything but the last entry of the array. Especially useful on
@@ -403,10 +403,10 @@
   // values in the array. The **guard** check allows it to work with `_.map`.
   _.last = function(array, n, guard) {
     if (array == null) return void 0;
-    if ((n != null) && !guard) {
-      return slice.call(array, Math.max(array.length - n, 0));
-    } else {
+    if ((n == null) || guard) {
       return array[array.length - 1];
+    } else {
+      return slice.call(array, Math.max(array.length - n, 0));
     }
   };
 


### PR DESCRIPTION
In _.first and _.last, the check the style is:

```
(n != null) && !guard 
```

But in _.initial and _.rest, it was the the opposite (DeMorgan's law):

```
(n == null) || guard
```

When reading the code, this was a little confusing, so I figured I would change it to make the style the same...it could also be switched the other way, but I think this is more logical.

EDIT: reversed it to not use double negatives.
