### PR TITLE
use each (rather than _.each) internally

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1188,7 +1188,7 @@
   };
 
   // Functions for escaping and unescaping strings to/from HTML interpolation.
-  _.each(['escape', 'unescape'], function(method) {
+  each(['escape', 'unescape'], function(method) {
     _[method] = function(string) {
       if (string == null) return '';
       return ('' + string).replace(entityRegexes[method], function(match) {


### PR DESCRIPTION
This is the only place we use `_.each` rather than `each`.
