### PR TITLE
assign value to new arrays at creation in _.groupBy

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -356,7 +356,7 @@
   // Groups the object's values by a criterion. Pass either a string attribute
   // to group by, or a function that returns the criterion.
   _.groupBy = group(function(result, key, value) {
-    (_.has(result, key) ? result[key] : (result[key] = [])).push(value);
+    _.has(result, key) ? result[key].push(value) : result[key] = [value];
   });
 
   // Indexes the object's values by a criterion, similar to `groupBy`, but for


### PR DESCRIPTION
In _.groupBy new arrays are created empty, then the current value is added via array.push. It would be faster to create new arrays and assign value in one step and only call push on existing arrays.

A jsperf comparison as proof of concept: http://jsperf.com/array-push-vs-literal
