### PR TITLE
changelog: fix 0.3.2 release date

### DIFF
--- a/index.html
+++ b/index.html
@@ -2591,7 +2591,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="0.3.2">
-        <b class="header">0.3.2</b> &mdash; <small><i>Oct 28, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.1...0.3.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.3.2/index.html">Docs</a><br />
+        <b class="header">0.3.2</b> &mdash; <small><i>Oct 29, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.1...0.3.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.3.2/index.html">Docs</a><br />
         Now runs on stock <a href="http://www.mozilla.org/rhino/">Rhino</a>
         interpreters with: <tt>load("underscore.js")</tt>.
         Added <a href="#identity"><tt>identity</tt></a> as a utility function.


### PR DESCRIPTION
```
$ git show 0.3.2
commit d2d1285e26a206278ae9f711a589b5e49f54c60e
Author: Jeremy Ashkenas <jashkenas@gmail.com>
Date:   Thu Oct 29 14:45:56 2009 -0400

    version 0.3.2, with 'identity', and Rhino support
```

Currently, 0.3.2 appears to have been released _before_ 0.3.1. ;)
