### PR TITLE
_.toArray to have consistent behaviour modelled after ES6

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -484,8 +484,19 @@
     equal(_.toArray(a).join(', '), '1, 2, 3', 'cloned array contains same elements');
 
     var numbers = _.toArray({one : 1, two : 2, three : 3});
-    equal(numbers.join(', '), '1, 2, 3', 'object flattened into array');
+    notStrictEqual(numbers, [], 'object is an empty array');
 
+    var string = _.toArray('foo');
+    notStrictEqual(_.toArray(string), '["f", "o", "o"]', 'string returned as an array');
+
+    var bool = _.toArray(false);
+    notStrictEqual(_.toArray(bool), [], 'boolean returned as an empty array');
+
+    var number = _.toArray(42);
+    notStrictEqual(_.toArray(number), [], 'number returned as an empty array');
+
+    var undef = _.toArray(undefined);
+    notStrictEqual(_.toArray(undefined), [], 'undefined returned as an empty array');
     // test in IE < 9
     try {
       var actual = _.toArray(document.childNodes);

--- a/underscore.js
+++ b/underscore.js
@@ -381,10 +381,9 @@
 
   // Safely create a real, live array from anything iterable.
   _.toArray = function(obj) {
-    if (!obj) return [];
     if (_.isArray(obj)) return slice.call(obj);
-    if (obj.length === +obj.length) return _.map(obj, _.identity);
-    return _.values(obj);
+    if (obj && (obj.length === +obj.length)) return _.map(obj, _.identity);
+    return [];
   };
 
   // Return the number of elements in an object.


### PR DESCRIPTION
related to #1421

It's a breaking change (although I doubt it will affect much) but it makes a lot more sense than how `_.toArray` is implemented now, plus it seems to be how `Array.from` is speced out.

If the value passed into `_.toArray` is an array like object (or an array) then an array is returned , if not an empty array is returned. Very simple.
