### PR TITLE
Adding _.method

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -35,6 +35,12 @@ $(document).ready(function() {
     equal(_.property('name')(moe), 'moe', 'should return the property with the given name');
   });
 
+  test("method", function() {
+    var foo = { bar: function(num) { return num + 2; } };
+    equal(_.method("bar", 4)(foo), 6, 'should curry correctly via name');
+    equal(_.method(foo.bar, 5)(foo), 7, 'should curry correctly');
+  });
+
   test("random", function() {
     var array = _.range(1000);
     var min = Math.pow(2, 31);

--- a/underscore.js
+++ b/underscore.js
@@ -1094,6 +1094,16 @@
     };
   };
 
+  _.method = function(fn) {
+    var curry = _.rest(arguments),
+        fnStr = _.isString(fn);
+
+    return function(obj) {
+      var f = (fnStr ? obj[fn] : fn);
+      return f.apply(obj, curry);
+    };
+  };
+
   // Run a function **n** times.
   _.times = function(n, iterator, context) {
     var accum = Array(Math.max(0, n));


### PR DESCRIPTION
As proposed in issue #1345 here's a pull request for _.method, i.e. method function support,

This is quite concise when executing the same function on a collection of objects (varying context), e.g.

_.any(views, _.method("isDisabled"));

In addition, _.method supports currying, e.g.

_.method(foo, 3)

will create a member function that calls foo with 3 as the first argument.
