### PR TITLE
add opt-in non-coercing of strings for toArray

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -491,6 +491,13 @@ $(document).ready(function() {
     var numbers = _.toArray({one : 1, two : 2, three : 3});
     equal(numbers.join(', '), '1, 2, 3', 'object flattened into array');
 
+    var string = 'abc';
+    var emptyString = '';
+    equal(_.toArray(string).join(', '), 'a, b, c', 'string into array of characters');
+    equal(_.toArray(string, true).join(', '), 'abc', 'string not coerced');
+    equal(_.toArray(emptyString).join(', '), '', 'empty string into empty array');
+    equal(_.toArray(emptyString, true).join(', '), '', 'empty string not coerced');
+
     // test in IE < 9
     try {
       var actual = _.toArray(document.childNodes);

--- a/underscore.js
+++ b/underscore.js
@@ -380,9 +380,10 @@
   };
 
   // Safely create a real, live array from anything iterable.
-  _.toArray = function(obj) {
+  _.toArray = function(obj, noCoerce) {
     if (!obj) return [];
     if (_.isArray(obj)) return slice.call(obj);
+    if (noCoerce) return [obj];
     if (obj.length === +obj.length) return _.map(obj, _.identity);
     return _.values(obj);
   };


### PR DESCRIPTION
The current implementation of `toArray` coerces `String`s into `Array`s of characters. These commits adds an opt-in flag directing it to leave strings in tact.

Given:

``` js
var array;
var string = 'a string';
```

allows code such as:

``` js
if (! _.isArray(string)) {
  array = [string];
}
```

to be simplified to:

``` js
array = _.toArray(string, true);
```

resulting in:

``` js
['a string']
```

instead of (currently):

``` js
['a', ' ', 's', 't', 'r', 'i', 'n', 'g']
```
