### PR TITLE
changelog: use time elements for release dates

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,10 @@
       font-size: 16px;
       line-height: 30px;
     }
+    time {
+      font-style: italic;
+      font-size: smaller;
+    }
     span.alias {
       font-size: 14px;
       font-style: italic;
@@ -175,6 +179,10 @@
       }
     }
   </style>
+  <script>
+    // Allow specific HTML5 elements to be styled in old versions of IE.
+    document.createElement('time');
+  </script>
 </head>
 <body>
 
@@ -1916,7 +1924,7 @@ _([1, 2, 3]).value();
       <h2 id="changelog">Change Log</h2>
 
       <p id="1.5.2">
-        <b class="header">1.5.2</b> &mdash; <small><i>September 7, 2013</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.5.1...1.5.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.5.2/index.html">Docs</a><br />
+        <b class="header">1.5.2</b> &mdash; <time datetime="2013-09-07">September 7, 2013</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.5.1...1.5.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.5.2/index.html">Docs</a><br />
         <ul>
           <li>
             Added an <tt>indexBy</tt> function, which fits in alongside its
@@ -1935,7 +1943,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.5.1">
-        <b class="header">1.5.1</b> &mdash; <small><i>July 8, 2013</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.5.0...1.5.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.5.1/index.html">Docs</a><br />
+        <b class="header">1.5.1</b> &mdash; <time datetime="2013-07-08">July 8, 2013</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.5.0...1.5.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.5.1/index.html">Docs</a><br />
         <ul>
           <li>
             Removed <tt>unzip</tt>, as it's simply the application of <tt>zip</tt>
@@ -1946,7 +1954,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.5.0">
-        <b class="header">1.5.0</b> &mdash; <small><i>July 6, 2013</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.4...1.5.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.5.0/index.html">Docs</a><br />
+        <b class="header">1.5.0</b> &mdash; <time datetime="2013-07-06">July 6, 2013</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.4...1.5.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.5.0/index.html">Docs</a><br />
         <ul>
           <li>
             Added a new <tt>unzip</tt> function, as the inverse of <tt>_.zip</tt>.
@@ -1977,7 +1985,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.4.4">
-        <b class="header">1.4.4</b> &mdash; <small><i>January 30, 2013</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.3...1.4.4">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.4.4/index.html">Docs</a><br />
+        <b class="header">1.4.4</b> &mdash; <time datetime="2013-01-30">January 30, 2013</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.3...1.4.4">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.4.4/index.html">Docs</a><br />
         <ul>
           <li>
             Added <tt>_.findWhere</tt>, for finding the first element in a list
@@ -2003,7 +2011,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.4.3">
-        <b class="header">1.4.3</b> &mdash; <small><i>December 4, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.2...1.4.3">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.4.3/index.html">Docs</a><br />
+        <b class="header">1.4.3</b> &mdash; <time datetime="2012-12-04">December 4, 2012</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.2...1.4.3">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.4.3/index.html">Docs</a><br />
         <ul>
           <li>
             Improved Underscore compatibility with Adobe's JS engine that can be
@@ -2028,7 +2036,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.4.2">
-        <b class="header">1.4.2</b> &mdash; <small><i>October 6, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.1...1.4.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.4.2/index.html">Docs</a><br />
+        <b class="header">1.4.2</b> &mdash; <time datetime="2012-10-06">October 6, 2012</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.1...1.4.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.4.2/index.html">Docs</a><br />
         <ul>
           <li>
             For backwards compatibility, returned to pre-1.4.0 behavior when
@@ -2039,7 +2047,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.4.1">
-        <b class="header">1.4.1</b> &mdash; <small><i>October 1, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.0...1.4.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.4.1/index.html">Docs</a><br />
+        <b class="header">1.4.1</b> &mdash; <time datetime="2012-10-01">October 1, 2012</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.4.0...1.4.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.4.1/index.html">Docs</a><br />
         <ul>
           <li>
             Fixed a 1.4.0 regression in the <tt>lastIndexOf</tt> function.
@@ -2048,7 +2056,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.4.0">
-        <b class="header">1.4.0</b> &mdash; <small><i>September 27, 2012</i></small>  &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.3.3...1.4.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.4.0/index.html">Docs</a><br />
+        <b class="header">1.4.0</b> &mdash; <time datetime="2012-09-27">September 27, 2012</time>  &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.3.3...1.4.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.4.0/index.html">Docs</a><br />
         <ul>
           <li>
             Added a <tt>pairs</tt> function, for turning a JavaScript object
@@ -2113,7 +2121,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.3.3">
-        <b class="header">1.3.3</b> &mdash; <small><i>April 10, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.3.1...1.3.3">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.3.3/index.html">Docs</a><br />
+        <b class="header">1.3.3</b> &mdash; <time datetime="2012-04-10">April 10, 2012</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.3.1...1.3.3">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.3.3/index.html">Docs</a><br />
         <ul>
           <li>
             Many improvements to <tt>_.template</tt>, which now provides the
@@ -2156,7 +2164,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.3.1">
-        <b class="header">1.3.1</b> &mdash; <small><i>January 23, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.3.0...1.3.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.3.1/index.html">Docs</a><br />
+        <b class="header">1.3.1</b> &mdash; <time datetime="2012-01-23">January 23, 2012</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.3.0...1.3.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.3.1/index.html">Docs</a><br />
         <ul>
           <li>
             Added an <tt>_.has</tt> function, as a safer way to use <tt>hasOwnProperty</tt>.
@@ -2175,7 +2183,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.3.0">
-        <b class="header">1.3.0</b> &mdash; <small><i>January 11, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.4...1.3.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.3.0/index.html">Docs</a><br />
+        <b class="header">1.3.0</b> &mdash; <time datetime="2012-01-11">January 11, 2012</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.4...1.3.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.3.0/index.html">Docs</a><br />
         <ul>
           <li>
             Removed AMD (RequireJS) support from Underscore. If you'd like to use
@@ -2186,7 +2194,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.2.4">
-        <b class="header">1.2.4</b> &mdash; <small><i>January 4, 2012</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.3...1.2.4">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.2.4/index.html">Docs</a><br />
+        <b class="header">1.2.4</b> &mdash; <time datetime="2012-01-04">January 4, 2012</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.3...1.2.4">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.2.4/index.html">Docs</a><br />
         <ul>
           <li>
             You now can (and probably should, as it's simpler)
@@ -2209,7 +2217,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.2.3">
-        <b class="header">1.2.3</b> &mdash; <small><i>December 7, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.2...1.2.3">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.2.3/index.html">Docs</a><br />
+        <b class="header">1.2.3</b> &mdash; <time datetime="2011-12-07">December 7, 2011</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.2...1.2.3">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.2.3/index.html">Docs</a><br />
         <ul>
           <li>
             Dynamic scope is now preserved for compiled <tt>_.template</tt> functions,
@@ -2227,7 +2235,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.2.2">
-        <b class="header">1.2.2</b> &mdash; <small><i>November 14, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.1...1.2.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.2.1/index.html">Docs</a><br />
+        <b class="header">1.2.2</b> &mdash; <time datetime="2011-11-14">November 14, 2011</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.1...1.2.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.2.1/index.html">Docs</a><br />
         <ul>
           <li>
             Continued tweaks to <tt>_.isEqual</tt> semantics. Now JS primitives are
@@ -2250,7 +2258,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.2.1">
-        <b class="header">1.2.1</b> &mdash; <small><i>October 24, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.0...1.2.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.2.1/index.html">Docs</a><br />
+        <b class="header">1.2.1</b> &mdash; <time datetime="2011-10-24">October 24, 2011</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.2.0...1.2.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.2.1/index.html">Docs</a><br />
         <ul>
           <li>
             Several important bug fixes for <tt>_.isEqual</tt>, which should now
@@ -2291,7 +2299,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.2.0">
-        <b class="header">1.2.0</b> &mdash; <small><i>October 5, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.7...1.2.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.2.0/index.html">Docs</a><br />
+        <b class="header">1.2.0</b> &mdash; <time datetime="2011-10-05">October 5, 2011</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.7...1.2.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.2.0/index.html">Docs</a><br />
         <ul>
           <li>
             The <tt>_.isEqual</tt> function now
@@ -2322,7 +2330,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.1.7">
-        <b class="header">1.1.7</b> &mdash; <small><i>July 13, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.6...1.1.7">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.1.7/index.html">Docs</a><br />
+        <b class="header">1.1.7</b> &mdash; <time datetime="2011-07-13">July 13, 2011</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.6...1.1.7">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.1.7/index.html">Docs</a><br />
         Added <tt>_.groupBy</tt>, which aggregates a collection into groups of like items.
         Added <tt>_.union</tt> and <tt>_.difference</tt>, to complement the
         (re-named) <tt>_.intersection</tt>.
@@ -2333,7 +2341,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.1.6">
-        <b class="header">1.1.6</b> &mdash; <small><i>April 18, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.5...1.1.6">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.1.6/index.html">Docs</a><br />
+        <b class="header">1.1.6</b> &mdash; <time datetime="2011-04-18">April 18, 2011</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.5...1.1.6">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.1.6/index.html">Docs</a><br />
         Added <tt>_.after</tt>, which will return a function that only runs after
         first being called a specified number of times.
         <tt>_.invoke</tt> can now take a direct function reference.
@@ -2344,7 +2352,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.1.5">
-        <b class="header">1.1.5</b> &mdash; <small><i>March 20, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.4...1.1.5">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.1.5/index.html">Docs</a><br />
+        <b class="header">1.1.5</b> &mdash; <time datetime="2011-03-20">March 20, 2011</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.4...1.1.5">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.1.5/index.html">Docs</a><br />
         Added an <tt>_.defaults</tt> function, for use merging together JS objects
         representing default options.
         Added an <tt>_.once</tt> function, for manufacturing functions that should
@@ -2357,7 +2365,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.1.4">
-        <b class="header">1.1.4</b> &mdash; <small><i>January 9, 2011</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.3...1.1.4">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.1.4/index.html">Docs</a><br />
+        <b class="header">1.1.4</b> &mdash; <time datetime="2011-01-09">January 9, 2011</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.3...1.1.4">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.1.4/index.html">Docs</a><br />
         Improved compliance with ES5's Array methods when passing <tt>null</tt>
         as a value. <tt>_.wrap</tt> now correctly sets <tt>this</tt> for the
         wrapped function. <tt>_.indexOf</tt> now takes an optional flag for
@@ -2367,7 +2375,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.1.3">
-        <b class="header">1.1.3</b> &mdash; <small><i>December 1, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.2...1.1.3">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.1.3/index.html">Docs</a><br />
+        <b class="header">1.1.3</b> &mdash; <time datetime="2010-12-01">December 1, 2010</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.2...1.1.3">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.1.3/index.html">Docs</a><br />
         In CommonJS, Underscore may now be required with just: <br />
         <tt>var _ = require("underscore")</tt>.
         Added <tt>_.throttle</tt> and <tt>_.debounce</tt> functions.
@@ -2384,21 +2392,21 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.1.2">
-        <b class="header">1.1.2</b> &mdash; <small><i>October 15, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.1...1.1.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.1.2/index.html">Docs</a><br />
+        <b class="header">1.1.2</b> &mdash; <time datetime="2010-10-15">October 15, 2010</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.1...1.1.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.1.2/index.html">Docs</a><br />
         Fixed <tt>_.contains</tt>, which was mistakenly pointing at
         <tt>_.intersect</tt> instead of <tt>_.include</tt>, like it should
         have been. Added <tt>_.unique</tt> as an alias for <tt>_.uniq</tt>.
       </p>
 
       <p id="1.1.1">
-        <b class="header">1.1.1</b> &mdash; <small><i>October 5, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.0...1.1.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.1.1/index.html">Docs</a><br />
+        <b class="header">1.1.1</b> &mdash; <time datetime="2010-10-05">October 5, 2010</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.1.0...1.1.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.1.1/index.html">Docs</a><br />
         Improved the speed of <tt>_.template</tt>, and its handling of multiline
         interpolations. Ryan Tenney contributed optimizations to many Underscore
         functions. An annotated version of the source code is now available.
       </p>
 
       <p id="1.1.0">
-        <b class="header">1.1.0</b> &mdash; <small><i>August 18, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.4...1.1.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.1.0/index.html">Docs</a><br />
+        <b class="header">1.1.0</b> &mdash; <time datetime="2010-08-18">August 18, 2010</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.4...1.1.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.1.0/index.html">Docs</a><br />
         The method signature of <tt>_.reduce</tt> has been changed to match
         the ECMAScript 5 signature, instead of the Ruby/Prototype.js version.
         This is a backwards-incompatible change. <tt>_.template</tt> may now be
@@ -2407,33 +2415,33 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="1.0.4">
-        <b class="header">1.0.4</b> &mdash; <small><i>June 22, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.3...1.0.4">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.0.4/index.html">Docs</a><br />
+        <b class="header">1.0.4</b> &mdash; <time datetime="2010-06-22">June 22, 2010</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.3...1.0.4">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.0.4/index.html">Docs</a><br />
         <a href="http://themoell.com/">Andri Möll</a> contributed the <tt>_.memoize</tt>
         function, which can be used to speed up expensive repeated computations
         by caching the results.
       </p>
 
       <p id="1.0.3">
-        <b class="header">1.0.3</b> &mdash; <small><i>June 14, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.2...1.0.3">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.0.3/index.html">Docs</a><br />
+        <b class="header">1.0.3</b> &mdash; <time datetime="2010-06-14">June 14, 2010</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.2...1.0.3">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.0.3/index.html">Docs</a><br />
         Patch that makes <tt>_.isEqual</tt> return <tt>false</tt> if any property
         of the compared object has a <tt>NaN</tt> value. Technically the correct
         thing to do, but of questionable semantics. Watch out for NaN comparisons.
       </p>
 
       <p id="1.0.2">
-        <b class="header">1.0.2</b> &mdash; <small><i>March 23, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.1...1.0.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.0.2/index.html">Docs</a><br />
+        <b class="header">1.0.2</b> &mdash; <time datetime="2010-03-23">March 23, 2010</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.1...1.0.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.0.2/index.html">Docs</a><br />
         Fixes <tt>_.isArguments</tt> in recent versions of Opera, which have
         arguments objects as real Arrays.
       </p>
 
       <p id="1.0.1">
-        <b class="header">1.0.1</b> &mdash; <small><i>March 19, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.0...1.0.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.0.1/index.html">Docs</a><br />
+        <b class="header">1.0.1</b> &mdash; <time datetime="2010-03-19">March 19, 2010</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.0.0...1.0.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.0.1/index.html">Docs</a><br />
         Bugfix for <tt>_.isEqual</tt>, when comparing two objects with the same
         number of undefined keys, but with different names.
       </p>
 
       <p id="1.0.0">
-        <b class="header">1.0.0</b> &mdash; <small><i>March 18, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.6.0...1.0.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.0.0/index.html">Docs</a><br />
+        <b class="header">1.0.0</b> &mdash; <time datetime="2010-03-18">March 18, 2010</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.6.0...1.0.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/1.0.0/index.html">Docs</a><br />
         Things have been stable for many months now, so Underscore is now
         considered to be out of beta, at <b>1.0</b>. Improvements since <b>0.6</b>
         include <tt>_.isBoolean</tt>, and the ability to have <tt>_.extend</tt>
@@ -2441,7 +2449,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="0.6.0">
-        <b class="header">0.6.0</b> &mdash; <small><i>February 24, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.8...0.6.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.6.0/index.html">Docs</a><br />
+        <b class="header">0.6.0</b> &mdash; <time datetime="2010-02-24">February 24, 2010</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.8...0.6.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.6.0/index.html">Docs</a><br />
         Major release. Incorporates a number of
         <a href="https://github.com/ratbeard">Mile Frawley's</a> refactors for
         safer duck-typing on collection functions, and cleaner internals. A new
@@ -2452,7 +2460,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="0.5.8">
-        <b class="header">0.5.8</b> &mdash; <small><i>January 28, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.7...0.5.8">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.5.8/index.html">Docs</a><br />
+        <b class="header">0.5.8</b> &mdash; <time datetime="2010-01-28">January 28, 2010</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.7...0.5.8">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.5.8/index.html">Docs</a><br />
         Fixed Underscore's collection functions to work on
         <a href="https://developer.mozilla.org/En/DOM/NodeList">NodeLists</a> and
         <a href="https://developer.mozilla.org/En/DOM/HTMLCollection">HTMLCollections</a>
@@ -2461,32 +2469,32 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="0.5.7">
-        <b class="header">0.5.7</b> &mdash; <small><i>January 20, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.6...0.5.7">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.5.7/index.html">Docs</a><br />
+        <b class="header">0.5.7</b> &mdash; <time datetime="2010-01-20">January 20, 2010</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.6...0.5.7">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.5.7/index.html">Docs</a><br />
         A safer implementation of <tt>_.isArguments</tt>, and a
         faster <tt>_.isNumber</tt>,<br />thanks to
         <a href="http://jedschmidt.com/">Jed Schmidt</a>.
       </p>
 
       <p id="0.5.6">
-        <b class="header">0.5.6</b> &mdash; <small><i>January 18, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.5...0.5.6">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.5.6/index.html">Docs</a><br />
+        <b class="header">0.5.6</b> &mdash; <time datetime="2010-01-18">January 18, 2010</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.5...0.5.6">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.5.6/index.html">Docs</a><br />
         Customizable delimiters for <tt>_.template</tt>, contributed by
         <a href="https://github.com/iamnoah">Noah Sloan</a>.
       </p>
 
       <p id="0.5.5">
-        <b class="header">0.5.5</b> &mdash; <small><i>January 9, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.4...0.5.5">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.5.5/index.html">Docs</a><br />
+        <b class="header">0.5.5</b> &mdash; <time datetime="2010-01-09">January 9, 2010</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.4...0.5.5">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.5.5/index.html">Docs</a><br />
         Fix for a bug in MobileSafari's OOP-wrapper, with the arguments object.
       </p>
 
       <p id="0.5.4">
-        <b class="header">0.5.4</b> &mdash; <small><i>January 5, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.2...0.5.4">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.5.4/index.html">Docs</a><br />
+        <b class="header">0.5.4</b> &mdash; <time datetime="2010-01-05">January 5, 2010</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.2...0.5.4">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.5.4/index.html">Docs</a><br />
         Fix for multiple single quotes within a template string for
         <tt>_.template</tt>. See:
         <a href="http://www.west-wind.com/Weblog/posts/509108.aspx">Rick Strahl's blog post</a>.
       </p>
 
       <p id="0.5.2">
-        <b class="header">0.5.2</b> &mdash; <small><i>January 1, 2010</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.1...0.5.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.5.2/index.html">Docs</a><br />
+        <b class="header">0.5.2</b> &mdash; <time datetime="2010-01-01">January 1, 2010</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.1...0.5.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.5.2/index.html">Docs</a><br />
         New implementations of <tt>isArray</tt>, <tt>isDate</tt>, <tt>isFunction</tt>,
         <tt>isNumber</tt>, <tt>isRegExp</tt>, and <tt>isString</tt>, thanks to
         a suggestion from
@@ -2502,7 +2510,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="0.5.1">
-        <b class="header">0.5.1</b> &mdash; <small><i>December 9, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.0...0.5.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.5.1/index.html">Docs</a><br />
+        <b class="header">0.5.1</b> &mdash; <time datetime="2009-12-09">December 9, 2009</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.5.0...0.5.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.5.1/index.html">Docs</a><br />
         Added an <tt>_.isArguments</tt> function. Lots of little safety checks
         and optimizations contributed by
         <a href="https://github.com/iamnoah">Noah Sloan</a> and
@@ -2510,7 +2518,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="0.5.0">
-        <b class="header">0.5.0</b> &mdash; <small><i>December 7, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.7...0.5.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.5.0/index.html">Docs</a><br />
+        <b class="header">0.5.0</b> &mdash; <time datetime="2009-12-07">December 7, 2009</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.7...0.5.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.5.0/index.html">Docs</a><br />
         <b>[API Changes]</b> <tt>_.bindAll</tt> now takes the context object as
         its first parameter. If no method names are passed, all of the context
         object's methods are bound to it, enabling chaining and easier binding.
@@ -2523,7 +2531,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="0.4.7">
-        <b class="header">0.4.7</b> &mdash; <small><i>December 6, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.6...0.4.7">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.4.7/index.html">Docs</a><br />
+        <b class="header">0.4.7</b> &mdash; <time datetime="2009-12-06">December 6, 2009</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.6...0.4.7">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.4.7/index.html">Docs</a><br />
         Added <tt>isDate</tt>, <tt>isNaN</tt>, and <tt>isNull</tt>, for completeness.
         Optimizations for <tt>isEqual</tt> when checking equality between Arrays
         or Dates. <tt>_.keys</tt> is now <small><i><b>25%&ndash;2X</b></i></small> faster (depending on your
@@ -2531,7 +2539,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="0.4.6">
-        <b class="header">0.4.6</b> &mdash; <small><i>November 30, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.5...0.4.6">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.4.6/index.html">Docs</a><br />
+        <b class="header">0.4.6</b> &mdash; <time datetime="2009-11-30">November 30, 2009</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.5...0.4.6">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.4.6/index.html">Docs</a><br />
         Added the <tt>range</tt> function, a port of the
         <a href="http://docs.python.org/library/functions.html#range">Python
         function of the same name</a>, for generating flexibly-numbered lists
@@ -2540,7 +2548,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="0.4.5">
-        <b class="header">0.4.5</b> &mdash; <small><i>November 19, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.4...0.4.5">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.4.5/index.html">Docs</a><br />
+        <b class="header">0.4.5</b> &mdash; <time datetime="2009-11-19">November 19, 2009</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.4...0.4.5">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.4.5/index.html">Docs</a><br />
         Added <tt>rest</tt> for Arrays and arguments objects, and aliased
         <tt>first</tt> as <tt>head</tt>, and <tt>rest</tt> as <tt>tail</tt>,
         thanks to <a href="https://github.com/lukesutton">Luke Sutton</a>'s patches.
@@ -2549,24 +2557,24 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="0.4.4">
-        <b class="header">0.4.4</b> &mdash; <small><i>November 18, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.3...0.4.4">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.4.4/index.html">Docs</a><br />
+        <b class="header">0.4.4</b> &mdash; <time datetime="2009-11-18">November 18, 2009</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.3...0.4.4">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.4.4/index.html">Docs</a><br />
         Added <tt>isString</tt>, and <tt>isNumber</tt>, for consistency. Fixed
         <tt>_.isEqual(NaN, NaN)</tt> to return <i>true</i> (which is debatable).
       </p>
 
       <p id="0.4.3">
-        <b class="header">0.4.3</b> &mdash; <small><i>November 9, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.2...0.4.3">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.4.3/index.html">Docs</a><br />
+        <b class="header">0.4.3</b> &mdash; <time datetime="2009-11-09">November 9, 2009</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.2...0.4.3">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.4.3/index.html">Docs</a><br />
         Started using the native <tt>StopIteration</tt> object in browsers that support it.
         Fixed Underscore setup for CommonJS environments.
       </p>
 
       <p id="0.4.2">
-        <b class="header">0.4.2</b> &mdash; <small><i>November 9, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.1...0.4.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.4.2/index.html">Docs</a><br />
+        <b class="header">0.4.2</b> &mdash; <time datetime="2009-11-09">November 9, 2009</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.1...0.4.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.4.2/index.html">Docs</a><br />
         Renamed the unwrapping function to <tt>value</tt>, for clarity.
       </p>
 
       <p id="0.4.1">
-        <b class="header">0.4.1</b> &mdash; <small><i>November 8, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.0...0.4.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.4.1/index.html">Docs</a><br />
+        <b class="header">0.4.1</b> &mdash; <time datetime="2009-11-08">November 8, 2009</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.4.0...0.4.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.4.1/index.html">Docs</a><br />
         Chained Underscore objects now support the Array prototype methods, so
         that you can perform the full range of operations on a wrapped array
         without having to break your chain. Added a <tt>breakLoop</tt> method
@@ -2575,7 +2583,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="0.4.0">
-        <b class="header">0.4.0</b> &mdash; <small><i>November 7, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.3...0.4.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.4.0/index.html">Docs</a><br />
+        <b class="header">0.4.0</b> &mdash; <time datetime="2009-11-07">November 7, 2009</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.3...0.4.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.4.0/index.html">Docs</a><br />
         All Underscore functions can now be called in an object-oriented style,
         like so: <tt>_([1, 2, 3]).map(...);</tt>. Original patch provided by
         <a href="http://macournoyer.com/">Marc-André Cournoyer</a>.
@@ -2585,20 +2593,20 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="0.3.3">
-        <b class="header">0.3.3</b> &mdash; <small><i>October 31, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.2...0.3.3">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.3.3/index.html">Docs</a><br />
+        <b class="header">0.3.3</b> &mdash; <time datetime="2009-10-31">October 31, 2009</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.2...0.3.3">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.3.3/index.html">Docs</a><br />
         Added the JavaScript 1.8 function <tt>reduceRight</tt>. Aliased it
         as <tt>foldr</tt>, and aliased <tt>reduce</tt> as <tt>foldl</tt>.
       </p>
 
       <p id="0.3.2">
-        <b class="header">0.3.2</b> &mdash; <small><i>October 29, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.1...0.3.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.3.2/index.html">Docs</a><br />
+        <b class="header">0.3.2</b> &mdash; <time datetime="2009-10-29">October 29, 2009</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.1...0.3.2">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.3.2/index.html">Docs</a><br />
         Now runs on stock <a href="http://www.mozilla.org/rhino/">Rhino</a>
         interpreters with: <tt>load("underscore.js")</tt>.
         Added <a href="#identity"><tt>identity</tt></a> as a utility function.
       </p>
 
       <p id="0.3.1">
-        <b class="header">0.3.1</b> &mdash; <small><i>October 29, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.0...0.3.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.3.1/index.html">Docs</a><br />
+        <b class="header">0.3.1</b> &mdash; <time datetime="2009-10-29">October 29, 2009</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.3.0...0.3.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.3.1/index.html">Docs</a><br />
         All iterators are now passed in the original collection as their third
         argument, the same as JavaScript 1.6's <b>forEach</b>. Iterating over
         objects is now called with <tt>(value, key, collection)</tt>, for details
@@ -2606,7 +2614,7 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="0.3.0">
-        <b class="header">0.3.0</b> &mdash; <small><i>October 29, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.2.0...0.3.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.3.0/index.html">Docs</a><br />
+        <b class="header">0.3.0</b> &mdash; <time datetime="2009-10-29">October 29, 2009</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.2.0...0.3.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.3.0/index.html">Docs</a><br />
         Added <a href="https://github.com/DmitryBaranovskiy">Dmitry Baranovskiy</a>'s
         comprehensive optimizations, merged in
         <a href="https://github.com/kriskowal">Kris Kowal</a>'s patches to make Underscore
@@ -2615,20 +2623,20 @@ _([1, 2, 3]).value();
       </p>
 
       <p id="0.2.0">
-        <b class="header">0.2.0</b> &mdash; <small><i>October 28, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.1.1...0.2.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.2.0/index.html">Docs</a><br />
+        <b class="header">0.2.0</b> &mdash; <time datetime="2009-10-28">October 28, 2009</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.1.1...0.2.0">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.2.0/index.html">Docs</a><br />
         Added <tt>compose</tt> and <tt>lastIndexOf</tt>, renamed <tt>inject</tt> to
         <tt>reduce</tt>, added aliases for <tt>inject</tt>, <tt>filter</tt>,
         <tt>every</tt>, <tt>some</tt>, and <tt>forEach</tt>.
       </p>
 
       <p id="0.1.1">
-        <b class="header">0.1.1</b> &mdash; <small><i>October 28, 2009</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.1.0...0.1.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.1.1/index.html">Docs</a><br />
+        <b class="header">0.1.1</b> &mdash; <time datetime="2009-10-28">October 28, 2009</time> &mdash; <a href="https://github.com/jashkenas/underscore/compare/0.1.0...0.1.1">Diff</a> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.1.1/index.html">Docs</a><br />
         Added <tt>noConflict</tt>, so that the "Underscore" object can be assigned to
         other variables.
       </p>
 
       <p id="0.1.0">
-        <b class="header">0.1.0</b> &mdash; <small><i>October 28, 2009</i></small> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.1.1/index.html">Docs</a><br />
+        <b class="header">0.1.0</b> &mdash; <time datetime="2009-10-28">October 28, 2009</time> &mdash; <a href="http://htmlpreview.github.io/?https://raw.github.com/jashkenas/underscore/0.1.1/index.html">Docs</a><br />
         Initial release of Underscore.js.
       </p>
 


### PR DESCRIPTION
The markup change is purely semantic; the site's appearance is unchanged. Using time elements (with some straightforward styling) seems cleaner than the current small+i combo.

To ensure I didn't introduce any typos, I wrote a couple of scripts and compared their output.

``` bash
git tag | xargs -I {} \
  git --no-pager log --max-count=1 --pretty=format:'%d | %ad | %ad
' --date=short --decorate=short {} | \
  sed -e 's/ (tag: \(.*\))/\1/' \
      -e 's/ \([0-9]*\)-0*\([0-9]*\)-0*\([0-9]*\)$/ \2 \3, \1/' \
      -e 's/ 1 / January /' \
      -e 's/ 2 / February /' \
      -e 's/ 3 / March /' \
      -e 's/ 4 / April /' \
      -e 's/ 5 / May /' \
      -e 's/ 6 / June /' \
      -e 's/ 7 / July /' \
      -e 's/ 8 / August /' \
      -e 's/ 9 / September /' \
      -e 's/ 10 / October /' \
      -e 's/ 11 / November /' \
      -e 's/ 12 / December /'
```

``` javascript
_.chain(document.querySelectorAll('[id]'))
  .filter(function(el) {
    return /^\d\.\d\.\d$/.test(el.id);
  })
  .map(function(el) {
    var time = el.querySelector('time');
    return [el.id, time.getAttribute('datetime'), time.innerHTML].join(' | ');
  })
  .value()
  .reverse()
  .join('\n');
```

I noticed that the 1.4.2 release date was incorrect, so fixed it in an isolated commit. The only remaining differences are 0.5.3 and 1.3.2 which, though tagged, do not appear in the change log. I believe this is intentional.
