### PR TITLE
_.keys accepts non-object arguments.

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -29,6 +29,8 @@ $(document).ready(function() {
     answers = 0;
     _.each(null, function(){ ++answers; });
     equal(answers, 0, 'handles a null properly');
+
+    _.each(false, function(){});
   });
 
   test('map', function() {

--- a/test/objects.js
+++ b/test/objects.js
@@ -7,11 +7,11 @@ $(document).ready(function() {
     // the test above is not safe because it relies on for-in enumeration order
     var a = []; a[1] = 0;
     equal(_.keys(a).join(', '), '1', 'is not fooled by sparse arrays; see issue #95');
-    raises(function() { _.keys(null); }, TypeError, 'throws an error for `null` values');
-    raises(function() { _.keys(void 0); }, TypeError, 'throws an error for `undefined` values');
-    raises(function() { _.keys(1); }, TypeError, 'throws an error for number primitives');
-    raises(function() { _.keys('a'); }, TypeError, 'throws an error for string primitives');
-    raises(function() { _.keys(true); }, TypeError, 'throws an error for boolean primitives');
+    deepEqual(_.keys(null), []);
+    deepEqual(_.keys(void 0), []);
+    deepEqual(_.keys(1), []);
+    deepEqual(_.keys('a'), []);
+    deepEqual(_.keys(true), []);
   });
 
   test("values", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -786,8 +786,9 @@
 
   // Retrieve the names of an object's properties.
   // Delegates to **ECMAScript 5**'s native `Object.keys`
-  _.keys = nativeKeys || function(obj) {
-    if (obj !== Object(obj)) throw new TypeError('Invalid object');
+  _.keys = function(obj) {
+    if (!_.isObject(obj)) return [];
+    if (nativeKeys) return nativeKeys(obj);
     var keys = [];
     for (var key in obj) if (_.has(obj, key)) keys.push(key);
     return keys;


### PR DESCRIPTION
Some time ago, an optimization was accepted for `_.each` (10695ba5) that uses `_.keys` for iteration instead of `for (var prop in obj)`.  This has broken the usage of `_.each(false, ...)` and friends by throwing instead of acting as a no-op.  I don't see a good reason we should throw at all on non-objects and I propose that we do not.

Further, the `_.keys` optimization has been used in several other methods that now throw on non-object arguments (`pairs`, `invert`, `size`, `values`).  I've commented on this before in #1286 and I still think these micro-optimizations are much less important than not throwing unexpectedly, especially in a backwards incompatible manner.

_Note: The actual usage wasn't `_.each(false, ...)`.  It was `_.each(unexpectedVaryingReturnType(), ...)`._
