### PR TITLE
Prevent false negatives for _.throttle tests.

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -239,10 +239,10 @@ $(document).ready(function() {
 
     var time = new Date;
     while (new Date - time < 350) throttledIncr();
-    ok(counter === 3);
+    ok(counter <= 3);
 
     _.delay(function() {
-      equal(counter, 4);
+      ok(counter <= 4);
       start();
     }, 200);
   });


### PR DESCRIPTION
This seems alright to me and @jdalton points out that he uses something similar.  It does alter what we're testing a bit though, which is why I'm unsure of it.
