### PR TITLE
The way _.indexOf acts if passed a string seems confusing

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -193,6 +193,10 @@ $(document).ready(function() {
     numbers = [1, 2, 3, 1, 2, 3, 1, 2, 3];
     index = _.indexOf(numbers, 2, 5);
     equal(index, 7, 'supports the fromIndex argument');
+
+    var string = 'foo';
+    index = _.indexOf(string, 'oo');
+    equal(index, 1, 'should operate on strings of lengths greater than 1');
   });
 
   test("lastIndexOf", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -545,19 +545,23 @@
   // If the array is large and already in sort order, pass `true`
   // for **isSorted** to use binary search.
   _.indexOf = function(array, item, isSorted) {
-    if (array == null) return -1;
-    var i = 0, length = array.length;
-    if (isSorted) {
-      if (typeof isSorted == 'number') {
-        i = (isSorted < 0 ? Math.max(0, length + isSorted) : isSorted);
-      } else {
-        i = _.sortedIndex(array, item);
-        return array[i] === item ? i : -1;
+    if (typeof array == 'string') {
+      return array.indexOf(item);
+    } else {
+      if (array == null) return -1;
+      var i = 0, length = array.length;
+      if (isSorted) {
+        if (typeof isSorted == 'number') {
+          i = (isSorted < 0 ? Math.max(0, length + isSorted) : isSorted);
+        } else {
+          i = _.sortedIndex(array, item);
+          return array[i] === item ? i : -1;
+        }
       }
+      if (nativeIndexOf && array.indexOf === nativeIndexOf) return array.indexOf(item, isSorted);
+      for (; i < length; i++) if (array[i] === item) return i;
+      return -1;
     }
-    if (nativeIndexOf && array.indexOf === nativeIndexOf) return array.indexOf(item, isSorted);
-    for (; i < length; i++) if (array[i] === item) return i;
-    return -1;
   };
 
   // Delegates to **ECMAScript 5**'s native `lastIndexOf` if available.


### PR DESCRIPTION
I was developing and wasn't really thinking too closely about what I was doing but I passed a string to _.indexOf expecting it to delegate to the native String.prototype.indexOf method. When it didn't work correctly I thought about what I was doing a bit and realized it was silly since String.prototype.indexOf is supported in all major browsers.

At first I chalked it up to the fact I was just being dumb. Then I thought about it more and realized that _.indexOf actually does work on strings as long as your only looking for one character.

Example:
_.indexOf('foo', 'o'); // returns 1
_.indexOf('foo', 'oo'); // returns -1

Because of the example above I felt this pull request might make sense. Check to see if a string was passed, if true return the result of the strings .indexOf method else continue with regular execution of _.indexOf.

Does this make sense to anyone else?
