### PR TITLE
Change debounce so that it calls immediately if wait is 0

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -706,8 +706,8 @@
           if (!immediate) result = func.apply(context, args);
         }
       };
-      var callNow = immediate && !timeout;
-      if (!timeout) {
+      var callNow = immediate && !timeout || wait === 0;
+      if (!timeout && wait > 0) {
         timeout = setTimeout(later, wait);
       }
       if (callNow) result = func.apply(context, args);


### PR DESCRIPTION
Right now, if _.debounce is called with a wait of 0, it will set a timeout for the later callback before calling the func. As a result it takes a noticeable period amount of time for the callback to call, this can be obvious and annoying in graphics application / animation.

Admittedly setting a debounce with a wait of 0 is an edge case, but might occur if it is given as a parameter, or if debouncing is activated dynamically based on performance considerations.

This change has an extremely low touch and the logic only applies in the case where wait === 0.
