### PR TITLE
recursive _.pluck() when passed multiple keys

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -249,8 +249,9 @@ $(document).ready(function() {
   });
 
   test('pluck', function() {
-    var people = [{name : 'moe', age : 30}, {name : 'curly', age : 50}];
+    var people = [{name : 'moe', age : {years : 30}}, {name : 'curly', age : {years : 50}}];
     equal(_.pluck(people, 'name').join(', '), 'moe, curly', 'pulls names out of objects');
+    equal(_.pluck(people, 'age', 'years').join(', '), '30, 50', 'recursively plucks properties');
   });
 
   test('where', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -232,7 +232,12 @@
 
   // Convenience version of a common use case of `map`: fetching a property.
   _.pluck = function(obj, key) {
-    return _.map(obj, function(value){ return value[key]; });
+    if (arguments.length > 2) {
+      var otherKeys = _.toArray(arguments).slice(2);
+      return _.pluck.apply(this, [_.pluck(obj, key)].concat(otherKeys));
+    } else {
+      return _.map(obj, function(value){ return value[key]; });
+    }
   };
 
   // Convenience version of a common use case of `filter`: selecting only objects


### PR DESCRIPTION
_.pluck() calls itself recursively when passed multiple key arguments. Like so

``` javascript
var orders = [
    {orderId: 123, shipping: {method: 'express', cost: 995} },
    {orderId: 124, shipping: {method: 'standard', cost: 495} }
];
_.pluck(orders, 'shipping', 'cost')
=> [995, 495]
```

(branch with updated doco: https://github.com/joelplane/underscore/tree/pluck-take-multiple-args-with-doco)
