### PR TITLE
Optimize _.contains for performance

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -215,9 +215,9 @@
   _.contains = _.include = function(obj, target) {
     if (obj == null) return false;
     if (nativeIndexOf && obj.indexOf === nativeIndexOf) return obj.indexOf(target) != -1;
-    return any(obj, function(value) {
-      return value === this;
-    }, target);
+    return any(obj, (function(target) {
+      return function(value) { return value === target; };
+    })(target));
   };
 
   // Invoke a method (with arguments) on every item in a collection.


### PR DESCRIPTION
Currently surprisingly `_.contains` is slower than `_.indexOf` when called with small arrays (except FireFox), see [this](http://jsperf.com/contains-vs-indexof-on-arrays/3), this PR improved the performance of `_.contains`. see it [here](http://jsperf.com/improve-contains/4).

This can affect on any function that uses `_.contains`, currently: `_.uniq`, `_.intersection`, `_.difference` and `_.omit`.

The amazing thing is that, this can improve performance of `_.contains` even when it called with arrays on modern browsers. While we know that when `_.contains` called on arrays, this method uses the `indexOf` of the array and the execution path never reaches to the function `any`. I think that relates to optimization algorithms used by JavaScript engines.

This change increases the ease of access to the closure variable `target` by wrapping the callback in an IIFE.
