### PR TITLE
Getter/setter-safe _.functions

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -815,7 +815,9 @@
   _.functions = _.methods = function(obj) {
     var names = [];
     for (var key in obj) {
-      if (_.isFunction(obj[key])) names.push(key);
+      try {
+        if (_.isFunction(obj[key])) names.push(key);
+      } catch (e) {};
     }
     return names.sort();
   };


### PR DESCRIPTION
The _.functions method throws an error if the object contains defined properties with getters/setters. Wrapping the conditional block of the method in a try/catch block catches these errors and allows further parsing of the object. Since the properties that throw these errors in _.isFunction are not functions _themselves_, it seems proper that they should not be included in the names array returned by _.functions.
