### PR TITLE
Typo in expectation, extend really does copy undefined properties

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -52,7 +52,7 @@ $(document).ready(function() {
     result = _.extend({x:'x'}, {a:'a', x:2}, {a:'b'});
     ok(_.isEqual(result, {x:2, a:'b'}), 'extending from multiple source objects last property trumps');
     result = _.extend({}, {a: void 0, b: null});
-    equal(_.keys(result).join(''), 'ab', 'extend does copy undefined values');
+    equal(_.keys(result).join(''), 'ab', 'extend copies undefined values');
 
     try {
       result = {};


### PR DESCRIPTION
Based on https://github.com/jashkenas/underscore/issues/123, it appears this assertion was inverted but the language was never updated to reflect it.
