### PR TITLE
add regexp flag order test for _.isEqual

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -208,6 +208,7 @@
 
     // RegExps.
     ok(_.isEqual(/(?:)/gim, /(?:)/gim), 'RegExps with equivalent patterns and flags are equal');
+    ok(_.isEqual(/(?:)/gi, /(?:)/ig), 'Flag order is not significant');
     ok(!_.isEqual(/(?:)/g, /(?:)/gi), 'RegExps with equivalent patterns and different flags are not equal');
     ok(!_.isEqual(/Moe/gim, /Curly/gim), 'RegExps with different patterns and equivalent flags are not equal');
     ok(!_.isEqual(/(?:)/gi, /(?:)/g), 'Commutative equality is implemented for RegExps');


### PR DESCRIPTION
This seems like correct behaviour given that regexp string representations are normalized:

``` javascript
> /foo/ig.toString()
'/foo/gi'
```
