### PR TITLE
Values returns empty array for non objects.

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -17,6 +17,7 @@ $(document).ready(function() {
   test("values", function() {
     equal(_.values({one: 1, two: 2}).join(', '), '1, 2', 'can extract the values from an object');
     equal(_.values({one: 1, two: 2, length: 3}).join(', '), '1, 2, 3', '... even when one of them is "length"');
+    deepEqual(_.values(null), []);
   });
 
   test("pairs", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -775,6 +775,7 @@
 
   // Retrieve the values of an object's properties.
   _.values = function(obj) {
+    if (!_.isObject(obj)) return [];
     var keys = _.keys(obj);
     var length = keys.length;
     var values = new Array(length);


### PR DESCRIPTION
As [pointed out](http://git.io/2w0MPQ) in 481798a94e6770c570a4b3352cf4bf1292f19063, `_.values` previously returned an empty array for non-object values.  While I don't feel strongly about this, it seems unnecessary to break backward compatibility here.
