### PR TITLE
UMD-ready Underscore

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -3,16 +3,41 @@
 //     (c) 2009-2013 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
 //     Underscore may be freely distributed under the MIT license.
 
-(function() {
+// UMD module definition (https://github.com/umdjs/umd).
+(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(factory);
+  }
+  else if (typeof exports === 'object') {
+    // Export the Underscore object for **Node.js**, with
+    // backwards-compatibility for the old `require()` API.
+    if (typeof module === 'object' && module.exports) {
+      exports = module.exports = factory();
+    }
+    exports._ = factory();
+  } else {
+    // Save the previous value of the `_` variable.
+    var previousUnderscore = root._;
+
+    // Instantiate the factory.
+    var underscore = factory();
+
+    // Browser globals. Add `_` as a global object via a string identifier, for
+    // Closure Compiler "advanced" mode.
+    root._ = underscore;
+
+    // Run Underscore.js in *noConflict* mode, returning the `_` variable to its
+    // previous owner. Returns a reference to the Underscore object.
+    root._.noConflict = function() {
+      root._ = previousUnderscore;
+      return underscore;
+    };
+  }
+}(this, function() {
 
   // Baseline setup
   // --------------
-
-  // Establish the root object, `window` in the browser, or `exports` on the server.
-  var root = this;
-
-  // Save the previous value of the `_` variable.
-  var previousUnderscore = root._;
 
   // Establish the object that gets returned to break out of a loop iteration.
   var breaker = {};
@@ -50,19 +75,6 @@
     if (!(this instanceof _)) return new _(obj);
     this._wrapped = obj;
   };
-
-  // Export the Underscore object for **Node.js**, with
-  // backwards-compatibility for the old `require()` API. If we're in
-  // the browser, add `_` as a global object via a string identifier,
-  // for Closure Compiler "advanced" mode.
-  if (typeof exports !== 'undefined') {
-    if (typeof module !== 'undefined' && module.exports) {
-      exports = module.exports = _;
-    }
-    exports._ = _;
-  } else {
-    root._ = _;
-  }
 
   // Current version.
   _.VERSION = '1.5.2';
@@ -1049,10 +1061,8 @@
   // Utility Functions
   // -----------------
 
-  // Run Underscore.js in *noConflict* mode, returning the `_` variable to its
-  // previous owner. Returns a reference to the Underscore object.
+  // *noConflict* stub. Returns a reference to the Underscore object.
   _.noConflict = function() {
-    root._ = previousUnderscore;
     return this;
   };
 
@@ -1273,4 +1283,6 @@
 
   });
 
-}).call(this);
+  return _;
+
+}));


### PR DESCRIPTION
Underscore.js is now an [UMD](https://github.com/umdjs/umd) module.

The UMD definition is based on https://github.com/umdjs/umd/blob/master/returnExports.js.

A stub `noConflict` function is provided in Underscore.js to retain API compatibility.
The real `noConflict` method is only defined once if Underscore.js is not loaded as-is in the browser (ie. as an AMD-module or in a Node.js environment).
