### PR TITLE
variadic _.isEqual

### DIFF
--- a/index.html
+++ b/index.html
@@ -1356,10 +1356,10 @@ _.has({a: 1, b: 2, c: 3}, "b");
 </pre>
 
       <p id="isEqual">
-        <b class="header">isEqual</b><code>_.isEqual(object, other)</code>
+        <b class="header">isEqual</b><code>_.isEqual(*values)</code>
         <br />
-        Performs an optimized deep comparison between the two objects, to determine
-        if they should be considered equal.
+        Performs optimized deep comparisons to determine whether all the provided
+        <b>values</b> should be considered equal.
       </p>
       <pre>
 var moe   = {name: 'moe', luckyNumbers: [13, 27, 34]};

--- a/test/objects.js
+++ b/test/objects.js
@@ -141,7 +141,7 @@
 
     // Basic equality and identity comparisons.
     ok(_.isEqual(null, null), '`null` is equal to `null`');
-    ok(_.isEqual(), '`undefined` is equal to `undefined`');
+    ok(_.isEqual(undefined, undefined), '`undefined` is equal to `undefined`');
 
     ok(!_.isEqual(0, -0), '`0` is not equal to `-0`');
     ok(!_.isEqual(-0, 0), 'Commutative equality is implemented for `0` and `-0`');
@@ -372,6 +372,17 @@
 
     var other = { 'a': 1 };
     strictEqual(_.isEqual(new Foo, other), false);
+
+    // Various numbers of arguments
+    strictEqual(_.isEqual(), true);
+    strictEqual(_.isEqual(0), true);
+    strictEqual(_.isEqual(0, 0), true);
+    strictEqual(_.isEqual(0, 0, 0), true);
+    strictEqual(_.isEqual(0, 0, 0, 0), true);
+    strictEqual(_.isEqual(0, 0, 0, 1), false);
+    strictEqual(_.isEqual(0, 0, 1, 0), false);
+    strictEqual(_.isEqual(0, 1, 0, 0), false);
+    strictEqual(_.isEqual(1, 0, 0, 0), false);
   });
 
   test('isEmpty', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -992,9 +992,14 @@
     return result;
   };
 
-  // Perform a deep comparison to check if two objects are equal.
-  _.isEqual = function(a, b) {
-    return eq(a, b, [], []);
+  // Are all the provided arguments equal in value?
+  _.isEqual = function(first) {
+    for (var i = 1, length = arguments.length; i < length; i++) {
+      if (!eq(first, arguments[i], [], [])) {
+        return false;
+      }
+    }
+    return true;
   };
 
   // Is a given array, string, or object empty?


### PR DESCRIPTION
This is useful for comparing all the items in a collection:

``` javascript
_.isEqual.apply(_, items)
```

The naming is a bit awkward. In certain contexts **equal** sounds best:

``` javascript
_.equal(a, b, c)
```

In other contexts, **isEqual** is better:

``` javascript
_(a).isEqual(b)
```

I stuck with the existing name as it's the least disruptive change.

---

Clojure's [`=`](http://clojuredocs.org/clojure_core/clojure.core/=) raises an ArityException if passed no arguments. I asked on `#clojure` whether this is because it's nonsensical to ask whether all the elements in the empty set are equal. Apparently this is not the case: it's a valid question and the answer is yes, all the elements are equal.
