### PR TITLE
Use _.identity in _.sortBy if iterator is not specified

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -346,6 +346,10 @@ $(document).ready(function() {
     });
 
     deepEqual(actual, collection, 'sortBy should be stable');
+
+  	var list = ["q", "w", "e", "r", "t", "y"];
+    var sorted = _.sortBy(list);
+    equal(sorted.join(''), 'eqrtwy', 'uses _.identity if iterator is not specified');
   });
 
   test('groupBy', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -315,7 +315,7 @@
 
   // Sort the object's values by a criterion produced by an iterator.
   _.sortBy = function(obj, value, context) {
-    var iterator = lookupIterator(value);
+    var iterator = value == null ? _.identity : lookupIterator(value);
     return _.pluck(_.map(obj, function(value, index, list) {
       return {
         value: value,


### PR DESCRIPTION
For me, it was a suprise, that `_.sortBy` without iterator is no-op.

``` js
_.sortBy([3, 2, 1]); // returns [3, 2, 1];
```

Thiis PR makes `_.sortBy` use `_.identity` as default iterator, same as eg `_.groupBy` so:

``` js
_.sortBy([3, 2, 1]); // returns [1, 2, 3]
```
