### PR TITLE
Update pick and omit to accept a predicate

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -71,6 +71,15 @@
     result = _.pick({a:1, b:2, c:3}, ['a'], 'b');
     ok(_.isEqual(result, {a:1, b:2}), 'can restrict properties to those named in mixed args');
 
+    var isOdd = function(value, key, obj) { return value % 2 === 1; };
+    result = _.pick({a:1, b:2, c:3}, isOdd);
+    ok(_.isEqual(result, {a:1, c:3}), 'can accept a predicate');
+
+    var args;
+    var data = {a:1, b:2, c:3};
+    _.pick(data, function() {args = _.toArray(arguments); args.unshift(this);});
+    ok(_.isEqual([data, 3, 'c', data], args), 'predicate accepts arguments (context, value, key, object)');
+
     var Obj = function(){};
     Obj.prototype = {a: 1, b: 2, c: 3};
     ok(_.isEqual(_.pick(new Obj, 'a', 'c'), {a:1, c: 3}), 'include prototype props');
@@ -84,6 +93,15 @@
     ok(_.isEqual(result, {b:2}), 'can omit several named properties');
     result = _.omit({a:1, b:2, c:3}, ['b', 'c']);
     ok(_.isEqual(result, {a:1}), 'can omit properties named in an array');
+
+    var isOdd = function(value, key, obj) { return value % 2 === 1; };
+    result = _.omit({a:1, b:2, c:3}, isOdd);
+    ok(_.isEqual(result, {b:2}), 'can accept a predicate');
+
+    var args;
+    var data = {a:1, b:2, c:3};
+    _.omit(data, function() {args = _.toArray(arguments); args.unshift(this);});
+    ok(_.isEqual([data, 3, 'c', data], args), 'predicate accepts arguments (context, value, key, object)');
 
     var Obj = function(){};
     Obj.prototype = {a: 1, b: 2, c: 3};

--- a/underscore.js
+++ b/underscore.js
@@ -858,8 +858,15 @@
   _.pick = function(obj) {
     var copy = {};
     var keys = concat.apply(ArrayProto, slice.call(arguments, 1));
+    var predicate = function(v, k, o) { return k in o };
+
+    if (_.isFunction(_.first(keys))) {
+      predicate = _.first(keys);
+      keys = _.keys(obj);
+    }
+
     each(keys, function(key) {
-      if (key in obj) copy[key] = obj[key];
+      if (predicate.call(obj, obj[key], key, obj)) copy[key] = obj[key];
     });
     return copy;
   };
@@ -868,9 +875,15 @@
   _.omit = function(obj) {
     var copy = {};
     var keys = concat.apply(ArrayProto, slice.call(arguments, 1));
-    for (var key in obj) {
-      if (!_.contains(keys, key)) copy[key] = obj[key];
+    var predicate = function(v, k, o) { return _.contains(keys, k); };
+
+    if (_.isFunction(_.first(keys))) {
+      predicate = _.first(keys);
     }
+
+    for (var key in obj) {
+      if (!predicate.call(obj, obj[key], key, obj)) copy[key] = obj[key];
+    };
     return copy;
   };
 


### PR DESCRIPTION
Here's a small change that would add support for using predicates with `pick` and `omit`. The interface would support `_.pick(obj, 'key1', 'key2')` and `_.pick(obj, predicate)`. It's based on the discussion from #359 #833. If this feels like interface bloat, I think `_.subset(obj, predicate)` would be a good alternative.

Regardless of the api, adding an easy option for getting a subset of an object feels right. Using `reduce` is a lot of boilerplate and unintuitive for many people. 

``` js
_.reduce(obj, function(memo, v, k) {if(predicate) memo[k] = v; return memo}, {})
```

Here's a small code sample for how `omit` and `pick` would work.

``` js
var data = { 'name': 'moe', 'userid': 'moe1' , '_hint': 'knucklehead', '_seed': '96c4eb' };

_.pick(data, 'name');                                                    
_.pick(data, function(value, key) {  return key.charAt(0) != '_'; });    

_.omit(data, 'userid');                                                                      
_.omit(data, function(value, key) { return key.charAt(0) == '_'; });  

// → { 'name': 'moe' }
// → { 'name': 'moe', 'userid': 'moe1' }
// → { 'name': 'moe', 'age': 40, 'userid': 'moe1' }
// → { 'name': 'moe', 'userid': 'moe1' }
```
