### PR TITLE
Add support for specifying comparators in set ops

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -113,6 +113,31 @@ $(document).ready(function() {
     equal(_.intersection(theSixStooges, leaders).join(''), 'moe', 'returns a duplicate-free array');
   });
 
+  test("intersection with comparators", function() {
+      var compDeepEqual = _.isEqual;
+
+      var compNormal = function(a, b) { return a == b; };
+
+      var object1 = {foo: 1, bar: 2, baz: 3};
+      var object2 = {foo: 2, bar: 5, baz: 8};
+      // object3 is equivalent to object 1
+      var object3 = {foo: 1, bar: 2, baz: 3};
+
+      var big_set = [object1, object2];
+      var smaller_set = [object3];
+      var result = _.intersection(compNormal, big_set, smaller_set);
+
+      // With ==, the objects aren't equal so no objects intersect
+      equal(JSON.stringify(result), '[]');
+
+      // With deep equality, the object should be removed
+      result = _.intersection(compDeepEqual, big_set, smaller_set);
+      equal(JSON.stringify(result), '[{"foo":1,"bar":2,"baz":3}]');
+
+      result = _.deepIntersection(big_set, smaller_set);
+      equal(JSON.stringify(result), '[{"foo":1,"bar":2,"baz":3}]');
+  });
+
   test("union", function() {
     var result = _.union([1, 2, 3], [2, 30, 1], [1, 40]);
     equal(result.join(' '), '1 2 3 30 40', 'takes the union of a list of arrays');
@@ -128,6 +153,34 @@ $(document).ready(function() {
     result = _.union(null, [1, 2, 3]);
     deepEqual(result, [null, 1, 2, 3]);
   });
+  
+  test("union with comparators", function() {
+      var compDeepEqual = _.isEqual;
+
+      var compNormal = function(a, b) { return a == b; };
+
+      var object1 = {foo: 1, bar: 2, baz: 3};
+      var object2 = {foo: 2, bar: 5, baz: 8};
+      // object3 is equivalent to object 1
+      var object3 = {foo: 1, bar: 2, baz: 3};
+
+      var big_set = [object1, object2];
+      var smaller_set = [object3];
+      var result = _.union(compNormal, big_set, smaller_set);
+
+      // With ==, the objects aren't equal so the union has 3 objects
+      equal(JSON.stringify(result), 
+          '[{"foo":1,"bar":2,"baz":3},{"foo":2,"bar":5,"baz":8},{"foo":1,"bar":2,"baz":3}]');
+
+      // With deep equality, the object should be removed
+      result = _.union(compDeepEqual, big_set, smaller_set);
+      equal(JSON.stringify(result), 
+          '[{"foo":1,"bar":2,"baz":3},{"foo":2,"bar":5,"baz":8}]');
+
+      result = _.deepUnion(big_set, smaller_set);
+      equal(JSON.stringify(result), 
+              '[{"foo":1,"bar":2,"baz":3},{"foo":2,"bar":5,"baz":8}]');  
+  });
 
   test("difference", function() {
     var result = _.difference([1, 2, 3], [2, 30, 40]);
@@ -135,6 +188,34 @@ $(document).ready(function() {
 
     result = _.difference([1, 2, 3, 4], [2, 30, 40], [1, 11, 111]);
     equal(result.join(' '), '3 4', 'takes the difference of three arrays');
+  });
+
+  test("difference with custom comparators", function() {
+      var compFoo = function(a,b) {
+          return a.foo == b.foo;
+      }
+
+      var compDeepEqual = _.isEqual;
+
+      var compNormal = function(a, b) { return a == b; };
+
+      var object1 = {foo: 1, bar: 2, baz: 3};
+      var object2 = {foo: 2, bar: 5, baz: 8};
+      var object3 = {foo: 1, bar: 2, baz: 3};
+
+      var big_set = [object1, object2];
+      var smaller_set = [object3];
+      var result = _.difference(compNormal, big_set, smaller_set);
+
+      // With ==, the objects aren't equal so no objects are removed
+      equal(JSON.stringify(result), '[{"foo":1,"bar":2,"baz":3},{"foo":2,"bar":5,"baz":8}]');
+
+      // With deep equality, the object should be removed
+      result = _.difference(compDeepEqual, big_set, smaller_set);
+      equal(JSON.stringify(result), '[{"foo":2,"bar":5,"baz":8}]');
+
+      result = _.deepDifference(big_set, smaller_set);
+      equal(JSON.stringify(result), '[{"foo":2,"bar":5,"baz":8}]');
   });
 
   test('zip', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -469,7 +469,10 @@
   // Produce a duplicate-free version of the array. If the array has already
   // been sorted, you have the option of using a faster algorithm.
   // Aliased as `unique`.
-  _.uniq = _.unique = function(array, isSorted, iterator, context) {
+  _.uniq = _.unique = function(array, isSorted, iterator, context, containsFunc) {
+    if (!containsFunc) {
+        containsFunc = _.contains;
+    }
     if (_.isFunction(isSorted)) {
       context = iterator;
       iterator = isSorted;
@@ -479,37 +482,110 @@
     var results = [];
     var seen = [];
     each(initial, function(value, index) {
-      if (isSorted ? (!index || seen[seen.length - 1] !== value) : !_.contains(seen, value)) {
+      if (isSorted ? (!index || seen[seen.length - 1] !== value) : !containsFunc(seen, value)) {
         seen.push(value);
         results.push(array[index]);
       }
     });
     return results;
   };
+  
+  var splitBehaviorOnFirstArg = function(argIsFunction, argIsntFunction) {
+      return function(first) {
+          if (_.isFunction(first)) {
+              return argIsFunction.apply(this, arguments);
+          } else {
+              return argIsntFunction.apply(this, arguments);
+          }
+      }
+  }
 
   // Produce an array that contains the union: each distinct element from all of
   // the passed-in arrays.
-  _.union = function() {
-    return _.uniq(_.flatten(arguments, true));
+  _.union = splitBehaviorOnFirstArg(function(comparator) {
+        var containFunc = containsClosure(comparator);
+        return _.uniq(_.flatten(slice.call(arguments, 1), true), 
+            undefined, undefined, undefined, containFunc);
+    }, function() {
+        return _.uniq(_.flatten(arguments, true));
+    });
+
+  _.deepUnion = function() {
+      return withPrependedArg(_.isEqual, arguments, _.union);
+  }
+
+  var withPrependedArg = function(firstArg, otherArgs, func) {
+      var args = slice.call(otherArgs, 0);
+      args.unshift(firstArg);
+      return func.apply(this, args);
   };
 
-  // Produce an array that contains every item shared between all the
-  // passed-in arrays.
-  _.intersection = function(array) {
-    var rest = slice.call(arguments, 1);
-    return _.filter(_.uniq(array), function(item) {
+  _.deepContains = function(list, item, equalityFunction) {
+      if (!equalityFunction) {
+          equalityFunction = _.isEqual
+      } 
+      return any(list, function(li) {
+          if (equalityFunction(li, item)) {
+              return true;
+          } else {
+              return false;
+          }
+      });
+  };
+
+  var containsClosure = function(equalityFunction) {
+      return function(list, item) {
+          return _.deepContains(list, item, equalityFunction);
+      }
+  }
+
+  var intersectionWithComparator = function(comparator, array) {
+      return withPrependedArg(containsClosure(comparator), slice.call(arguments, 1), intersectionWithContainment);
+  }
+  
+  var intersectionSansComparator = function(array) {
+      return withPrependedArg(_.contains, arguments, intersectionWithContainment);
+  }
+
+  var intersectionWithContainment = function(containmentFunc, array) {
+    var rest = slice.call(arguments, 2);
+    return _.filter(_.uniq(array, undefined, undefined, undefined, containmentFunc), function(item) {
       return _.every(rest, function(other) {
-        return _.indexOf(other, item) >= 0;
+        return containmentFunc(other, item);
       });
     });
+  };
+  
+
+  
+  _.intersection = splitBehaviorOnFirstArg(intersectionWithComparator, intersectionSansComparator);
+
+  _.deepIntersection = function() {
+      return withPrependedArg(_.isEqual, arguments, intersectionWithComparator);
+  }
+  
+  var differenceWithContainment = function(containmentFunc, array) {
+    var rest = concat.apply(ArrayProto, slice.call(arguments, 2));
+    return _.filter(array, function(value){ return !containmentFunc(rest, value); });
   };
 
   // Take the difference between one array and a number of other arrays.
   // Only the elements present in just the first array will remain.
-  _.difference = function(array) {
-    var rest = concat.apply(ArrayProto, slice.call(arguments, 1));
-    return _.filter(array, function(value){ return !_.contains(rest, value); });
+  var differenceSansComparator = function() {
+      return withPrependedArg(_.contains, arguments, differenceWithContainment);
   };
+
+
+  var differenceWithComparator = function(comparator) {
+      return withPrependedArg(containsClosure(comparator), slice.call(arguments, 1), differenceWithContainment);
+  }
+
+
+  _.difference = splitBehaviorOnFirstArg(differenceWithComparator, differenceSansComparator);
+
+  _.deepDifference = function() {
+      return withPrependedArg(_.isEqual, arguments, differenceWithComparator);
+  }
 
   // Zip together multiple lists into a single array -- elements that share
   // an index go together.


### PR DESCRIPTION
This commit adds support for specifying comparators in union,
difference, and intersection (#1339). The specification of comparators allows
for library users to specify _.isEqual for deep equality or to
specify their own methods that match a subset of paramters. It
also adds deepUnion, deepIntersection and deepDifference functions,
convienience functions that specify _.isEqual.

Under the hood, it actually allows the specification of a "contains"
function into several relevant relevant functions. This is created from
the comparator with a closure. The code to allow this a little cumbersome.
I'm open to suggestions on better methods of passing through a containment-
checking function -- one possibility would be to store the containment
function of the moment on this.

Let me know your temperature for merging these changes.
