### PR TITLE
Use the faster Date.now if available in throttle.

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -20,6 +20,11 @@
   // Save bytes in the minified (but not gzipped) version:
   var ArrayProto = Array.prototype, ObjProto = Object.prototype, FuncProto = Function.prototype;
 
+  //use the faster Date.now if available.
+  var dateNow = (Date.now || function() {
+    return new Date().getTime();
+  });
+
   // Create quick reference variables for speed access to core prototypes.
   var
     push             = ArrayProto.push,
@@ -653,12 +658,12 @@
     var previous = 0;
     options || (options = {});
     var later = function() {
-      previous = options.leading === false ? 0 : new Date;
+      previous = options.leading === false ? 0 : dateNow();
       timeout = null;
       result = func.apply(context, args);
     };
     return function() {
-      var now = new Date;
+      var now = dateNow();
       if (!previous && options.leading === false) previous = now;
       var remaining = wait - (now - previous);
       context = this;


### PR DESCRIPTION
Date.now introduced in ES5 is substantially faster than new Date; which is used in the throttle method. Since often the throttle method is used to reduce computation during very frequent events (mousemouve, scroll) it is probably important to have it as performant as possible on every invocation. Tests passing in ES5 complaint browsers and IE7.

JSperf:   http://jsperf.com/throttle-test 

Chrome reporting throttle with 'new Date' to be 77% slower than Date.now
While non-ES5 complaint browsers take a 8% hit due to an extra function overhead.
