### PR TITLE
add in _.invoke(collection, null, [*arguments]) support where null flags for functions in a collection.

### DIFF
--- a/docs/underscore.html
+++ b/docs/underscore.html
@@ -517,7 +517,7 @@ Aliased as <code>include</code>.</p>
     <span class="keyword">var</span> args = slice.call(arguments, <span class="number">2</span>);
     <span class="keyword">var</span> isFunc = _.isFunction(method);
     <span class="keyword">return</span> _.map(obj, <span class="keyword">function</span>(value) {
-      <span class="keyword">return</span> (isFunc ? method : value[method]).apply(value, args);
+      <span class="keyword">return</span> (isFunc ? method : method ? value[method] : value).apply(value, args);
     });
   };</pre></div></div>
             

--- a/index.html
+++ b/index.html
@@ -594,6 +594,7 @@ _.contains([1, 2, 3], 3);
         <b class="header">invoke</b><code>_.invoke(list, methodName, [*arguments])</code>
         <br />
         Calls the method named by <b>methodName</b> on each value in the <b>list</b>.
+        Passing false as the method name will invoke the objects in the collection themselves as functions.
         Any extra arguments passed to <b>invoke</b> will be forwarded on to the
         method invocation.
       </p>

--- a/test/collections.js
+++ b/test/collections.js
@@ -248,6 +248,12 @@ $(document).ready(function() {
     equal(s.call, undefined, "call function removed");
   });
 
+  test('invoke each object w/ falsy method', function(){
+    var list = [function(a){return a;}, function(a){return a*2}];
+    var result = _.invoke(list, null, 42);
+    equal(result.join(', '), '42, 84', 'invoked on functions themselves');
+  });
+
   test('pluck', function() {
     var people = [{name : 'moe', age : 30}, {name : 'curly', age : 50}];
     equal(_.pluck(people, 'name').join(', '), 'moe, curly', 'pulls names out of objects');

--- a/underscore.js
+++ b/underscore.js
@@ -231,7 +231,7 @@
     var args = slice.call(arguments, 2);
     var isFunc = _.isFunction(method);
     return _.map(obj, function(value) {
-      return (isFunc ? method : value[method]).apply(value, args);
+      return (isFunc ? method : method ? value[method] : value).apply(value, args);
     });
   };
 


### PR DESCRIPTION
I want to support passing null to _.invoke to allow this:

test('invoke each object w/ falsy method', function(){
    var list = [function(a){return a;}, function(a){return a*2}];
    var result = _.invoke(list, null, 42);
    equal(result.join(', '), '42, 84', 'invoked on functions themselves');
});

I've added the text to the docs and made a test.
