### PR TITLE
No need to escape tabs.

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1245,12 +1245,11 @@
     '\\':     '\\',
     '\r':     'r',
     '\n':     'n',
-    '\t':     't',
     '\u2028': 'u2028',
     '\u2029': 'u2029'
   };
 
-  var escaper = /\\|'|\r|\n|\t|\u2028|\u2029/g;
+  var escaper = /\\|'|\r|\n|\u2028|\u2029/g;
 
   // JavaScript micro-templating, similar to John Resig's implementation.
   // Underscore templating handles arbitrary delimiters, preserves whitespace,


### PR DESCRIPTION
Literal tab characters are perfectly legal in a string literal.  I suspect their inclusion stems from the original micro-templating implementation that replaced tabs with spaces.

Thanks for your help with the detective work @jdalton!
