### PR TITLE
Looping utility method

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -274,31 +274,58 @@ $(document).ready(function() {
     strictEqual(template(), '<<\nx\n>>');
   });
 
-  test('iter', function () {
+  test('loop with iterator', 3, function () {
+
+    var c = 0;
+    _.loop(10, function(num, i) {
+      c = num;
+    });
+    equal(c, 9, 'iter should iterate from 0 to end of range specified');
+
+    c = 0;
+    _.loop(1, 5, function(num, i) {
+      c += num;
+    });
+    equal(c, 10, 'iter should iterate from start to end of range specified');
+
+    c = 0;
+    _.loop(2, 6, 2, function(num, i) {
+      c += num;
+    });
+    equal(c, 6, 'iter should iterate from start to stop by step of range specified');
+  });
+
+  test('loop with lazy iterator', 5, function () {
+    var loop = _.loop(10);
+    ok(_.isFunction(loop), 'loop should be a function');
+
     var err;
     try {
-      _.iter();
+      loop();
     } catch (e) {
       err = e;
     }
     ok(err instanceof TypeError, 'throws an error if an interator is not provided');
 
     var c = 0;
-    _.iter(10, function(num, i) {
+    loop(function(num, i) {
       c = num;
     });
     equal(c, 9, 'iter should iterate from 0 to end of range specified');
 
     c = 0;
-    _.iter(1, 5, function(num, i) {
+    loop = _.loop(1, 5);
+    loop(function(num, i) {
       c += num;
     });
     equal(c, 10, 'iter should iterate from start to end of range specified');
 
     c = 0;
-    _.iter(2, 6, 2, function(num, i) {
+    loop = _.loop(2, 6, 2);
+    loop(function(num, i) {
       c += num;
     });
     equal(c, 6, 'iter should iterate from start to stop by step of range specified');
+
   });
 });

--- a/underscore.js
+++ b/underscore.js
@@ -1239,13 +1239,25 @@
   };
 
   // Iterates through a range of values by piggybacking on _.range and _.each
-  _.iter = function (start, stop, step, iterator) {
+  // if no iterator function is provided then a function for the iteration
+  // is returned
+  _.loop = function (start, stop, step, iterator) {
     var args = slice.call(arguments);
 
     iterator = args.pop();
-    if (!_.isFunction(iterator)) throw new TypeError;
+    if (_.isFunction(iterator)) {
+        each(_.range.apply(_, args), iterator);
+    } else {
+        // last argument was not an iterator function, put it back
+        args.push(iterator);
+        var range = _.range.apply(_, args);
 
-    each(_.range.apply(_, args), iterator);
+        // return a function that can be reused for iteration
+        return function(iterator) {
+            if (!_.isFunction(iterator)) throw new TypeError;
+            each(range, iterator);
+        };
+    }
   };
 
 


### PR DESCRIPTION
This pull request adds a utility method to making basic looping as simple as `_.loop(10, fn);`

`_.loop` makes use of the range method signature so a user can iterate from any start, stop and use step.

`_.loop` also can be lazily run by not providing the last param (the iterator). This will cause loop to return a function that can be run with the same range and make use of different iterator functions.

The tests for this show some basic examples, but you can probably imagine why this might be useful. More over, the docs for `_.range` state how `_.range` is handy when using `_.each`. Why not combine the two?! :smile: 
