### PR TITLE
add _.results() method and test

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -234,6 +234,20 @@
     strictEqual(_.result(null, 'x'), undefined);
   });
 
+  test('_.results iterates an object with function and return invoked results', function() {
+    var obj = {w: '', x: 'x', y: function(){ return this.x; }};
+    var results = _.results(obj)
+    strictEqual(results.w, '');
+    strictEqual(results.x, 'x');
+    strictEqual(results.y, 'x');
+
+    var contextObj = {x: '_x'}
+    var results = _.results(obj, contextObj)
+    strictEqual(results.w, '');
+    strictEqual(results.x, 'x');
+    strictEqual(results.y, '_x');
+  });
+
   test('_.templateSettings.variable', function() {
     var s = '<%=data.x%>';
     var data = {x: 'x'};

--- a/underscore.js
+++ b/underscore.js
@@ -1172,6 +1172,19 @@
     return _.isFunction(value) ? value.call(object) : value;
   };
 
+  // Iterates an one level object with functions inside and return invoked values
+  _.results = function(object, context) {
+    if (typeof context == "undefined") {
+      context = object;
+    };
+    var copy = {};
+    _.each(object, function(value, key) {
+      var v = _.isFunction(value) ? value.call(context) : value;
+      copy[key] = v;
+    });
+    return copy;
+  };
+
   // Add your own custom functions to the Underscore object.
   _.mixin = function(obj) {
     each(_.functions(obj), function(name) {


### PR DESCRIPTION
When working on project with Backbone, I often find such a pattern that I need to define a config object inside View/Model/Collection, which contains both values and functions. Something like this

``` javascript
var Foo = Backbone.collection.extend({
  this.query: {
    perPage: 10,
    page: function(){this.nextPage()};
  }
});
```

I have not found a quick way to convert `this.query` to object with plain values only, when `_.result()` only deals with single key. So I added this method `_.results` which will iterate a whole one level only object, invoke each function and return values, as well as applying context as needed.

Hope this would be useful.
