### PR TITLE
_.rejectWhere

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -184,6 +184,19 @@ $(document).ready(function() {
     equal(evens.join(', '), '2, 4, 6', 'rejected each odd number');
   });
 
+  test('rejectWhere', function() {
+    var odds = _.rejectWhere([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
+    equal(odds, 1, 'rejected each even number');
+
+    var context = "obj";
+
+    var evens = _.rejectWhere([1, 2, 3, 4, 5, 6], function(num){
+      equal(context, "obj");
+      return num % 2 != 0;
+    }, context);
+    equal(evens, 2, 'rejected each odd number');
+  });
+
   test('all', function() {
     ok(_.all([], _.identity), 'the empty set');
     ok(_.all([true, true, true], _.identity), 'all true values');

--- a/underscore.js
+++ b/underscore.js
@@ -188,6 +188,13 @@
     }, context);
   };
 
+  // Return the first element for which a truth test fails.
+  _.rejectWhere = function(obj, iterator, context) {
+    return _.find(obj, function(value, index, list) {
+      return !iterator.call(context, value, index, list);
+    }, context);
+  };
+
   // Determine whether all of the elements match a truth test.
   // Delegates to **ECMAScript 5**'s native `every` if available.
   // Aliased as `all`.


### PR DESCRIPTION
From #1338, adds `_.rejectWhere`.

The method returns the first element for which the iterator returns false.
It has the same signature that `_.reject` while mimicking the (inverse) behaviour of `_.findWhere`.

It may not be the expected signature/behaviour though. This PR is a starter for a discussion with the maintainers and @talkless.
## 

Disclaimer: Made for [24pullrequests.com](http://24pullrequests.com)
