### PR TITLE
setTimeout receives arguments after delay argument

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -664,7 +664,7 @@
   // it with the arguments supplied.
   _.delay = function(func, wait) {
     var args = slice.call(arguments, 2);
-    return setTimeout(function(){ return func.apply(null, args); }, wait);
+    return setTimeout.apply(null, [func, wait].concat(args));
   };
 
   // Defers a function, scheduling it to run after the current call stack has


### PR DESCRIPTION
According to `setTimeout` [syntax](https://developer.mozilla.org/en-US/docs/Web/API/Window.setTimeout) we can pass arguments to executable function after `delay` argument

``` javascript
setTimeout(function(a, b){
  console.log('args', a, b);
}, 0, 'this is a', 'this is b');
```

In `delay` method we can apply `func`, `wait` and all args as one argument list. Also using this approach `func` saves context.
