### PR TITLE
Update underscore.js

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1117,7 +1117,10 @@
   // Add your own custom functions to the Underscore object.
   _.mixin = function(obj) {
     each(_.functions(obj), function(name) {
-      var func = _[name] = obj[name];
+      var func = obj[name];
+      if (!_[name]) {
+        _[name] = obj[name];
+      }
       _.prototype[name] = function() {
         var args = [this._wrapped];
         push.apply(args, arguments);


### PR DESCRIPTION
Avoid extra copy for _[name] for the OOP call _.mixin(_)
