### PR TITLE
_.attempt(object, 'method', [*arguments])

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -269,4 +269,13 @@ $(document).ready(function() {
     strictEqual(template(), '<<\nx\n>>');
   });
 
+  test('attempt calls a method on a defined object', function() {
+    var obj = {x: '', y: function() { return true; }, z: function() { return _.toArray(arguments).join(''); }};
+    strictEqual(_.attempt(obj, 'x'), undefined);
+    strictEqual(_.attempt(obj, 'y'), true);
+    strictEqual(_.attempt(obj, 'z', 1, 2, 3), '123');
+    strictEqual(_.attempt(null, 'x'), undefined);
+    strictEqual(_.attempt(undefined, 'x'), undefined);
+  });
+
 });

--- a/underscore.js
+++ b/underscore.js
@@ -1095,6 +1095,15 @@
     return _.isFunction(value) ? value.call(object) : value;
   };
 
+  // If object is not undefined or null then invoke the named `method` function
+  // with `object` as context and arguments; otherwise, return undefined.
+  _.attempt = function(object, method) {
+    if (object == null) return void 0;
+    var func = object[method];
+    var args = slice.call(arguments, 2);
+    return _.isFunction(func) ? func.apply(object, args) : void 0;
+  };
+
   // Add your own custom functions to the Underscore object.
   _.mixin = function(obj) {
     each(_.functions(obj), function(name) {


### PR DESCRIPTION
A helper function, similar to Rails' `try`, that will call the method on object, unless object is undefined or null. Passes the 3rd+ argument as the arguments to the method.

Often when cleaning up Backbone views, I need to remove a subview that may have been attached:

``` javascript
if (this.subView && this.subView.close) { this.subView.close(); }
```

`_.attempt` will do the same, turning that into:

``` javascript
_.attempt(this.subView, 'close');
```

This is extremely similar to `_.result`, with the distinction that you use `attempt` to call a method on an object that may or may not be defined and you can pass arguments, not just evaluating a (potentially function) property.
