### PR TITLE
Revert "_.partition only accepts arrays."

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,6 +221,7 @@
       <li>- <a href="#sample">sample</a></li>
       <li>- <a href="#toArray">toArray</a></li>
       <li>- <a href="#size">size</a></li>
+      <li>- <a href="#partition">partition</a></li>
     </ul>
 
     <a class="toc_title" href="#arrays">
@@ -234,7 +235,6 @@
       <li>- <a href="#compact">compact</a></li>
       <li>- <a href="#flatten">flatten</a></li>
       <li>- <a href="#without">without</a></li>
-      <li>- <a href="#partition">partition</a></li>
       <li>- <a href="#union">union</a></li>
       <li>- <a href="#intersection">intersection</a></li>
       <li>- <a href="#difference">difference</a></li>
@@ -775,6 +775,17 @@ _.size({one: 1, two: 2, three: 3});
 =&gt; 3
 </pre>
 
+      <p id="partition">
+        <b class="header">partition</b><code>_.partition(array, predicate)</code>
+        <br />
+        Split <b>array</b> into two arrays: one whose elements all satisfy
+        <b>predicate</b> and one whose elements all do not satisfy <b>predicate</b>.
+      </p>
+      <pre>
+_.partition([0, 1, 2, 3, 4, 5], isOdd);
+=&gt; [[1, 3, 5], [0, 2, 4]]
+</pre>
+
       <h2 id="arrays">Array Functions</h2>
 
       <p>
@@ -866,17 +877,6 @@ _.flatten([1, [2], [3, [[4]]]], true);
       <pre>
 _.without([1, 2, 1, 0, 3, 1, 4], 0, 1);
 =&gt; [2, 3, 4]
-</pre>
-
-      <p id="partition">
-        <b class="header">partition</b><code>_.partition(array, predicate)</code>
-        <br />
-        Split <b>array</b> into two arrays: one whose elements all satisfy
-        <b>predicate</b> and one whose elements all do not satisfy <b>predicate</b>.
-      </p>
-      <pre>
-_.partition([0, 1, 2, 3, 4, 5], isOdd);
-=&gt; [[1, 3, 5], [0, 2, 4]]
 </pre>
 
       <p id="union">

--- a/test/arrays.js
+++ b/test/arrays.js
@@ -226,21 +226,4 @@
     equal(_.range(0, -10, -1).join(' '), '0 -1 -2 -3 -4 -5 -6 -7 -8 -9', 'final example in the Python docs');
   });
 
-  test('partition', function() {
-    var list = [0, 1, 2, 3, 4, 5];
-    deepEqual(_.partition(list, function(x) { return x < 4; }), [[0,1,2,3],[4,5]], 'handles bool return values');
-    deepEqual(_.partition(list, function(x) { return x & 1; }), [[1,3,5],[0,2,4]], 'handles 0 and 1 return values');
-    deepEqual(_.partition(list, function(x) { return x - 3; }), [[0,1,2,4,5],[3]], 'handles other numeric return values');
-    deepEqual(_.partition(list, function(x) { return x > 1 ? null : true; }), [[0,1],[2,3,4,5]], 'handles null return values');
-    deepEqual(_.partition(list, function(x) { if(x < 2) return true; }), [[0,1],[2,3,4,5]], 'handles undefined return values');
-
-    // Default iterator
-    deepEqual(_.partition([1, false, true, '']), [[1, true], [false, '']], 'Default iterator');
-    deepEqual(_.partition([{x: 1}, {x: 0}, {x: 1}], 'x'), [[{x: 1}, {x: 1}], [{x: 0}]], 'Takes a string');
-
-    // Context
-    var predicate = function(x){ return x === this.x };
-    deepEqual(_.partition([1, 2, 3], predicate, {x: 2}), [[2], [1, 3]], 'partition takes a context argument');
-  });
-
 })();

--- a/test/collections.js
+++ b/test/collections.js
@@ -511,4 +511,22 @@
     equal(_.size(null), 0, 'handles nulls');
   });
 
+  test('partition', function() {
+    var list = [0, 1, 2, 3, 4, 5];
+    deepEqual(_.partition(list, function(x) { return x < 4; }), [[0,1,2,3],[4,5]], 'handles bool return values');
+    deepEqual(_.partition(list, function(x) { return x & 1; }), [[1,3,5],[0,2,4]], 'handles 0 and 1 return values');
+    deepEqual(_.partition(list, function(x) { return x - 3; }), [[0,1,2,4,5],[3]], 'handles other numeric return values');
+    deepEqual(_.partition(list, function(x) { return x > 1 ? null : true; }), [[0,1],[2,3,4,5]], 'handles null return values');
+    deepEqual(_.partition(list, function(x) { if(x < 2) return true; }), [[0,1],[2,3,4,5]], 'handles undefined return values');
+    deepEqual(_.partition({a: 1, b: 2, c: 3}, function(x) { return x > 1; }), [[2, 3], [1]], 'handles objects');
+
+    // Default iterator
+    deepEqual(_.partition([1, false, true, '']), [[1, true], [false, '']], 'Default iterator');
+    deepEqual(_.partition([{x: 1}, {x: 0}, {x: 1}], 'x'), [[{x: 1}, {x: 1}], [{x: 0}]], 'Takes a string');
+
+    // Context
+    var predicate = function(x){ return x === this.x };
+    deepEqual(_.partition([1, 2, 3], predicate, {x: 2}), [[2], [1, 3]], 'partition takes a context argument');
+  });
+
 })();

--- a/underscore.js
+++ b/underscore.js
@@ -465,13 +465,12 @@
 
   // Split an array into two arrays: one whose elements all satisfy the given
   // predicate, and one whose elements all do not satisfy the predicate.
-  _.partition = function(array, predicate, context) {
+  _.partition = function(obj, predicate, context) {
     predicate = lookupIterator(predicate);
     var pass = [], fail = [];
-    for (var i = 0, length = array.length; i < length; i++) {
-      var elem = array[i];
+    each(obj, function(elem) {
       (predicate.call(context, elem) ? pass : fail).push(elem);
-    }
+    });
     return [pass, fail];
   };
 


### PR DESCRIPTION
Apologies for the back and forth, but I didn't take into account in #1476 that this would be breaking change for 1.6.0.  I think we should just move the docs and leave the collection support.  I've also renamed the `array` argument as `obj`.
