### PR TITLE
problem in _.each function

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -82,7 +82,7 @@
     if (obj == null) return;
     if (nativeForEach && obj.forEach === nativeForEach) {
       obj.forEach(iterator, context);
-    } else if (obj.length === +obj.length) {
+    } else if (Object.prototype.toString.call( obj ) === '[object Array]') {
       for (var i = 0, length = obj.length; i < length; i++) {
         if (iterator.call(context, obj[i], i, obj) === breaker) return;
       }


### PR DESCRIPTION
in _.each function: 
The test for the argument "obj" to be an Array has been
if (obj.length === +obj.length)

This seems unfortunatelly not to be the best test since this
var obj = {length:1} 
is not an Array, but will be taken for one (and hence break _.each)

An alternative test criteria which would avoid this problem is:
if (Object.prototype.toString.call( obj ) === '[object Array]')
