### PR TITLE
reference "filter" rather than its alias, "select"

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,7 +357,7 @@
 
     <p>
       Underscore provides 80-odd functions that support both the usual
-      functional suspects: <b>map</b>, <b>select</b>, <b>invoke</b> &mdash;
+      functional suspects: <b>map</b>, <b>filter</b>, <b>invoke</b> &mdash;
       as well as more specialized helpers: function binding, javascript
       templating, deep equality testing, and so on. It delegates to built-in
       functions, if present, so modern browsers will use the


### PR DESCRIPTION
It's odd to reference an alias, here.
