### PR TITLE
Optionally registers as AMD module

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1284,4 +1284,16 @@
 
   });
 
+  // AMD registration happens at the end for compatibility with AMD loaders
+  // that may not enforce next-turn semantics on modules. Even though general
+  // practice for AMD registration is to be anonymous, underscore registers
+  // as a named module because, like jQuery, it is a base library that is
+  // popular enough to be bundled in a third party lib, but not be part of
+  // an AMD load request. Those cases could generate an error when an
+  // anonymous define() is called outside of a loader request.
+  if (typeof define === 'function' && define.amd) {
+    define('underscore', [], function() {
+      return _;
+    });
+  }
 }).call(this);


### PR DESCRIPTION
As requested by @jashkenas, he wanted to see what adding an optional AMD registration would look like today. This is based on the version used in https://github.com/amdjs/underscore, but more comments to help explain the specific style used.
