### PR TITLE
Support js minifier license comment convention

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1,8 +1,9 @@
-//     Underscore.js 1.5.2
-//     http://underscorejs.org
-//     (c) 2009-2013 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
-//     Underscore may be freely distributed under the MIT license.
-
+/*!
+    Underscore.js 1.5.2
+    http://underscorejs.org
+    (c) 2009-2013 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+    Underscore may be freely distributed under the MIT license.
+*/
 (function() {
 
   // Baseline setup


### PR DESCRIPTION
Many JS minifiers use the convention that comments starting with '/*!' are preserved as license comments. This ensures the
license comment is preserved when using these tools.
