### PR TITLE
Deep-equality support in set operations (intersection, difference, uniq, union)

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -99,6 +99,11 @@ $(document).ready(function() {
 
     var result = (function(){ return _.uniq(arguments); })(1, 2, 1, 3, 1, 4);
     equal(result.join(', '), '1, 2, 3, 4', 'works on an arguments object');
+    
+    list = [{name:'moe'}, {name:'curly'}, {name:'larry'}, {name:'curly'}];
+    deepEqual(_.uniq(list, false, undefined, undefined, true), [{name:'moe'}, {name:'curly'}, {name:'larry'}]);
+    
+    
   });
 
   test("intersection", function() {
@@ -109,6 +114,8 @@ $(document).ready(function() {
     equal(result.join(''), 'moe', 'works on an arguments object');
     var theSixStooges = ['moe', 'moe', 'curly', 'curly', 'larry', 'larry'];
     equal(_.intersection(theSixStooges, leaders).join(''), 'moe', 'returns a duplicate-free array');
+    var stoogesOO = [{name: 'moe'}, {name: 'curly'}, {name: 'larry'}], leadersOO = [{name: 'moe'}, {name: 'groucho'}];
+    deepEqual(_.intersectionDeep(stoogesOO, leadersOO), [{name: 'moe'}], 'performs deep comparison correctly while computing intersections');
   });
 
   test("union", function() {
@@ -125,6 +132,9 @@ $(document).ready(function() {
 
     result = _.union(null, [1, 2, 3]);
     deepEqual(result, [null, 1, 2, 3]);
+    
+    result = _.unionDeep([{name: 'Marx'}, {name: 'Engels'}], [{name: 'Engels'}, {name: 'Bebel'}]);
+    deepEqual(result, [{name: 'Marx'}, {name: 'Engels'}, {name: 'Bebel'}]);
   });
 
   test("difference", function() {
@@ -133,6 +143,9 @@ $(document).ready(function() {
 
     result = _.difference([1, 2, 3, 4], [2, 30, 40], [1, 11, 111]);
     equal(result.join(' '), '3 4', 'takes the difference of three arrays');
+    
+    result = _.differenceDeep([{name: 'porkchop'}, {name: 'steak'}, {name: 'potato'}], [{name: 'steak'}]);
+    deepEqual(result, [{name: 'porkchop'}, {name: 'potato'}], 'takes object properties into account when computing set difference');
   });
 
   test('zip', function() {


### PR DESCRIPTION
Added deep-compare variants of several array/set functions, which let the user operate on sets of complex objects instead of simple values. Objects can be compared by deep equality, not just by the === operator.
New versions (*Deep) of most of the functions are needed because the originals are variadic functions and modifying their arguments would lead to total API breakage.
A few basic tests are included and seem to work. Documentation is not provided (however, the functions by design have identical semantics to their shallow-comparing counterparts apart from the comparison method).

Not sure if this is the most elegant way to do it, but I did not see a more obvious method of operating on objects by value in sets.
