### PR TITLE
add anchor to each section in change log

### DIFF
--- a/index.html
+++ b/index.html
@@ -1915,7 +1915,7 @@ _([1, 2, 3]).value();
 
       <h2 id="changelog">Change Log</h2>
 
-      <p>
+      <p id="1.5.2">
         <b class="header">1.5.2</b> &mdash; <small><i>Sept. 7, 2013</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.5.1...1.5.2">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.5.2/index.html">Docs</a><br />
         <ul>
           <li>
@@ -1934,7 +1934,7 @@ _([1, 2, 3]).value();
         </ul>
       </p>
 
-      <p>
+      <p id="1.5.1">
         <b class="header">1.5.1</b> &mdash; <small><i>Jul. 8, 2013</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.5.0...1.5.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.5.1/index.html">Docs</a><br />
         <ul>
           <li>
@@ -1945,7 +1945,7 @@ _([1, 2, 3]).value();
         </ul>
       </p>
 
-      <p>
+      <p id="1.5.0">
         <b class="header">1.5.0</b> &mdash; <small><i>Jul. 6, 2013</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.4...1.5.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.5.0/index.html">Docs</a><br />
         <ul>
           <li>
@@ -1976,7 +1976,7 @@ _([1, 2, 3]).value();
         </ul>
       </p>
 
-      <p>
+      <p id="1.4.4">
         <b class="header">1.4.4</b> &mdash; <small><i>Jan. 30, 2013</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.3...1.4.4">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.4.4/index.html">Docs</a><br />
         <ul>
           <li>
@@ -2002,7 +2002,7 @@ _([1, 2, 3]).value();
         </ul>
       </p>
 
-      <p>
+      <p id="1.4.3">
         <b class="header">1.4.3</b> &mdash; <small><i>Dec. 4, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.2...1.4.3">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.4.3/index.html">Docs</a><br />
         <ul>
           <li>
@@ -2027,7 +2027,7 @@ _([1, 2, 3]).value();
         </ul>
       </p>
 
-      <p>
+      <p id="1.4.2">
         <b class="header">1.4.2</b> &mdash; <small><i>Oct. 1, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.1...1.4.2">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.4.2/index.html">Docs</a><br />
         <ul>
           <li>
@@ -2038,7 +2038,7 @@ _([1, 2, 3]).value();
         </ul>
       </p>
 
-      <p>
+      <p id="1.4.1">
         <b class="header">1.4.1</b> &mdash; <small><i>Oct. 1, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.0...1.4.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.4.1/index.html">Docs</a><br />
         <ul>
           <li>
@@ -2047,7 +2047,7 @@ _([1, 2, 3]).value();
         </ul>
       </p>
 
-      <p>
+      <p id="1.4.0">
         <b class="header">1.4.0</b> &mdash; <small><i>Sept. 27, 2012</i></small>  &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.3.3...1.4.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.4.0/index.html">Docs</a><br />
         <ul>
           <li>
@@ -2112,7 +2112,7 @@ _([1, 2, 3]).value();
         </ul>
       </p>
 
-      <p>
+      <p id="1.3.3">
         <b class="header">1.3.3</b> &mdash; <small><i>April 10, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.3.1...1.3.3">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.3.3/index.html">Docs</a><br />
         <ul>
           <li>
@@ -2155,7 +2155,7 @@ _([1, 2, 3]).value();
         </ul>
       </p>
 
-      <p>
+      <p id="1.3.1">
         <b class="header">1.3.1</b> &mdash; <small><i>Jan. 23, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.3.0...1.3.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.3.1/index.html">Docs</a><br />
         <ul>
           <li>
@@ -2174,7 +2174,7 @@ _([1, 2, 3]).value();
         </ul>
       </p>
 
-      <p>
+      <p id="1.3.0">
         <b class="header">1.3.0</b> &mdash; <small><i>Jan. 11, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.4...1.3.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.3.0/index.html">Docs</a><br />
         <ul>
           <li>
@@ -2185,7 +2185,7 @@ _([1, 2, 3]).value();
         </ul>
       </p>
 
-      <p>
+      <p id="1.2.4">
         <b class="header">1.2.4</b> &mdash; <small><i>Jan. 4, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.3...1.2.4">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.2.4/index.html">Docs</a><br />
         <ul>
           <li>
@@ -2208,7 +2208,7 @@ _([1, 2, 3]).value();
         </ul>
       </p>
 
-      <p>
+      <p id="1.2.3">
         <b class="header">1.2.3</b> &mdash; <small><i>Dec. 7, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.2...1.2.3">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.2.3/index.html">Docs</a><br />
         <ul>
           <li>
@@ -2226,7 +2226,7 @@ _([1, 2, 3]).value();
         </ul>
       </p>
 
-      <p>
+      <p id="1.2.2">
         <b class="header">1.2.2</b> &mdash; <small><i>Nov. 14, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.1...1.2.2">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.2.1/index.html">Docs</a><br />
         <ul>
           <li>
@@ -2249,7 +2249,7 @@ _([1, 2, 3]).value();
         </ul>
       </p>
 
-      <p>
+      <p id="1.2.1">
         <b class="header">1.2.1</b> &mdash; <small><i>Oct. 24, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.0...1.2.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.2.1/index.html">Docs</a><br />
         <ul>
           <li>
@@ -2288,7 +2288,7 @@ _([1, 2, 3]).value();
         </ul>
       </p>
 
-      <p>
+      <p id="1.2.0">
         <b class="header">1.2.0</b> &mdash; <small><i>Oct. 5, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.7...1.2.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.2.0/index.html">Docs</a><br />
         <ul>
           <li>
@@ -2319,7 +2319,7 @@ _([1, 2, 3]).value();
         </ul>
       </p>
 
-      <p>
+      <p id="1.1.7">
         <b class="header">1.1.7</b> &mdash; <small><i>July 13, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.6...1.1.7">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.1.7/index.html">Docs</a><br />
         Added <tt>_.groupBy</tt>, which aggregates a collection into groups of like items.
         Added <tt>_.union</tt> and <tt>_.difference</tt>, to complement the
@@ -2330,7 +2330,7 @@ _([1, 2, 3]).value();
         in the prototype chain.
       </p>
 
-      <p>
+      <p id="1.1.6">
         <b class="header">1.1.6</b> &mdash; <small><i>April 18, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.5...1.1.6">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.1.6/index.html">Docs</a><br />
         Added <tt>_.after</tt>, which will return a function that only runs after
         first being called a specified number of times.
@@ -2341,7 +2341,7 @@ _([1, 2, 3]).value();
         <tt>_.bind</tt> now errors when trying to bind an undefined value.
       </p>
 
-      <p>
+      <p id="1.1.5">
         <b class="header">1.1.5</b> &mdash; <small><i>Mar 20, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.4...1.1.5">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.1.5/index.html">Docs</a><br />
         Added an <tt>_.defaults</tt> function, for use merging together JS objects
         representing default options.
@@ -2354,7 +2354,7 @@ _([1, 2, 3]).value();
         Fixed a bug with <tt>_.keys</tt> when used over sparse arrays.
       </p>
 
-      <p>
+      <p id="1.1.4">
         <b class="header">1.1.4</b> &mdash; <small><i>Jan 9, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.3...1.1.4">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.1.4/index.html">Docs</a><br />
         Improved compliance with ES5's Array methods when passing <tt>null</tt>
         as a value. <tt>_.wrap</tt> now correctly sets <tt>this</tt> for the
@@ -2364,7 +2364,7 @@ _([1, 2, 3]).value();
         to work properly in ES5's strict mode.
       </p>
 
-      <p>
+      <p id="1.1.3">
         <b class="header">1.1.3</b> &mdash; <small><i>Dec 1, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.2...1.1.3">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.1.3/index.html">Docs</a><br />
         In CommonJS, Underscore may now be required with just: <br />
         <tt>var _ = require("underscore")</tt>.
@@ -2381,21 +2381,21 @@ _([1, 2, 3]).value();
         consistency with ES5's <tt>forEach</tt>.
       </p>
 
-      <p>
+      <p id="1.1.2">
         <b class="header">1.1.2</b> &mdash; <small><i>Oct 15, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.1...1.1.2">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.1.2/index.html">Docs</a><br />
         Fixed <tt>_.contains</tt>, which was mistakenly pointing at
         <tt>_.intersect</tt> instead of <tt>_.include</tt>, like it should
         have been. Added <tt>_.unique</tt> as an alias for <tt>_.uniq</tt>.
       </p>
 
-      <p>
+      <p id="1.1.1">
         <b class="header">1.1.1</b> &mdash; <small><i>Oct 5, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.0...1.1.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.1.1/index.html">Docs</a><br />
         Improved the speed of <tt>_.template</tt>, and its handling of multiline
         interpolations. Ryan Tenney contributed optimizations to many Underscore
         functions. An annotated version of the source code is now available.
       </p>
 
-      <p>
+      <p id="1.1.0">
         <b class="header">1.1.0</b> &mdash; <small><i>Aug 18, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.4...1.1.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.1.0/index.html">Docs</a><br />
         The method signature of <tt>_.reduce</tt> has been changed to match
         the ECMAScript 5 signature, instead of the Ruby/Prototype.js version.
@@ -2404,33 +2404,33 @@ _([1, 2, 3]).value();
         is a new alias for <tt>_.include</tt>.
       </p>
 
-      <p>
+      <p id="1.0.4">
         <b class="header">1.0.4</b> &mdash; <small><i>Jun 22, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.3...1.0.4">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.0.4/index.html">Docs</a><br />
         <a href="http://themoell.com/">Andri Möll</a> contributed the <tt>_.memoize</tt>
         function, which can be used to speed up expensive repeated computations
         by caching the results.
       </p>
 
-      <p>
+      <p id="1.0.3">
         <b class="header">1.0.3</b> &mdash; <small><i>Jun 14, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.2...1.0.3">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.0.3/index.html">Docs</a><br />
         Patch that makes <tt>_.isEqual</tt> return <tt>false</tt> if any property
         of the compared object has a <tt>NaN</tt> value. Technically the correct
         thing to do, but of questionable semantics. Watch out for NaN comparisons.
       </p>
 
-      <p>
+      <p id="1.0.2">
         <b class="header">1.0.2</b> &mdash; <small><i>Mar 23, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.1...1.0.2">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.0.2/index.html">Docs</a><br />
         Fixes <tt>_.isArguments</tt> in recent versions of Opera, which have
         arguments objects as real Arrays.
       </p>
 
-      <p>
+      <p id="1.0.1">
         <b class="header">1.0.1</b> &mdash; <small><i>Mar 19, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.0...1.0.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.0.1/index.html">Docs</a><br />
         Bugfix for <tt>_.isEqual</tt>, when comparing two objects with the same
         number of undefined keys, but with different names.
       </p>
 
-      <p>
+      <p id="1.0.0">
         <b class="header">1.0.0</b> &mdash; <small><i>Mar 18, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.6.0...1.0.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/1.0.0/index.html">Docs</a><br />
         Things have been stable for many months now, so Underscore is now
         considered to be out of beta, at <b>1.0</b>. Improvements since <b>0.6</b>
@@ -2438,7 +2438,7 @@ _([1, 2, 3]).value();
         take multiple source objects.
       </p>
 
-      <p>
+      <p id="0.6.0">
         <b class="header">0.6.0</b> &mdash; <small><i>Feb 24, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.4...0.5.5">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.5.5/index.html">Docs</a><br />
         Major release. Incorporates a number of
         <a href="http://github.com/ratbeard">Mile Frawley's</a> refactors for
@@ -2449,7 +2449,7 @@ _([1, 2, 3]).value();
         and <tt>Object.keys</tt>.
       </p>
 
-      <p>
+      <p id="0.5.8">
         <b class="header">0.5.8</b><br />
         Fixed Underscore's collection functions to work on
         <a href="https://developer.mozilla.org/En/DOM/NodeList">NodeLists</a> and
@@ -2458,32 +2458,32 @@ _([1, 2, 3]).value();
         <a href="http://github.com/jmtulloss">Justin Tulloss</a>.
       </p>
 
-      <p>
+      <p id="0.5.7">
         <b class="header">0.5.7</b> &mdash; <small><i>Jan 20, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.5...0.5.7">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.5.7/index.html">Docs</a><br />
         A safer implementation of <tt>_.isArguments</tt>, and a
         faster <tt>_.isNumber</tt>,<br />thanks to
         <a href="http://jedschmidt.com/">Jed Schmidt</a>.
       </p>
 
-      <p>
+      <p id="0.5.6">
         <b class="header">0.5.6</b>
         Customizable delimiters for <tt>_.template</tt>, contributed by
         <a href="http://github.com/iamnoah">Noah Sloan</a>.
       </p>
 
-      <p>
+      <p id="0.5.5">
         <b class="header">0.5.5</b> &mdash; <small><i>Jan 9, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.4...0.5.5">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.5.5/index.html">Docs</a><br />
         Fix for a bug in MobileSafari's OOP-wrapper, with the arguments object.
       </p>
 
-      <p>
+      <p id="0.5.4">
         <b class="header">0.5.4</b> &mdash; <small><i>Jan 5, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.2...0.5.4">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.5.4/index.html">Docs</a><br />
         Fix for multiple single quotes within a template string for
         <tt>_.template</tt>. See:
         <a href="http://www.west-wind.com/Weblog/posts/509108.aspx">Rick Strahl's blog post</a>.
       </p>
 
-      <p>
+      <p id="0.5.2">
         <b class="header">0.5.2</b> &mdash; <small><i>Jan 1, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.1...0.5.2">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.5.2/index.html">Docs</a><br />
         New implementations of <tt>isArray</tt>, <tt>isDate</tt>, <tt>isFunction</tt>,
         <tt>isNumber</tt>, <tt>isRegExp</tt>, and <tt>isString</tt>, thanks to
@@ -2499,7 +2499,7 @@ _([1, 2, 3]).value();
         which is handy for injecting side effects (like logging) into chained calls.
       </p>
 
-      <p>
+      <p id="0.5.1">
         <b class="header">0.5.1</b> &mdash; <small><i>Dec 9, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.0...0.5.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.5.1/index.html">Docs</a><br />
         Added an <tt>_.isArguments</tt> function. Lots of little safety checks
         and optimizations contributed by
@@ -2507,7 +2507,7 @@ _([1, 2, 3]).value();
         <a href="http://themoell.com/">Andri Möll</a>.
       </p>
 
-      <p>
+      <p id="0.5.0">
         <b class="header">0.5.0</b> &mdash; <small><i>Dec 7, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.7...0.5.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.5.0/index.html">Docs</a><br />
         <b>[API Changes]</b> <tt>_.bindAll</tt> now takes the context object as
         its first parameter. If no method names are passed, all of the context
@@ -2520,7 +2520,7 @@ _([1, 2, 3]).value();
         <a href="http://github.com/grayrest/">Karl Guertin</a> contributed patches.
       </p>
 
-      <p>
+      <p id="0.4.7">
         <b class="header">0.4.7</b> &mdash; <small><i>Dec 6, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.6...0.4.7">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.4.7/index.html">Docs</a><br />
         Added <tt>isDate</tt>, <tt>isNaN</tt>, and <tt>isNull</tt>, for completeness.
         Optimizations for <tt>isEqual</tt> when checking equality between Arrays
@@ -2528,7 +2528,7 @@ _([1, 2, 3]).value();
         browser) which speeds up the functions that rely on it, such as <tt>_.each</tt>.
       </p>
 
-      <p>
+      <p id="0.4.6">
         <b class="header">0.4.6</b> &mdash; <small><i>Nov 30, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.5...0.4.6">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.4.6/index.html">Docs</a><br />
         Added the <tt>range</tt> function, a port of the
         <a href="http://docs.python.org/library/functions.html#range">Python
@@ -2537,7 +2537,7 @@ _([1, 2, 3]).value();
         <a href="http://github.com/kylichuku">Kirill Ishanov</a>.
       </p>
 
-      <p>
+      <p id="0.4.5">
         <b class="header">0.4.5</b> &mdash; <small><i>Nov 19, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.4...0.4.5">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.4.5/index.html">Docs</a><br />
         Added <tt>rest</tt> for Arrays and arguments objects, and aliased
         <tt>first</tt> as <tt>head</tt>, and <tt>rest</tt> as <tt>tail</tt>,
@@ -2546,24 +2546,24 @@ _([1, 2, 3]).value();
         <i>arguments</i> objects.
       </p>
 
-      <p>
+      <p id="0.4.4">
         <b class="header">0.4.4</b> &mdash; <small><i>Nov 18, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.3...0.4.4">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.4.4/index.html">Docs</a><br />
         Added <tt>isString</tt>, and <tt>isNumber</tt>, for consistency. Fixed
         <tt>_.isEqual(NaN, NaN)</tt> to return <i>true</i> (which is debatable).
       </p>
 
-      <p>
+      <p id="0.4.3">
         <b class="header">0.4.3</b> &mdash; <small><i>Nov 9, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.2...0.4.3">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.4.3/index.html">Docs</a><br />
         Started using the native <tt>StopIteration</tt> object in browsers that support it.
         Fixed Underscore setup for CommonJS environments.
       </p>
 
-      <p>
+      <p id="0.4.2">
         <b class="header">0.4.2</b> &mdash; <small><i>Nov 9, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.2...0.4.2">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.4.2/index.html">Docs</a><br />
         Renamed the unwrapping function to <tt>value</tt>, for clarity.
       </p>
 
-      <p>
+      <p id="0.4.1">
         <b class="header">0.4.1</b> &mdash; <small><i>Nov 8, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.0...0.4.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.4.1/index.html">Docs</a><br />
         Chained Underscore objects now support the Array prototype methods, so
         that you can perform the full range of operations on a wrapped array
@@ -2572,7 +2572,7 @@ _([1, 2, 3]).value();
         <tt>isEmpty</tt> function that works on arrays and objects.
       </p>
 
-      <p>
+      <p id="0.4.0">
         <b class="header">0.4.0</b> &mdash; <small><i>Nov 7, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.3...0.4.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.4.0/index.html">Docs</a><br />
         All Underscore functions can now be called in an object-oriented style,
         like so: <tt>_([1, 2, 3]).map(...);</tt>. Original patch provided by
@@ -2582,20 +2582,20 @@ _([1, 2, 3]).value();
         was added, providing a sorted list of all the functions in Underscore.
       </p>
 
-      <p>
+      <p id="0.3.3">
         <b class="header">0.3.3</b> &mdash; <small><i>Oct 31, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.2...0.3.3">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.3.3/index.html">Docs</a><br />
         Added the JavaScript 1.8 function <tt>reduceRight</tt>. Aliased it
         as <tt>foldr</tt>, and aliased <tt>reduce</tt> as <tt>foldl</tt>.
       </p>
 
-      <p>
+      <p id="0.3.2">
         <b class="header">0.3.2</b> &mdash; <small><i>Oct 28, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.1...0.3.2">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.3.2/index.html">Docs</a><br />
         Now runs on stock <a href="http://www.mozilla.org/rhino/">Rhino</a>
         interpreters with: <tt>load("underscore.js")</tt>.
         Added <a href="#identity"><tt>identity</tt></a> as a utility function.
       </p>
 
-      <p>
+      <p id="0.3.1">
         <b class="header">0.3.1</b> &mdash; <small><i>Oct 29, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.0...0.3.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.3.1/index.html">Docs</a><br />
         All iterators are now passed in the original collection as their third
         argument, the same as JavaScript 1.6's <b>forEach</b>. Iterating over
@@ -2603,7 +2603,7 @@ _([1, 2, 3]).value();
         see <a href="#each"><tt>_.each</tt></a>.
       </p>
 
-      <p>
+      <p id="0.3.0">
         <b class="header">0.3.0</b><br /> &mdash; <small><i>Oct 29, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.2.0...0.3.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.3.0/index.html">Docs</a><br />
         Added <a href="http://github.com/dmitryBaranovskiy">Dmitry Baranovskiy</a>'s
         comprehensive optimizations, merged in
@@ -2612,20 +2612,20 @@ _([1, 2, 3]).value();
         <a href="http://narwhaljs.org/">Narwhal</a> compliant.
       </p>
 
-      <p>
+      <p id="0.2.0">
         <b class="header">0.2.0</b> &mdash; <small><i>Oct 28, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.1.1...0.2.0">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.2.0/index.html">Docs</a><br />
         Added <tt>compose</tt> and <tt>lastIndexOf</tt>, renamed <tt>inject</tt> to
         <tt>reduce</tt>, added aliases for <tt>inject</tt>, <tt>filter</tt>,
         <tt>every</tt>, <tt>some</tt>, and <tt>forEach</tt>.
       </p>
 
-      <p>
+      <p id="0.1.1">
         <b class="header">0.1.1</b> &mdash; <small><i>Oct 28, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.1.0...0.1.1">Diff</a> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.1.1/index.html">Docs</a><br />
         Added <tt>noConflict</tt>, so that the "Underscore" object can be assigned to
         other variables.
       </p>
 
-      <p>
+      <p id="0.1.0">
         <b class="header">0.1.0</b> &mdash; <small><i>Oct 28, 2009</i></small> &mdash; <a href="http://htmlpreview.github.com/?https://raw.github.com/jashkenas/underscore/0.1.1/index.html">Docs</a><br />
         Initial release of Underscore.js.
       </p>


### PR DESCRIPTION
Earlier today I wanted to link to http://underscorejs.org/#1.1.3. This pull request will enable linking to the release notes for a particular version.
