### PR TITLE
Added pass test for _.pick

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -64,6 +64,8 @@ $(document).ready(function() {
 
   test("pick", function() {
     var result;
+    result = _.pick({a:1, b:2, c:3}, function(key) { if(key !== 'b') return true; });
+    ok(_.isEqual(result, {a:1, c:3}), 'can restrict properties to those who pass the test');
     result = _.pick({a:1, b:2, c:3}, 'a', 'c');
     ok(_.isEqual(result, {a:1, c:3}), 'can restrict properties to those named');
     result = _.pick({a:1, b:2, c:3}, ['b', 'c']);

--- a/underscore.js
+++ b/underscore.js
@@ -841,10 +841,18 @@
   // Return a copy of the object only containing the whitelisted properties.
   _.pick = function(obj) {
     var copy = {};
-    var keys = concat.apply(ArrayProto, slice.call(arguments, 1));
-    each(keys, function(key) {
-      if (key in obj) copy[key] = obj[key];
-    });
+    if(typeof arguments[1] === 'function') {
+      for(var key in obj) {
+        if(arguments[1](key)) {
+          copy[key] = obj[key]
+        }
+      };
+    } else {
+      var keys = concat.apply(ArrayProto, slice.call(arguments, 1));
+      each(keys, function(key) {
+        if (key in obj) copy[key] = obj[key];
+      });
+    }
     return copy;
   };
 


### PR DESCRIPTION
It would be convenient to have pass test callback in _.pick();

for instance:

``` javascript
_.pick({a:1, b:2, c:3}, function(key) { if( key != 'b') return true});
// returns {a: 1, c:3}
```
