### PR TITLE
_.throttle memory leak fix

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -673,6 +673,7 @@
       previous = options.leading === false ? 0 : getTime();
       timeout = null;
       result = func.apply(context, args);
+      context = args = null;
     };
     return function() {
       var now = getTime();
@@ -685,6 +686,7 @@
         timeout = null;
         previous = now;
         result = func.apply(context, args);
+        context = args = null;
       } else if (!timeout && options.trailing !== false) {
         timeout = setTimeout(later, remaining);
       }


### PR DESCRIPTION
Throttle was hanging on to previous arguments even though it doesn't need them causing a memory leak.

I was using throttle in an app of mine and couldn't figure out for the life of me how this huge DOM tree was still being leaked and tracked it down to throttle hanging onto the previous arguments even though it doesn't need them.
