### PR TITLE
Union and Difference Accept Only Arrays

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -125,8 +125,8 @@
     result = _.union(args, [2, 30, 1], [1, 40]);
     equal(result.join(' '), '1 2 3 30 40', 'takes the union of a list of arrays');
 
-    result = _.union(null, [1, 2, 3]);
-    deepEqual(result, [null, 1, 2, 3]);
+    result = _.union([1, 2, 3], 4);
+    deepEqual(result, [1, 2, 3], 'restrict the union to arrays only');
   });
 
   test('difference', function() {
@@ -135,6 +135,9 @@
 
     result = _.difference([1, 2, 3, 4], [2, 30, 40], [1, 11, 111]);
     equal(result.join(' '), '3 4', 'takes the difference of three arrays');
+
+    result = _.difference([1, 2, 3], 1);
+    deepEqual(result, [1, 2, 3], 'restrict the difference to arrays only');
   });
 
   test('zip', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -436,23 +436,26 @@
   };
 
   // Internal implementation of a recursive `flatten` function.
-  var flatten = function(input, shallow, output) {
+  var flatten = function(input, shallow, strict, output) {
     if (shallow && _.every(input, _.isArray)) {
       return concat.apply(output, input);
     }
-    each(input, function(value) {
-      if (_.isArray(value) || _.isArguments(value)) {
-        shallow ? push.apply(output, value) : flatten(value, shallow, output);
+    for (var i = 0, length = input.length; i < length; i++) {
+      var value = input[i];
+      if (!_.isArray(value) && !_.isArguments(value)) {
+        if (!strict) output.push(value);
+      } else if (shallow) {
+        push.apply(output, value);
       } else {
-        output.push(value);
+        flatten(value, shallow, strict, output);
       }
-    });
+    }
     return output;
   };
 
   // Flatten out an array, either recursively (by default), or just one level.
   _.flatten = function(array, shallow) {
-    return flatten(array, shallow, []);
+    return flatten(array, shallow, false, []);
   };
 
   // Return a version of the array that does not contain the specified value(s).
@@ -495,7 +498,7 @@
   // Produce an array that contains the union: each distinct element from all of
   // the passed-in arrays.
   _.union = function() {
-    return _.uniq(_.flatten(arguments, true));
+    return _.uniq(flatten(arguments, true, true, []));
   };
 
   // Produce an array that contains every item shared between all the
@@ -512,7 +515,7 @@
   // Take the difference between one array and a number of other arrays.
   // Only the elements present in just the first array will remain.
   _.difference = function(array) {
-    var rest = concat.apply(ArrayProto, slice.call(arguments, 1));
+    var rest = flatten(slice.call(arguments, 1), true, true, []);
     return _.filter(array, function(value){ return !_.contains(rest, value); });
   };
 


### PR DESCRIPTION
Based on #1428, I tweaked things a bit more (comments inline).

@michaelficarra I also dislike the extra boolean argument but I'm not sure what to do about it as all the other methods I can think of are a performance compromise (options hash, separate filter).  I'm not a big fan of co-opting `_.flatten` at all but it otherwise we're essentially including it twice.  Suggestions welcome!
