### PR TITLE
use sentence case for download descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -396,13 +396,13 @@
     <table>
       <tr>
         <td><a href="underscore.js">Development Version (1.6.0)</a></td>
-        <td><i>44kb, Uncompressed with Plentiful Comments</i></td>
+        <td><i>44kb, Uncompressed with plentiful comments</i></td>
       </tr>
       <tr>
         <td><a href="underscore-min.js">Production Version (1.6.0)</a></td>
         <td>
-          <i>5.0kb, Minified and Gzipped</i>
-          &nbsp;<small>(<a href="underscore-min.map">Source Map</a>)</small>
+          <i>5.0kb, Minified and gzipped</i>
+          &nbsp;<small>(<a href="underscore-min.map">source map</a>)</small>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
Currently, the descriptions of "Development Version" and "Production Version" are in title case, while the description of "Edge Version" is in sentence case.
