### PR TITLE
_.property support for null and undefined

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -37,6 +37,8 @@
   test('property', function() {
     var moe = {name : 'moe'};
     equal(_.property('name')(moe), 'moe', 'should return the property with the given name');
+    equal(_.property('name')(null), undefined, 'should return undefined for null values');
+    equal(_.property('name')(undefined), undefined, 'should return undefined for undefined values');
   });
 
   test('random', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -1134,7 +1134,7 @@
 
   _.property = function(key) {
     return function(obj) {
-      return obj[key];
+      return obj == null ? void 0 : obj[key];
     };
   };
 


### PR DESCRIPTION
The _.property method will currently throw an error if the returned function is passed in a `null` or `undefined` value. With this PR, in such a case `undefined` will be returned instead. This seems to be the least surprising behaviour as opposed to crashing the program.

contrived example:

``` javascript
var predicate = _.compose( _.partial(_.isEqual, 'foo') , _.property('foo'), _.property('bar'));
var result = _.filter([{bar : {foo: 'foo'}}, {foo: 'foo'}], predicate); 
console.log(result); // => [{bar : {foo: 'foo'}}]  : where as it would crash before
```
