### PR TITLE
Do not store a direct reference to Date.now

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1135,7 +1135,7 @@
   };
 
   // A (possibly faster) way to get the current timestamp as an integer.
-  _.now = Date.now || function() { return new Date().getTime(); };
+  _.now = function () { return Date.now(); } || function() { return new Date().getTime(); };
 
   // List of HTML entities for escaping.
   var entityMap = {


### PR DESCRIPTION
The adition of `_.now` made it much harder to use fake timers when testing (e.g., http://sinonjs.org/docs/#clock), because we need to stub `Date.now` before loading Underscore. This is not practical at all and doesn't allow for using fake timers only in some tests.

This patch adds a wrapper function around `Date.now`.

I understand that this may incur a small performance penalty, but I think that being able to test code that uses `_.now` (directly or indirectly) is more important.
