### PR TITLE
Add _.hasEvery and _.hasSome shortcut methods

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -574,4 +574,18 @@ $(document).ready(function() {
      child.prototype = obj;
      ok (_.has(child, "foo") == false, "has() does not check the prototype chain for a property.")
   });
+
+  test("hasEvery", function () {
+     var obj = {foo: "bar", baz: "bax"};
+     ok (_.hasEvery(obj, ["foo", "baz"]), "hasEvery() checks that the object has every property.");
+     ok (_.hasEvery(obj, ["foo", "baz", "bax"]) == false, "hasEvery() returns false if the object doesn't have every property.");
+     ok (_.hasAll(obj, ["foo", "baz"]), 'aliased as "hasAll"');
+  });
+
+  test("hasSome", function () {
+     var obj = {foo: "bar", baz: "bax"};
+     ok (_.hasSome(obj, ["foo", "zab"]), "hasSome() checks that the object has some of the properties.");
+     ok (_.hasSome(obj, ["oof", "zab"]) == false, "hasSome() returns false if the object doesn't have any of the properties.");
+     ok (_.hasAny(obj, ["foo", "zab"]), 'aliased as "hasAny"');
+  });
 });

--- a/underscore.js
+++ b/underscore.js
@@ -1028,6 +1028,15 @@
     return hasOwnProperty.call(obj, key);
   };
 
+  // Add some hasProperties shortcut methods: hasEvery, hasSome
+  each(['Every', 'Some', 'All', 'Any'], function(name) {
+    _['has' + name] = function(obj, keys) {
+      return _[name.toLowerCase()].call(undefined, keys, function(key) {
+        return _.has(obj, key);
+      });
+    };
+  });
+
   // Utility Functions
   // -----------------
 


### PR DESCRIPTION
I found `_.hasEvery` to be useful in a couple situations. I haven't needed to use `_.hasSome` yet but I threw it in anyway to match `_.every` and `_.some`.

```
_(object).hasEvery(keys);
_(object).hasSome(keys);
```
