### PR TITLE
Added Size, Keys examples with description

### DIFF
--- a/index.html
+++ b/index.html
@@ -1252,8 +1252,8 @@ welcome('moe');
 _.keys({one: 1, two: 2, three: 3});
 =&gt; ["one", "two", "three"]
 
-_.keys([1,2,3,4]);
-=&gt; ["0", "1", "2", "3"]
+_.keys(["foo", "bar", "baz"]);
+=&gt; ["0", "1", "2"]
 </pre>
 
       <p id="values">


### PR DESCRIPTION
Added an example to size method in the documentation for an array along with list(which was already present in the documentation). Found out interesting feature of _.keys which returns the index values  of the elements in an array as keys.
