### PR TITLE
Add _.nop as an alias for _.noop

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1115,7 +1115,7 @@
     };
   };
 
-  _.noop = function(){};
+  _.noop = _.nop = function(){};
 
   _.property = function(key) {
     return function(obj) {


### PR DESCRIPTION
I usually call my noops `nop` and I think its pretty common for other developers as well. See http://en.wikipedia.org/wiki/NOP.

Since we have aliases for other operations, maybe its worth adding this one too.
