### PR TITLE
Document in _.memoize why _.identity is a first-argument hasher

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -634,6 +634,7 @@
   // Memoize an expensive function by storing its results.
   _.memoize = function(func, hasher) {
     var memo = {};
+    // _.identity will return just the *first* argument when `.apply`ed to `arguments`.
     hasher || (hasher = _.identity);
     return function() {
       var key = hasher.apply(this, arguments);


### PR DESCRIPTION
With a comment, document the nonobvious behavior of `_.identity` in this context.

I wrote this comment to accompany the following sentence from [the current docs for `_.memoize`](http://documentcloud.github.io/underscore/#memoize):

> The default **hashFunction** just uses the first argument to the memoized function as the key.

I looked in the code, but couldn’t see how that was the case. The code quoted in [Issue #137](https://github.com/jashkenas/underscore/issues/137) was no longer there. I wondered if that sentence in the documentation was out-of-date. It took me a while to notice that the use of `apply` over `call` changed `_.identity` from returning `arguments` to returning the first argument.

I found the code confusing because I thought that a function named `identity` would change nothing. Thus, I assumed, when passed its arguments, it would return its arguments unchanged. So **another possible way** to clarify the code, instead of adding a comment, would be to create a local variable `var returnFirstArgument = _.identity;`, and then use that function as the default `hasher`. This moves the documentation out of a comment and into the code, which is generally good in principle. But that change makes a library function run an additional statement, so I don't know if you would find that change worth the tiny slowdown it would cause.
