### PR TITLE
add _.noop

### DIFF
--- a/index.html
+++ b/index.html
@@ -1625,6 +1625,13 @@ var moe = {name: 'moe'};
 moe === _.constant(moe)();
 =&gt; true</pre>
 
+      <p id="noop">
+        <b class="header">noop</b><code>_.noop()</code>
+        <br />
+        Returns <tt>undefined</tt> irrespective of the arguments passed to it.
+        Useful as the default for optional callback arguments.
+      </p>
+
       <p id="times">
         <b class="header">times</b><code>_.times(n, iterator, [context])</code>
         <br />

--- a/test/utility.js
+++ b/test/utility.js
@@ -30,6 +30,10 @@
     equal(_.constant(moe)(), moe, 'should create a function that returns moe');
   });
 
+  test('noop', function() {
+    strictEqual(_.noop('curly', 'larry', 'moe'), undefined, 'should always return undefined');
+  });
+
   test('property', function() {
     var moe = {name : 'moe'};
     equal(_.property('name')(moe), 'moe', 'should return the property with the given name');

--- a/underscore.js
+++ b/underscore.js
@@ -1102,6 +1102,8 @@
     };
   };
 
+  _.noop = function() {};
+
   _.property = function(key) {
     return function(obj) {
       return obj[key];


### PR DESCRIPTION
This is an unassuming function, but I've found myself defining it more often than one might imagine.

An example of a situation in which this function is useful:

``` coffeescript
f = (x, success = (->), error = (->)) ->
```

``` coffeescript
f = (x, success = _.noop, error = _.noop) ->
```
