### PR TITLE
result-apply-args

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -226,12 +226,13 @@
   });
 
   test('result calls functions and returns primitives', function() {
-    var obj = {w: '', x: 'x', y: function(){ return this.x; }};
+    var obj = {w: '', x: 'x', y: function(){ return this.x; }, z: function(p){ return p + this.x; }};
     strictEqual(_.result(obj, 'w'), '');
     strictEqual(_.result(obj, 'x'), 'x');
     strictEqual(_.result(obj, 'y'), 'x');
-    strictEqual(_.result(obj, 'z'), undefined);
+    strictEqual(_.result(obj, 'v'), undefined);
     strictEqual(_.result(null, 'x'), undefined);
+    strictEqual(_.result(obj, 'z', 'foo'), 'foox');
   });
 
   test('_.templateSettings.variable', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -1141,7 +1141,7 @@
   _.result = function(object, property) {
     if (object == null) return void 0;
     var value = object[property];
-    return _.isFunction(value) ? value.call(object) : value;
+    return _.isFunction(value) ? value.apply(object, _.rest(arguments, 2)) : value;
   };
 
   // Add your own custom functions to the Underscore object.


### PR DESCRIPTION
Allow arguments to be passed to object method in `_.result()` call.

Since the `_.result()` function is a handy way of conditionally calling a method that may not exist, it should support passing arguments through to the method that is being invoked.

Example:

``` JavaScript
// Underscore hotness:
var answer = _.result(obj, 'z', 'foo');

// Rough equivalent in pure JS:
var answer;
if (obj && obj.z) {
  answer = obj.z('foo');
}
```
