### PR TITLE
Add starting semicolon to prevent concat errors

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -3,7 +3,7 @@
 //     (c) 2009-2014 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
 //     Underscore may be freely distributed under the MIT license.
 
-(function() {
+;(function() {
 
   // Baseline setup
   // --------------


### PR DESCRIPTION
This prevents concat errors when underscore is included just after the semicolon-less library, like Zepto.
