### PR TITLE
reword introduction

### DIFF
--- a/index.html
+++ b/index.html
@@ -341,14 +341,11 @@
     </p>
 
     <p>
-      <a href="http://github.com/jashkenas/underscore/">Underscore</a> is a
-      utility-belt library for JavaScript that provides a lot of the
-      functional programming support that you would expect in
-      <a href="http://prototypejs.org/doc/latest/">Prototype.js</a>
-      (or <a href="http://www.ruby-doc.org/core/classes/Enumerable.html">Ruby</a>),
-      but without extending any of the built-in JavaScript objects. It's the
-      tie to go along with <a href="http://jquery.com">jQuery</a>'s tux,
-      and <a href="http://backbonejs.org">Backbone.js</a>'s suspenders.
+      <a href="http://github.com/jashkenas/underscore/">Underscore</a>
+      is a JavaScript library which facilitates functional programming
+      without extending built-in objects. It's the tie to go along with
+      <a href="http://jquery.com">jQuery</a>'s tux and
+      <a href="http://backbonejs.org">Backbone</a>'s suspenders.
     </p>
 
     <p>


### PR DESCRIPTION
- Underscore is now more widely recognized than Prototype.js, so describing the former as resembling the latter is not as helpful as it once was.
- We currently describe Underscore as both a tool-belt and a tie. :)
- I dropped the comma after "tux". The comma doesn't seem right to me.
- "Backbone.js's suspenders" is awkward. People refer to the library as Backbone in conversation, so dropping the suffix in this sentence seems sensible.
