### PR TITLE
added _.delayMethod

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -107,6 +107,16 @@
     setTimeout(function(){ ok(delayed, 'delayed the function'); start(); }, 150);
   });
 
+  asyncTest('delayMethod', 2, function() {
+    var obj = { test: function(a,b){ this.called = a+b; } };
+    _.delayMethod(obj,"test",100,"a","b");
+    _.delay(function(){ ok(!obj.called, "didn't call the method quite yet"); }, 50);
+    _.delay(function(){
+      ok(obj.called==="ab", "called with correct context and arguments");
+      start();
+    }, 150);
+  });
+
   asyncTest('defer', 1, function() {
     var deferred = false;
     _.defer(function(bool){ deferred = bool; }, true);

--- a/underscore.js
+++ b/underscore.js
@@ -670,6 +670,12 @@
     return setTimeout(function(){ return func.apply(null, args); }, wait);
   };
 
+  // Further syntactic sugar for delaying a method on an object
+  _.delayMethod = function(obj, methodname, wait) {
+    var args = slice.call(arguments, 3);
+    return setTimeout(function(){ return obj[methodname].apply(obj, args); }, wait);
+  };
+
   // Defers a function, scheduling it to run after the current call stack has
   // cleared.
   _.defer = function(func) {


### PR DESCRIPTION
I've found that it's quite common to want to use an object method as a timeout callback. That means you have to do this...

```
    _.delay(function(){obj.method();},time);
```

...or this...

```
    _.delay(_.bind(obj.method,obj),time]);
```

...to ensure that the context is correct. With this proposed change, you instead do this:

```
    _.delayMethod(obj,"method",time);
```
