### PR TITLE
Bug in isObject()

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1019,7 +1019,7 @@
 
   // Is a given variable an object?
   _.isObject = function(obj) {
-    return obj === Object(obj);
+    return !_.isArray(obj) && obj === Object(obj)
   };
 
   // Add some isType methods: isArguments, isFunction, isString, isNumber, isDate, isRegExp.


### PR DESCRIPTION
This commit removes the bug with object and array identification.

Before:
 _.isObject([1,2,3,4])
  => true
With this commit:
 _.isObject([1,2,3,4])
  => false
