### PR TITLE
Simplified _.max and _.min

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -295,6 +295,9 @@
     equal(_.max({'a': 'a'}), -Infinity, 'Maximum value of a non-numeric collection');
 
     equal(299999, _.max(_.range(1,300000)), 'Maximum value of a too-big array');
+
+    equal(3, _.max([1, 2, 3, 'test']), 'Finds correct max in array starting with num and containing a NaN');
+    equal(3, _.max(['test', 1, 2, 3]), 'Finds correct max in array starting with NaN');
   });
 
   test('min', function() {
@@ -312,6 +315,9 @@
     equal(_.min([now, then]), then);
 
     equal(1, _.min(_.range(1,300000)), 'Minimum value of a too-big array');
+
+    equal(1, _.min([1, 2, 3, 'test']), 'Finds correct min in array starting with num and containing a NaN');
+    equal(1, _.min(['test', 1, 2, 3]), 'Finds correct min in array starting with NaN');
   });
 
   test('sortBy', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -250,27 +250,47 @@
 
   // Return the maximum element or (element-based computation).
   _.max = function(obj, iterator, context) {
-    var result = -Infinity, lastComputed = -Infinity;
-    each(obj, function(value, index, list) {
-      var computed = iterator ? iterator.call(context, value, index, list) : value;
-      if (computed > lastComputed) {
-        result = value;
-        lastComputed = computed;
+    var result = -Infinity, lastComputed = -Infinity,
+        value, computed;
+    if (!iterator && _.isArray(obj)) {
+      for (var i = 0, length = obj.length; i < length; i++) {
+        value = obj[i];
+        if (value > result) {
+          result = value;
+        }
       }
-    });
+    } else {
+      each(obj, function(value, index, list) {
+        computed = iterator ? iterator.call(context, value, index, list) : value;
+        if (computed > lastComputed) {
+          result = value;
+          lastComputed = computed;
+        }
+      });
+    }
     return result;
   };
 
   // Return the minimum element (or element-based computation).
   _.min = function(obj, iterator, context) {
-    var result = Infinity, lastComputed = Infinity;
-    each(obj, function(value, index, list) {
-      var computed = iterator ? iterator.call(context, value, index, list) : value;
-      if (computed < lastComputed) {
-        result = value;
-        lastComputed = computed;
+    var result = Infinity, lastComputed = Infinity,
+        value, computed;
+    if (!iterator && _.isArray(obj)) {
+      for (var i = 0, length = obj.length; i < length; i++) {
+        value = obj[i];
+        if (value < result) {
+          result = value;
+        }
       }
-    });
+    } else {
+      each(obj, function(value, index, list) {
+        computed = iterator ? iterator.call(context, value, index, list) : value;
+        if (computed < lastComputed) {
+          result = value;
+          lastComputed = computed;
+        }
+      });
+    }
     return result;
   };
 


### PR DESCRIPTION
Bringing this back up - the last time I saw this being discussed is [#578](https://github.com/jashkenas/underscore/issues/578).

Curious on thoughts as given a comparitor case is the more common use case from my experience with the functions.

Removing the native apply also normalizes the output for some oddities mentioned in [#728](https://github.com/jashkenas/underscore/issues/728) when given a positive number as the first argument  and make the functions more consistent in general (for absurdly large collections)

E.g.

```
_.max([1, NaN]) //1 instead of NaN
```

[**Updated jsperf**](http://jsperf.com/simplified-max-min/2)
