### PR TITLE
Provide default value to result method. Fix #1495

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -270,6 +270,33 @@
     strictEqual(_.result(null, 'x'), undefined);
   });
 
+  test('result returns a default value if object is null or undefined', function() {
+    strictEqual(_.result(null, 'b', 'default'), 'default');
+    strictEqual(_.result(undefined, 'c', 'default'), 'default');
+    strictEqual(_.result(''.match('missing'), 1, 'default'), 'default');
+  });
+
+  test('result returns a default value if property of object is missing', function() {
+    strictEqual(_.result({d: null}, 'd', 'default'), null);
+    strictEqual(_.result({e: false}, 'e', 'default'), false);
+  });
+
+  test('result only returns the default value if the object does not have the property or is undefined', function() {
+    strictEqual(_.result({}, 'b', 'default'), 'default');
+    strictEqual(_.result({d: undefined}, 'd', 'default'), 'default');
+  });
+
+  test('result does not return the default if the property of an object is found in the prototype', function() {
+    var Foo = function(){};
+    Foo.prototype.bar = 1;
+    strictEqual(_.result(new Foo, 'bar', 2), 1);
+  });
+
+  test('result does use the fallback when the result of invoking the property is undefined', function() {
+    var obj = {a: function() {}};
+    strictEqual(_.result(obj, 'a', 'failed'), undefined);
+  });
+
   test('_.templateSettings.variable', function() {
     var s = '<%=data.x%>';
     var data = {x: 'x'};

--- a/underscore.js
+++ b/underscore.js
@@ -861,7 +861,7 @@
     if (nativeKeys) return nativeKeys(obj);
     var keys = [];
     for (var key in obj) if (_.has(obj, key)) keys.push(key);
-    
+
     // Ahem, Internet Explorer.
     if (hasEnumBug) {
       var nonEnumIdx = nonEnumerableProps.length;
@@ -1260,9 +1260,11 @@
 
   // If the value of the named `property` is a function then invoke it with the
   // `object` as context; otherwise, return it.
-  _.result = function(object, property) {
-    if (object == null) return void 0;
-    var value = object[property];
+  _.result = function(object, property, fallback) {
+    var value = object == null ? void 0 : object[property];
+    if (value === void 0) {
+      return fallback;
+    }
     return _.isFunction(value) ? object[property]() : value;
   };
 


### PR DESCRIPTION
This pull request fulfills the proposal suggested in #1495. With this addition, `_.result` now supports:

``` javascript
_.result(null, 'method', 'default') // => 'default'
_.result('string'.match('missing'), 1, 'default'); // => 'default'
_.result({}, 'method', 'default') // => default
```

EDIT: Additionally, falling back to a default value when given an object and a property will only happen if the result of _.has(object, property) is falsy:

``` javascript
_.result({}, 'method', 'default') // => 'default'
_.result({ method: null }, 'method', 'default') // => null
_.result({ method: undefined }, 'method', 'default') // => undefined
```

I had considered allowing the default value to be a function, which could be fairly useful. However that requires a more significant change and I wanted to first gauge if others found this would be particularly valuable.
