### PR TITLE
Optimize _.intersection for performance

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -518,7 +518,7 @@
   // passed-in arrays.
   _.intersection = function() {
     var args = slice.call(arguments);
-    var smallest = _.min(args, _.property('length'));
+    var smallest = _.min(args, function(a) { if (a) return a.length; });
     return _.filter(_.uniq(smallest), function(item) {
       return _.every(args, function(other) {
         return other === smallest || _.contains(other, item);


### PR DESCRIPTION
`_.intersection` can be faster if the smallest set is passed to the `_.filter` instead of the first one.

We can do this because of `commutative property` of sets:
A ∩ B = B ∩ A

jsPerfs:
[small set[3] as the first passed set](http://jsperf.com/improve-intersection/9)
[medium set[10] as the first passed set](http://jsperf.com/improve-intersection/8)
[large set[100] as the first passed set](http://jsperf.com/improve-intersection/10)
