### PR TITLE
add placeholder support to _.partial

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -46,6 +46,16 @@ $(document).ready(function() {
 
     obj.func = _.partial(func, 'a', 'b');
     equal(obj.func('c', 'd'), 'moe a b c d', 'can partially apply');
+
+    obj.func = _.partial(func, _, 'b', _, 'd');
+    equal(obj.func('a', 'c'), 'moe a b c d', 'can partially apply with placeholders');
+
+    func = _.partial(function() { return arguments.length; }, _, 'b', _, 'd');
+    equal(func('a', 'c', 'e'), 5, 'accepts more arguments than the number of placeholders');
+    equal(func('a'), 4, 'accepts fewer arguments than the number of placeholders');
+
+    func = _.partial(function() { return typeof arguments[2]; }, _, 'b', _, 'd');
+    equal(func('a'), 'undefined', 'unfilled placeholders are undefined');
   });
 
   test("bindAll", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -620,11 +620,19 @@
   };
 
   // Partially apply a function by creating a version that has had some of its
-  // arguments pre-filled, without changing its dynamic `this` context.
+  // arguments pre-filled, without changing its dynamic `this` context. _ acts
+  // as a placeholder, allowing any combination of arguments to be pre-filled.
   _.partial = function(func) {
-    var args = slice.call(arguments, 1);
+    var boundArgs = slice.call(arguments, 1);
     return function() {
-      return func.apply(this, args.concat(slice.call(arguments)));
+      var args = slice.call(boundArgs);
+      _.each(arguments, function(arg) {
+        var index = args.indexOf(_);
+        args[index >= 0 ? index : args.length] = arg;
+      });
+      return func.apply(this, _.map(args, function(value) {
+        return value === _ ? void 0 : value;
+      }));
     };
   };
 


### PR DESCRIPTION
This is another implementation of #1276/#1318. @jashkenas requested a simpler solution[¹](https://github.com/jashkenas/underscore/pull/1318#issuecomment-27896798); hopefully this fits the bill.

Possible example for the docs, should this pull request be accepted:

``` javascript
var product = _.partial(_.reduce, _, function(a, b) { return a * b; }, 1);
product([2, 3, 7]);
=> 42
```
