### PR TITLE
update documentation to reflect #1189

### DIFF
--- a/index.html
+++ b/index.html
@@ -1605,7 +1605,7 @@ _.uniqueId('contact_');
         <b class="header">escape</b><code>_.escape(string)</code>
         <br />
         Escapes a string for insertion into HTML, replacing
-        <tt>&amp;</tt>, <tt>&lt;</tt>, <tt>&gt;</tt>, <tt>&quot;</tt>, <tt>&#x27;</tt>, and <tt>&#x2F;</tt> characters.
+        <tt>&amp;</tt>, <tt>&lt;</tt>, <tt>&gt;</tt>, <tt>&quot;</tt>, and <tt>&#x27;</tt> characters.
       </p>
       <pre>
 _.escape('Curly, Larry &amp; Moe');
@@ -1616,7 +1616,7 @@ _.escape('Curly, Larry &amp; Moe');
         <br />
         The opposite of <a href="#escape"><b>escape</b></a>, replaces
         <tt>&amp;amp;</tt>, <tt>&amp;lt;</tt>, <tt>&amp;gt;</tt>,
-        <tt>&amp;quot;</tt>, <tt>&amp;#x27;</tt>, and <tt>&amp;#x2F;</tt>
+        <tt>&amp;quot;</tt>, and <tt>&amp;#x27;</tt>
         with their unescaped counterparts.
       </p>
       <pre>


### PR DESCRIPTION
`/` is now longer escaped to `&#x2F` and vice-versa
