### PR TITLE
Remove minified script inclusion in component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -4,7 +4,7 @@
   "keywords"      : ["util", "functional", "server", "client", "browser"],
   "repo"          : "jashkenas/underscore",
   "main"          : "underscore.js",
-  "scripts"       : ["underscore.js", "underscore-min.js"],
+  "scripts"       : ["underscore.js"],
   "version"       : "1.6.0",
   "license"       : "MIT"
 }


### PR DESCRIPTION
It's not necessary to include the minified version in component.json. Component-build will produce a minified bundle automatically. This is a regression introduced by #1470 
