### PR TITLE
add omitValues function

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -90,6 +90,24 @@ $(document).ready(function() {
     ok(_.isEqual(_.omit(new Obj, 'b'), {a:1, c: 3}), 'include prototype props');
   });
 
+  test("omitValues", function() {
+    var result;
+    result = _.omitValues({a:1, b:2, c:3}, 2);
+    ok(_.isEqual(result, {a:1, c:3}), 'can omit a single value');
+    result = _.omitValues({a:1, b:2, c:3}, 1, 3);
+    ok(_.isEqual(result, {b:2}), 'can omit several named values');
+    result = _.omitValues({a:1, b:2, c:3}, [2, 3]);
+    ok(_.isEqual(result, {a:1}), 'can omit values named in an array');
+    result = _.omitValues({a:1, b:null, c:false, d:'', e:2}, [2, '', false, null]);
+    ok(_.isEqual(result, {a:1}), 'can omit primatives');
+    result = _.omitValues({a:1, b:{foo: 'bar' }}, {foo: 'bar' });
+    ok(!_.isEqual(result, {a:1}), 'can not omit non-primatives');
+
+    var Obj = function(){};
+    Obj.prototype = {a: 1, b: 2, c: 3};
+    ok(_.isEqual(_.omitValues(new Obj, 2), {a:1, c: 3}), 'include prototype props');
+  });
+
   test("defaults", function() {
     var result;
     var options = {zero: 0, one: 1, empty: "", nan: NaN, nothing: null};

--- a/underscore.js
+++ b/underscore.js
@@ -857,6 +857,18 @@
     return copy;
   };
 
+   // Return a copy of the object without the blacklisted values (primatives or references only).
+  _.omitValues = function(obj) {
+    var copy = {};
+    var vals = concat.apply(ArrayProto, slice.call(arguments, 1));
+    var val;
+    for (var key in obj) {
+      val = obj[key]; 
+      if (!_.contains(vals, val)) copy[key] = val;
+    }
+    return copy;
+  };
+
   // Fill in a given object with default properties.
   _.defaults = function(obj) {
     each(slice.call(arguments, 1), function(source) {


### PR DESCRIPTION
After had already written this, I read the contributing file which mentions looking up existing functionality in contrib. There is an `omitWhen` method which allows you to pass a predicate for matching against values. While this can achieve the same thing, the functionality is not explicit, unlike `omitValues`. 

I needed the functionality and I forgot about contrib. No biggy if you think this is to analogous to `omitWhen`.

If you need a use case consider a need for default values, but an object's value for any key could potentially be  an empty string. In my mind, I would think `_.defaults` would be the right choice, but it doesn't see an empty string as an unset value (which makes sense).

```
var props = { age: 43 };
var instanceProps = { name: '' };
var defaults = { name: 'unknown' };
_.defaults(props, instanceProps, defaults); // { age: 43, name: '' } 
_.defaults(props, _.omitValues(instaceProps, ''), defaults); // { age: 43, name: 'unknown' } 
```

One thought on matching values. The behavior will likely be incorrect for objects unless you pass the reference directly as a value to omit. This should probably be of note that you can only omit primitives unless you pass in reference.
