### PR TITLE
Allow _.throttle to function correctly after the system time is updated

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -334,6 +334,28 @@
     _.delay(function(){ equal(counter, 1, 'incr was debounced'); start(); }, 96);
   });
 
+  asyncTest('debounce after system time is set backwards', 2, function() {
+    var counter = 0;
+    var origNowFunc = _.now;
+    var debouncedIncr = _.debounce(function(){
+      counter++;
+    }, 100, true);
+
+    debouncedIncr();
+    equal(counter, 1, 'incr was called immediately');
+
+    _.now = function () {
+      return new Date(2013, 0, 1, 1, 1, 1);
+    };
+
+    _.delay(function() {
+      debouncedIncr();
+      equal(counter, 2, 'incr was debounced successfully');
+      start();
+      _.now = origNowFunc;
+    },200);
+  });
+
   test('once', function() {
     var num = 0;
     var increment = _.once(function(){ num++; });

--- a/underscore.js
+++ b/underscore.js
@@ -717,7 +717,8 @@
 
     var later = function() {
       var last = _.now() - timestamp;
-      if (last < wait) {
+
+      if (last < wait && last > 0) {
         timeout = setTimeout(later, wait - last);
       } else {
         timeout = null;


### PR DESCRIPTION
I have found that if the system time is moved backwards, calls to throttle will stop executing.

To test this, if the system time is moved backwards by an hour then the `remaining` variable in `_.throttle` containing the time offset becomes a large positive integer and the throttle callback will not be called until the adjusted hour time difference has passed, instead of the expected wait time. 

For this reason I suggest that an additional check is made to see if `remaining` exceeds the `wait` time which will then clear the existing timeout and return the method to a normal state.

I have tested this in a project and provided a unit test as proof.
