### PR TITLE
Do not use native ES5 methods by default since for loops are faster

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -31,15 +31,15 @@
   // All **ECMAScript 5** native function implementations that we hope to use
   // are declared here.
   var
-    nativeForEach      = ArrayProto.forEach,
-    nativeMap          = ArrayProto.map,
-    nativeReduce       = ArrayProto.reduce,
-    nativeReduceRight  = ArrayProto.reduceRight,
-    nativeFilter       = ArrayProto.filter,
-    nativeEvery        = ArrayProto.every,
-    nativeSome         = ArrayProto.some,
-    nativeIndexOf      = ArrayProto.indexOf,
-    nativeLastIndexOf  = ArrayProto.lastIndexOf,
+    nativeForEach,
+    nativeMap,
+    nativeReduce,
+    nativeReduceRight,
+    nativeFilter,
+    nativeEvery,
+    nativeSome,
+    nativeIndexOf,
+    nativeLastIndexOf,
     nativeIsArray      = Array.isArray,
     nativeKeys         = Object.keys,
     nativeBind         = FuncProto.bind;
@@ -67,6 +67,31 @@
   // Current version.
   _.VERSION = '1.5.2';
 
+  // Switches usage ES5 Array methods on/off
+  _.useE55Arrays = function(useEs5) {
+    var useEs5 = _.isUndefined(useEs5) || !!useEs5;
+    if (useEs5) {
+      nativeForEach      = ArrayProto.forEach;
+      nativeMap          = ArrayProto.map;
+      nativeReduce       = ArrayProto.reduce;
+      nativeReduceRight  = ArrayProto.reduceRight;
+      nativeFilter       = ArrayProto.filter;
+      nativeEvery        = ArrayProto.every;
+      nativeSome         = ArrayProto.some;
+      nativeIndexOf      = ArrayProto.indexOf;
+      nativeLastIndexOf  = ArrayProto.lastIndexOf;
+    } else {
+      nativeForEach      = null;
+      nativeMap          = null;
+      nativeReduce       = null;
+      nativeReduceRight  = null;
+      nativeFilter       = null;
+      nativeEvery        = null;
+      nativeSome         = null;
+      nativeIndexOf      = null;
+      nativeLastIndexOf  = null;
+    }
+  }
   // Collection Functions
   // --------------------
 


### PR DESCRIPTION
`for` loops are way faster than native ES5 array traversal methods methods due to JIT optimizations. 
Hence use `for` loops by default and provide a method to turn on/off usage of these ES5 methods

JsPerf:
http://jsperf.com/array-filter-vs-for-loop
http://jsperf.com/jqeach-vs-for-vs-foreach
