### PR TITLE
Shorter isEmpty method

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -973,7 +973,7 @@
   // An "empty" object has no enumerable own-properties.
   _.isEmpty = function(obj) {
     if (obj == null) return true;
-    if (_.isArray(obj) || _.isString(obj)) return obj.length === 0;
+    if (obj.length === +obj.length) return obj.length === 0;
     for (var key in obj) if (_.has(obj, key)) return false;
     return true;
   };


### PR DESCRIPTION
Check for a numeric length property instead of checking `_.isArray(obj) || _.isString(obj)` for consistency with the rest of the codebase. Allows it to work with nodelists, arguments, etc.
