### PR TITLE
Add diff, docs, and date links to the changelog

### DIFF
--- a/index.html
+++ b/index.html
@@ -1874,7 +1874,7 @@ _([1, 2, 3]).value();
       <h2 id="changelog">Change Log</h2>
 
       <p>
-        <b class="header">1.5.2</b> &mdash; <small><i>Sept. 7, 2013</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.5.1...1.5.2">Diff</a><br />
+        <b class="header">1.5.2</b> &mdash; <small><i>Sept. 7, 2013</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.5.1...1.5.2">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.5.2/index.html">Docs</a><br />
         <ul>
           <li>
             Added an <tt>indexBy</tt> function, which fits in alongside its 
@@ -1893,7 +1893,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.5.1</b> &mdash; <small><i>Jul. 8, 2013</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.5.0...1.5.1">Diff</a><br />
+        <b class="header">1.5.1</b> &mdash; <small><i>Jul. 8, 2013</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.5.0...1.5.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.5.1/index.html">Docs</a><br />
         <ul>
           <li>
             Removed <tt>unzip</tt>, as it's simply the application of <tt>zip</tt>
@@ -1904,7 +1904,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.5.0</b> &mdash; <small><i>Jul. 6, 2013</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.4...1.5.0">Diff</a><br />
+        <b class="header">1.5.0</b> &mdash; <small><i>Jul. 6, 2013</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.4...1.5.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.5.0/index.html">Docs</a><br />
         <ul>
           <li>
             Added a new <tt>unzip</tt> function, as the inverse of <tt>_.zip</tt>.
@@ -1935,7 +1935,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.4.4</b> &mdash; <small><i>Jan. 30, 2013</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.3...1.4.4">Diff</a><br />
+        <b class="header">1.4.4</b> &mdash; <small><i>Jan. 30, 2013</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.3...1.4.4">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.4.4/index.html">Docs</a><br />
         <ul>
           <li>
             Added <tt>_.findWhere</tt>, for finding the first element in a list
@@ -1961,7 +1961,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.4.3</b> &mdash; <small><i>Dec. 4, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.2...1.4.3">Diff</a><br />
+        <b class="header">1.4.3</b> &mdash; <small><i>Dec. 4, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.2...1.4.3">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.4.3/index.html">Docs</a><br />
         <ul>
           <li>
             Improved Underscore compatibility with Adobe's JS engine that can be
@@ -1986,7 +1986,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.4.2</b> &mdash; <small><i>Oct. 1, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.1...1.4.2">Diff</a><br />
+        <b class="header">1.4.2</b> &mdash; <small><i>Oct. 1, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.1...1.4.2">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.4.2/index.html">Docs</a><br />
         <ul>
           <li>
             For backwards compatibility, returned to pre-1.4.0 behavior when
@@ -1997,7 +1997,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.4.1</b> &mdash; <small><i>Oct. 1, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.0...1.4.1">Diff</a><br />
+        <b class="header">1.4.1</b> &mdash; <small><i>Oct. 1, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.0...1.4.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.4.1/index.html">Docs</a><br />
         <ul>
           <li>
             Fixed a 1.4.0 regression in the <tt>lastIndexOf</tt> function.
@@ -2006,7 +2006,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.4.0</b> &mdash; <small><i>Sept. 27, 2012</i></small>  &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.3.3...1.4.0">Diff</a><br />
+        <b class="header">1.4.0</b> &mdash; <small><i>Sept. 27, 2012</i></small>  &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.3.3...1.4.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.4.0/index.html">Docs</a><br />
         <ul>
           <li>
             Added a <tt>pairs</tt> function, for turning a JavaScript object
@@ -2071,7 +2071,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.3.3</b> &mdash; <small><i>April 10, 2012</i></small><br />
+        <b class="header">1.3.3</b> &mdash; <small><i>April 10, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.3.1...1.3.3">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.3.3/index.html">Docs</a><br />
         <ul>
           <li>
             Many improvements to <tt>_.template</tt>, which now provides the
@@ -2114,7 +2114,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.3.1</b> &mdash; <small><i>Jan. 23, 2012</i></small><br />
+        <b class="header">1.3.1</b> &mdash; <small><i>Jan. 23, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.3.0...1.3.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.3.1/index.html">Docs</a><br />
         <ul>
           <li>
             Added an <tt>_.has</tt> function, as a safer way to use <tt>hasOwnProperty</tt>.
@@ -2133,7 +2133,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.3.0</b> &mdash; <small><i>Jan. 11, 2012</i></small><br />
+        <b class="header">1.3.0</b> &mdash; <small><i>Jan. 11, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.4...1.3.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.3.0/index.html">Docs</a><br />
         <ul>
           <li>
             Removed AMD (RequireJS) support from Underscore. If you'd like to use
@@ -2144,7 +2144,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.2.4</b> &mdash; <small><i>Jan. 4, 2012</i></small><br />
+        <b class="header">1.2.4</b> &mdash; <small><i>Jan. 4, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.3...1.2.4">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.2.4/index.html">Docs</a><br />
         <ul>
           <li>
             You now can (and probably should, as it's simpler)
@@ -2167,7 +2167,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.2.3</b> &mdash; <small><i>Dec. 7, 2011</i></small><br />
+        <b class="header">1.2.3</b> &mdash; <small><i>Dec. 7, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.2...1.2.3">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.2.3/index.html">Docs</a><br />
         <ul>
           <li>
             Dynamic scope is now preserved for compiled <tt>_.template</tt> functions,
@@ -2185,7 +2185,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.2.2</b> &mdash; <small><i>Nov. 14, 2011</i></small><br />
+        <b class="header">1.2.2</b> &mdash; <small><i>Nov. 14, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.1...1.2.2">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.2.1/index.html">Docs</a><br />
         <ul>
           <li>
             Continued tweaks to <tt>_.isEqual</tt> semantics. Now JS primitives are
@@ -2208,7 +2208,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.2.1</b> &mdash; <small><i>Oct. 24, 2011</i></small><br />
+        <b class="header">1.2.1</b> &mdash; <small><i>Oct. 24, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.0...1.2.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.2.1/index.html">Docs</a><br />
         <ul>
           <li>
             Several important bug fixes for <tt>_.isEqual</tt>, which should now
@@ -2247,7 +2247,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.2.0</b> &mdash; <small><i>Oct. 5, 2011</i></small><br />
+        <b class="header">1.2.0</b> &mdash; <small><i>Oct. 5, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.7...1.2.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.2.0/index.html">Docs</a><br />
         <ul>
           <li>
             The <tt>_.isEqual</tt> function now
@@ -2278,7 +2278,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.1.7</b> &mdash; <small><i>July 13, 2011</i></small><br />
+        <b class="header">1.1.7</b> &mdash; <small><i>July 13, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.6...1.1.7">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.1.7/index.html">Docs</a><br />
         Added <tt>_.groupBy</tt>, which aggregates a collection into groups of like items.
         Added <tt>_.union</tt> and <tt>_.difference</tt>, to complement the
         (re-named) <tt>_.intersection</tt>.
@@ -2289,7 +2289,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.1.6</b> &mdash; <small><i>April 18, 2011</i></small><br />
+        <b class="header">1.1.6</b> &mdash; <small><i>April 18, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.5...1.1.6">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.1.6/index.html">Docs</a><br />
         Added <tt>_.after</tt>, which will return a function that only runs after
         first being called a specified number of times.
         <tt>_.invoke</tt> can now take a direct function reference.
@@ -2300,7 +2300,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.1.5</b> &mdash; <small><i>Mar 20, 2011</i></small><br />
+        <b class="header">1.1.5</b> &mdash; <small><i>Mar 20, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.4...1.1.5">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.1.5/index.html">Docs</a><br />
         Added an <tt>_.defaults</tt> function, for use merging together JS objects
         representing default options.
         Added an <tt>_.once</tt> function, for manufacturing functions that should
@@ -2313,7 +2313,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.1.4</b> &mdash; <small><i>Jan 9, 2011</i></small><br />
+        <b class="header">1.1.4</b> &mdash; <small><i>Jan 9, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.3...1.1.4">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.1.4/index.html">Docs</a><br />
         Improved compliance with ES5's Array methods when passing <tt>null</tt>
         as a value. <tt>_.wrap</tt> now correctly sets <tt>this</tt> for the
         wrapped function. <tt>_.indexOf</tt> now takes an optional flag for
@@ -2323,7 +2323,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.1.3</b> &mdash; <small><i>Dec 1, 2010</i></small><br />
+        <b class="header">1.1.3</b> &mdash; <small><i>Dec 1, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.2...1.1.3">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.1.3/index.html">Docs</a><br />
         In CommonJS, Underscore may now be required with just: <br />
         <tt>var _ = require("underscore")</tt>.
         Added <tt>_.throttle</tt> and <tt>_.debounce</tt> functions.
@@ -2340,21 +2340,21 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.1.2</b><br />
+        <b class="header">1.1.2</b> &mdash; <small><i>Oct 15, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.1...1.1.2">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.1.2/index.html">Docs</a><br />
         Fixed <tt>_.contains</tt>, which was mistakenly pointing at
         <tt>_.intersect</tt> instead of <tt>_.include</tt>, like it should
         have been. Added <tt>_.unique</tt> as an alias for <tt>_.uniq</tt>.
       </p>
 
       <p>
-        <b class="header">1.1.1</b><br />
+        <b class="header">1.1.1</b> &mdash; <small><i>Oct 5, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.0...1.1.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.1.1/index.html">Docs</a><br />
         Improved the speed of <tt>_.template</tt>, and its handling of multiline
         interpolations. Ryan Tenney contributed optimizations to many Underscore
         functions. An annotated version of the source code is now available.
       </p>
 
       <p>
-        <b class="header">1.1.0</b><br />
+        <b class="header">1.1.0</b> &mdash; <small><i>Aug 18, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.4...1.1.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.1.0/index.html">Docs</a><br />
         The method signature of <tt>_.reduce</tt> has been changed to match
         the ECMAScript 5 signature, instead of the Ruby/Prototype.js version.
         This is a backwards-incompatible change. <tt>_.template</tt> may now be
@@ -2363,33 +2363,33 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">1.0.4</b><br />
+        <b class="header">1.0.4</b> &mdash; <small><i>Jun 22, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.3...1.0.4">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.0.4/index.html">Docs</a><br />
         <a href="http://themoell.com/">Andri Möll</a> contributed the <tt>_.memoize</tt>
         function, which can be used to speed up expensive repeated computations
         by caching the results.
       </p>
 
       <p>
-        <b class="header">1.0.3</b><br />
+        <b class="header">1.0.3</b> &mdash; <small><i>Jun 14, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.2...1.0.3">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.0.3/index.html">Docs</a><br />
         Patch that makes <tt>_.isEqual</tt> return <tt>false</tt> if any property
         of the compared object has a <tt>NaN</tt> value. Technically the correct
         thing to do, but of questionable semantics. Watch out for NaN comparisons.
       </p>
 
       <p>
-        <b class="header">1.0.2</b><br />
+        <b class="header">1.0.2</b> &mdash; <small><i>Mar 23, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.1...1.0.2">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.0.2/index.html">Docs</a><br />
         Fixes <tt>_.isArguments</tt> in recent versions of Opera, which have
         arguments objects as real Arrays.
       </p>
 
       <p>
-        <b class="header">1.0.1</b><br />
+        <b class="header">1.0.1</b> &mdash; <small><i>Mar 19, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.0...1.0.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.0.1/index.html">Docs</a><br />
         Bugfix for <tt>_.isEqual</tt>, when comparing two objects with the same
         number of undefined keys, but with different names.
       </p>
 
       <p>
-        <b class="header">1.0.0</b><br />
+        <b class="header">1.0.0</b> &mdash; <small><i>Mar 18, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.6.0...1.0.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.0.0/index.html">Docs</a><br />
         Things have been stable for many months now, so Underscore is now
         considered to be out of beta, at <b>1.0</b>. Improvements since <b>0.6</b>
         include <tt>_.isBoolean</tt>, and the ability to have <tt>_.extend</tt>
@@ -2397,7 +2397,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">0.6.0</b><br />
+        <b class="header">0.6.0</b> &mdash; <small><i>Feb 24, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.4...0.5.5">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.5.5/index.html">Docs</a><br />
         Major release. Incorporates a number of
         <a href="http://github.com/ratbeard">Mile Frawley's</a> refactors for
         safer duck-typing on collection functions, and cleaner internals. A new
@@ -2417,32 +2417,32 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">0.5.7</b><br />
+        <b class="header">0.5.7</b> &mdash; <small><i>Jan 20, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.5...0.5.7">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.5.7/index.html">Docs</a><br />
         A safer implementation of <tt>_.isArguments</tt>, and a
         faster <tt>_.isNumber</tt>,<br />thanks to
         <a href="http://jedschmidt.com/">Jed Schmidt</a>.
       </p>
 
       <p>
-        <b class="header">0.5.6</b><br />
+        <b class="header">0.5.6</b>
         Customizable delimiters for <tt>_.template</tt>, contributed by
         <a href="http://github.com/iamnoah">Noah Sloan</a>.
       </p>
 
       <p>
-        <b class="header">0.5.5</b><br />
+        <b class="header">0.5.5</b> &mdash; <small><i>Jan 9, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.4...0.5.5">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.5.5/index.html">Docs</a><br />
         Fix for a bug in MobileSafari's OOP-wrapper, with the arguments object.
       </p>
 
       <p>
-        <b class="header">0.5.4</b><br />
+        <b class="header">0.5.4</b> &mdash; <small><i>Jan 5, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.2...0.5.4">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.5.4/index.html">Docs</a><br />
         Fix for multiple single quotes within a template string for
         <tt>_.template</tt>. See:
         <a href="http://www.west-wind.com/Weblog/posts/509108.aspx">Rick Strahl's blog post</a>.
       </p>
 
       <p>
-        <b class="header">0.5.2</b><br />
+        <b class="header">0.5.2</b> &mdash; <small><i>Jan 1, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.1...0.5.2">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.5.2/index.html">Docs</a><br />
         New implementations of <tt>isArray</tt>, <tt>isDate</tt>, <tt>isFunction</tt>,
         <tt>isNumber</tt>, <tt>isRegExp</tt>, and <tt>isString</tt>, thanks to
         a suggestion from
@@ -2458,7 +2458,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">0.5.1</b><br />
+        <b class="header">0.5.1</b> &mdash; <small><i>Dec 9, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.0...0.5.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.5.1/index.html">Docs</a><br />
         Added an <tt>_.isArguments</tt> function. Lots of little safety checks
         and optimizations contributed by
         <a href="http://github.com/iamnoah/">Noah Sloan</a> and
@@ -2466,7 +2466,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">0.5.0</b><br />
+        <b class="header">0.5.0</b> &mdash; <small><i>Dec 7, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.7...0.5.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.5.0/index.html">Docs</a><br />
         <b>[API Changes]</b> <tt>_.bindAll</tt> now takes the context object as
         its first parameter. If no method names are passed, all of the context
         object's methods are bound to it, enabling chaining and easier binding.
@@ -2479,7 +2479,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">0.4.7</b><br />
+        <b class="header">0.4.7</b> &mdash; <small><i>Dec 6, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.6...0.4.7">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.4.7/index.html">Docs</a><br />
         Added <tt>isDate</tt>, <tt>isNaN</tt>, and <tt>isNull</tt>, for completeness.
         Optimizations for <tt>isEqual</tt> when checking equality between Arrays
         or Dates. <tt>_.keys</tt> is now <small><i><b>25%&ndash;2X</b></i></small> faster (depending on your
@@ -2487,7 +2487,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">0.4.6</b><br />
+        <b class="header">0.4.6</b> &mdash; <small><i>Nov 30, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.5...0.4.6">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.4.6/index.html">Docs</a><br />
         Added the <tt>range</tt> function, a port of the
         <a href="http://docs.python.org/library/functions.html#range">Python
         function of the same name</a>, for generating flexibly-numbered lists
@@ -2496,7 +2496,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">0.4.5</b><br />
+        <b class="header">0.4.5</b> &mdash; <small><i>Nov 19, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.4...0.4.5">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.4.5/index.html">Docs</a><br />
         Added <tt>rest</tt> for Arrays and arguments objects, and aliased
         <tt>first</tt> as <tt>head</tt>, and <tt>rest</tt> as <tt>tail</tt>,
         thanks to <a href="http://github.com/lukesutton/">Luke Sutton</a>'s patches.
@@ -2505,24 +2505,24 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">0.4.4</b><br />
+        <b class="header">0.4.4</b> &mdash; <small><i>Nov 18, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.3...0.4.4">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.4.4/index.html">Docs</a><br />
         Added <tt>isString</tt>, and <tt>isNumber</tt>, for consistency. Fixed
         <tt>_.isEqual(NaN, NaN)</tt> to return <i>true</i> (which is debatable).
       </p>
 
       <p>
-        <b class="header">0.4.3</b><br />
+        <b class="header">0.4.3</b> &mdash; <small><i>Nov 9, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.2...0.4.3">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.4.3/index.html">Docs</a><br />
         Started using the native <tt>StopIteration</tt> object in browsers that support it.
         Fixed Underscore setup for CommonJS environments.
       </p>
 
       <p>
-        <b class="header">0.4.2</b><br />
+        <b class="header">0.4.2</b> &mdash; <small><i>Nov 9, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.2...0.4.2">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.4.2/index.html">Docs</a><br />
         Renamed the unwrapping function to <tt>value</tt>, for clarity.
       </p>
 
       <p>
-        <b class="header">0.4.1</b><br />
+        <b class="header">0.4.1</b> &mdash; <small><i>Nov 8, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.0...0.4.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.4.1/index.html">Docs</a><br />
         Chained Underscore objects now support the Array prototype methods, so
         that you can perform the full range of operations on a wrapped array
         without having to break your chain. Added a <tt>breakLoop</tt> method
@@ -2531,7 +2531,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">0.4.0</b><br />
+        <b class="header">0.4.0</b> &mdash; <small><i>Nov 7, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.3...0.4.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.4.0/index.html">Docs</a><br />
         All Underscore functions can now be called in an object-oriented style,
         like so: <tt>_([1, 2, 3]).map(...);</tt>. Original patch provided by
         <a href="http://macournoyer.com/">Marc-André Cournoyer</a>.
@@ -2541,20 +2541,20 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">0.3.3</b><br />
+        <b class="header">0.3.3</b> &mdash; <small><i>Oct 31, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.2...0.3.3">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.3.3/index.html">Docs</a><br />
         Added the JavaScript 1.8 function <tt>reduceRight</tt>. Aliased it
         as <tt>foldr</tt>, and aliased <tt>reduce</tt> as <tt>foldl</tt>.
       </p>
 
       <p>
-        <b class="header">0.3.2</b><br />
+        <b class="header">0.3.2</b> &mdash; <small><i>Oct 28, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.1...0.3.2">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.3.2/index.html">Docs</a><br />
         Now runs on stock <a href="http://www.mozilla.org/rhino/">Rhino</a>
         interpreters with: <tt>load("underscore.js")</tt>.
         Added <a href="#identity"><tt>identity</tt></a> as a utility function.
       </p>
 
       <p>
-        <b class="header">0.3.1</b><br />
+        <b class="header">0.3.1</b> &mdash; <small><i>Oct 29, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.0...0.3.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.3.1/index.html">Docs</a><br />
         All iterators are now passed in the original collection as their third
         argument, the same as JavaScript 1.6's <b>forEach</b>. Iterating over
         objects is now called with <tt>(value, key, collection)</tt>, for details
@@ -2562,7 +2562,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">0.3.0</b><br />
+        <b class="header">0.3.0</b><br /> &mdash; <small><i>Oct 29, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.2.0...0.3.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.3.0/index.html">Docs</a><br />
         Added <a href="http://github.com/dmitryBaranovskiy">Dmitry Baranovskiy</a>'s
         comprehensive optimizations, merged in
         <a href="http://github.com/kriskowal/">Kris Kowal</a>'s patches to make Underscore
@@ -2571,20 +2571,20 @@ _([1, 2, 3]).value();
       </p>
 
       <p>
-        <b class="header">0.2.0</b><br />
+        <b class="header">0.2.0</b> &mdash; <small><i>Oct 28, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.1.1...0.2.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.2.0/index.html">Docs</a><br />
         Added <tt>compose</tt> and <tt>lastIndexOf</tt>, renamed <tt>inject</tt> to
         <tt>reduce</tt>, added aliases for <tt>inject</tt>, <tt>filter</tt>,
         <tt>every</tt>, <tt>some</tt>, and <tt>forEach</tt>.
       </p>
 
       <p>
-        <b class="header">0.1.1</b><br />
+        <b class="header">0.1.1</b> &mdash; <small><i>Oct 28, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.1.0...0.1.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.1.1/index.html">Docs</a><br />
         Added <tt>noConflict</tt>, so that the "Underscore" object can be assigned to
         other variables.
       </p>
 
       <p>
-        <b class="header">0.1.0</b><br />
+        <b class="header">0.1.0</b> &mdash; <small><i>Oct 28, 2009</i></small> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.1.1/index.html">Docs</a><br />
         Initial release of Underscore.js.
       </p>
 


### PR DESCRIPTION
Bring underscore's changelog docs up to parity with Backbone's, particularly for older releases.

0.5.6 and 0.5.8 weren't tagged so they're left hanging.
