### PR TITLE
Optimize _.max and _.min for performance

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -261,12 +261,12 @@
       return Math.max.apply(Math, obj);
     }
     if (!iterator && _.isEmpty(obj)) return -Infinity;
-    var result = {computed : -Infinity, value: -Infinity};
+    var result = -Infinity, lastComputed = -Infinity;
     each(obj, function(value, index, list) {
       var computed = iterator ? iterator.call(context, value, index, list) : value;
-      computed > result.computed && (result = {value : value, computed : computed});
+      computed > lastComputed && (result = value, lastComputed = computed);
     });
-    return result.value;
+    return result;
   };
 
   // Return the minimum element (or element-based computation).
@@ -275,12 +275,12 @@
       return Math.min.apply(Math, obj);
     }
     if (!iterator && _.isEmpty(obj)) return Infinity;
-    var result = {computed : Infinity, value: Infinity};
+    var result = Infinity, lastComputed = Infinity;
     each(obj, function(value, index, list) {
       var computed = iterator ? iterator.call(context, value, index, list) : value;
-      computed < result.computed && (result = {value : value, computed : computed});
+      computed < lastComputed && (result = value, lastComputed = computed);
     });
-    return result.value;
+    return result;
   };
 
   // Shuffle an array, using the modern version of the 


### PR DESCRIPTION
One optimization applied to `_.max` and `_.min` to prevent object creation in their loops. This change affects when passing large lists (length >= 65535) to this functions.

Performance gain depends on the arrangement of the passed lists to this functions:
An ascending sorted list is a bad arrangement for the `_.max` and a descending sorted list is bad for the `_.min`.

I prepared 4 jsPerfs to show you performance gains of this changes:
(`_.max` and `_.min` are the current versions and `_.max2` and `_.min2` are the new versions of this functions.)

`_.max` on a large randomly arranged list: [_.max(randomList)](http://jsperf.com/underscores-max-random-list/4)
`_.min` on a large randomly arranged list: [_.min(randomList)](http://jsperf.com/underscores-min-random-list/4)
`_.max` on a large bad arranged list: [_.max(badList)](http://jsperf.com/underscores-max-bad-list/6)
`_.min` on a large bad arranged list: [_.min(badList)](http://jsperf.com/underscores-min-bad-list/4)
