### PR TITLE
Cleaner '_' placeholder support to partial

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -46,8 +46,8 @@ $(document).ready(function() {
 
     obj.func = _.partial(func, 'a', 'b');
     equal(obj.func('c', 'd'), 'moe a b c d', 'can partially apply');
-    obj.func = _.partial(func, _, 'f', _, 'h');
-    equal(obj.func('e', 'g'), 'moe e f g h', 'can partially apply with placeholders');
+    obj.func = _.partial(func, _, 1, _, 3);
+    equal(obj.func(0, 2), 'moe 0 1 2 3', 'can partially apply with placeholders');
     obj.func = _.partial(func, _, 'f', _, 'h');
     equal(obj.func('e', 'g', 'l', 'k', 'm'), 'moe e f g h l k m', 'can partially apply with more arguments than partials');
     obj.func = _.partial(func, _, 'f', _, 'h');

--- a/underscore.js
+++ b/underscore.js
@@ -626,19 +626,21 @@
     var partialArgs = slice.call(arguments, 1),
       placeHolders = [],
       index = -1;
-    while ((index = _.indexOf(partialArgs, _, index + 1)) !== -1) {
+    while ((index = _.indexOf(partialArgs, _, index + 1)) > -1) {
       placeHolders.push(index);
     }
 
     return function() {
-      var args = slice.call(arguments);
-      each(placeHolders, function(index) {
-        partialArgs[index] = args.length ? args.shift() : _;
-      });
+      var pLen = placeHolders.length,
+        aLen = arguments.length,
+        i = 0;
+      for (; i < pLen; i++) {
+        partialArgs[placeHolders[i]] = i < aLen ? arguments[i] : _;
+      }
 
-      return arguments.length < placeHolders.length ?
+      return aLen < pLen ?
         _.partial.apply(_, [func].concat(partialArgs)) :
-        func.apply(this, partialArgs.concat(args));
+        func.apply(this, partialArgs.concat(slice.call(arguments, i)));
     };
   };
 


### PR DESCRIPTION
This is a refactored version of PR #1318 to make the code more obvious. All features are the same, and I've added another test to make sure that calling a copy of a partial doesn't affect later calls.
