### PR TITLE
Added _.serialize(): Serialize key-value pairs of an object into urlencoded format

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -24,6 +24,13 @@ $(document).ready(function() {
     deepEqual(_.pairs({one: 1, two: 2, length: 3}), [['one', 1], ['two', 2], ['length', 3]], '... even when one of them is "length"');
   });
 
+  test("serialize", function() {
+    equal(_.serialize({foo: 'bar', baz: 'qux'}), 'foo=bar&baz=qux', 'can serialize an object');
+    equal(_.serialize({foo: function() { return 'bar';}, baz: 'qux'}), 'foo=bar&baz=qux', 'can serialize an object, with an invoked function');
+    equal(_.serialize({foo: 'foo bar', baz: 'qux'}), 'foo=foo+bar&baz=qux', 'can correctly encode spaces in serialized object');
+    equal(_.serialize({'foo bar': '!@#$%^&*()"\''}), 'foo+bar=!%40%23%24%25%5E%26*()%22\'', 'urlencodes characters in serialized result');
+  });
+
   test("invert", function() {
     var obj = {first: 'Moe', second: 'Larry', third: 'Curly'};
     equal(_.keys(_.invert(obj)).join(' '), 'Moe Larry Curly', 'can invert an object');

--- a/underscore.js
+++ b/underscore.js
@@ -807,6 +807,16 @@
     return pairs;
   };
 
+  // Serialize key-value pairs of an object into urlencoded format
+  _.serialize = function(obj) {
+    var pairs = _.pairs(obj);
+    return _.reduce(pairs, function(memo, pair) {
+      var key = _.first(pair), value = _.last(pair);
+      value = _.isFunction(value) ? value() : value;
+      return memo + '&' + encodeURIComponent(key) + '=' + encodeURIComponent(value);
+    }, '').replace('&', '').replace(/%20/g, '+');
+  };
+
   // Invert the keys and values of an object. The values must be serializable.
   _.invert = function(obj) {
     var result = {};


### PR DESCRIPTION
Extended Objects with a serialize method, which has long been missing imo. Tend to write this into a utility function or a few lines of code, where it's not appropriate to use $.param(). Would prefer to see it readily available in this library, although it's more abstracted than some other Underscore methods. Otherwise, it could be demoted and qualify as a useful _.mixin that I'll commit elsewhere.
