### PR TITLE
changelog: linkify contributor names

### DIFF
--- a/index.html
+++ b/index.html
@@ -2258,8 +2258,10 @@ _([1, 2, 3]).value();
             <tt>length</tt> properties. <small>(#329)</small>
           </li>
           <li>
-            <b>jrburke</b> contributed Underscore exporting for AMD module loaders,
-            and <b>tonylukasavage</b> for Appcelerator Titanium.
+            <a href="https://github.com/jrburke">James Burke</a>
+            contributed Underscore exporting for AMD module loaders, and
+            <a href="https://github.com/tonylukasavage">Tony Lukasavage</a>
+            for Appcelerator Titanium.
             <small>(#335, #338)</small>
           </li>
           <li>


### PR DESCRIPTION
Extracted from #1449. This brings the treatment of these contributors in line with mentions elsewhere in the document:

``` html
<a href="https://github.com/username">First Last</a>
```
