### PR TITLE
Moved "later" function definition out of the returned debounce function

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -703,22 +703,24 @@
   // leading edge, instead of the trailing.
   _.debounce = function(func, wait, immediate) {
     var timeout, args, context, timestamp, result;
+
+    var later = function() {
+      var last = _.now() - timestamp;
+      if (last < wait) {
+        timeout = setTimeout(later, wait - last);
+      } else {
+        timeout = null;
+        if (!immediate) {
+          result = func.apply(context, args);
+          context = args = null;
+        }
+      }
+    };
+
     return function() {
       context = this;
       args = arguments;
       timestamp = _.now();
-      var later = function() {
-        var last = _.now() - timestamp;
-        if (last < wait) {
-          timeout = setTimeout(later, wait - last);
-        } else {
-          timeout = null;
-          if (!immediate) {
-            result = func.apply(context, args);
-            context = args = null;
-          }
-        }
-      };
       var callNow = immediate && !timeout;
       if (!timeout) {
         timeout = setTimeout(later, wait);


### PR DESCRIPTION
Not sure why 'later' was defined within the returned function by _.debounce, since it only captures variables defined in the above scope. So moved it up to keep it consistent with _.throttle and also gain a bit of speed this way.
