### PR TITLE
Fix _.intersection to take intersection with a none array

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -111,6 +111,8 @@ $(document).ready(function() {
     equal(result.join(''), 'moe', 'works on an arguments object');
     var theSixStooges = ['moe', 'moe', 'curly', 'curly', 'larry', 'larry'];
     equal(_.intersection(theSixStooges, leaders).join(''), 'moe', 'returns a duplicate-free array');
+    equal(_.intersection(stooges, 'moe').join(''), 'moe', 'can take the set intersection of some arrays with a none array');
+    equal(_.intersection('moe', stooges).join(''), 'moe', 'can take the set intersection of some arrays with a none array as the first parameter');
   });
 
   test("union", function() {
@@ -132,6 +134,15 @@ $(document).ready(function() {
   test("difference", function() {
     var result = _.difference([1, 2, 3], [2, 30, 40]);
     equal(result.join(' '), '1 3', 'takes the difference of two arrays');
+
+    result = _.difference([1], 2);
+    equal(result.join(' '), '1', 'takes the difference of an array and a none array');
+
+    result = _.difference(1, [2]);
+    equal(result.join(' '), '1', 'takes the difference of a none array and an array');
+
+    result = _.difference(1, 2);
+    equal(result.join(' '), '1', 'takes the difference of two none array');
 
     result = _.difference([1, 2, 3, 4], [2, 30, 40], [1, 11, 111]);
     equal(result.join(' '), '3 4', 'takes the difference of three arrays');

--- a/underscore.js
+++ b/underscore.js
@@ -495,10 +495,11 @@
   // Produce an array that contains every item shared between all the
   // passed-in arrays.
   _.intersection = function(array) {
+    array = _.isArray(array) ? array : (_.isArguments(array) ? slice.call(array) : [array]);
     var rest = slice.call(arguments, 1);
     return _.filter(_.uniq(array), function(item) {
       return _.every(rest, function(other) {
-        return _.indexOf(other, item) >= 0;
+        return other === item || _.indexOf(other, item) >= 0;
       });
     });
   };
@@ -506,6 +507,7 @@
   // Take the difference between one array and a number of other arrays.
   // Only the elements present in just the first array will remain.
   _.difference = function(array) {
+    array = _.isArray(array) ? array : (_.isArguments(array) ? slice.call(array) : [array]);
     var rest = concat.apply(ArrayProto, slice.call(arguments, 1));
     return _.filter(array, function(value){ return !_.contains(rest, value); });
   };


### PR DESCRIPTION
It seems that underscore considers none array arguments of sets related operations as single-member sets.

``` javascript
_.union([1], [2])
// => [1, 2]
_.union([1], 2)
// => [1, 2]

_.difference([1, 2], [1])
// => [2]
_.difference([1, 2], 1)
// => [2]
```

But `_.intersection` acts differently:

``` javascript
_.intersection([1, 2], [1])
// => [1]
_.intersection([1, 2], 1)
// => []
```

The suggested changes can fix the problem.
