### PR TITLE
fixes #1390: make _.where consistent when used with empty attrs object

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -266,6 +266,11 @@ $(document).ready(function() {
     equal(result.b, 2, "Only get the first object matched.")
     result = _.where(list, {a: 1}, false);
     equal(result.length, 3);
+
+    result = _.where(list, {});
+    equal(result.length, list.length);
+    result = _.where(list, {}, true);
+    equal(result, list[0]);
   });
 
   test('findWhere', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -243,7 +243,6 @@
   // Convenience version of a common use case of `filter`: selecting only objects
   // containing specific `key:value` pairs.
   _.where = function(obj, attrs, first) {
-    if (_.isEmpty(attrs)) return first ? void 0 : [];
     return _[first ? 'find' : 'filter'](obj, function(value) {
       for (var key in attrs) {
         if (attrs[key] !== value[key]) return false;


### PR DESCRIPTION
Fixes #1390.
