### PR TITLE
Add link to `toolz` project in links section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1874,7 +1874,7 @@ _([1, 2, 3]).value();
       <p>
         <a href="http://toolz.readthedocs.org/">PyToolz</a>, a Python port
         that extends itertools and functools to include much of the
-        Underscore API
+        Underscore API.
       </p>
 
       <h2 id="changelog">Change Log</h2>


### PR DESCRIPTION
This adds a link to `toolz`, a similar project in Python.

See http://toolz.readthedocs.org/en/latest/api.html 
