### PR TITLE
fixes #1548: _.initial broken for n > array.length

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -35,6 +35,7 @@
   test('initial', function() {
     equal(_.initial([1,2,3,4,5]).join(', '), '1, 2, 3, 4', 'working initial()');
     equal(_.initial([1,2,3,4],2).join(', '), '1, 2', 'initial can take an index');
+    equal(_.initial([1,2,3,4],6).join(''), '', 'initial can take a large index');
     var result = (function(){ return _(arguments).initial(); })(1, 2, 3, 4);
     equal(result.join(', '), '1, 2, 3', 'initial works on arguments object');
     result = _.map([[1,2,3],[1,2,3]], _.initial);

--- a/underscore.js
+++ b/underscore.js
@@ -392,7 +392,7 @@
   // the array, excluding the last N. The **guard** check allows it to work with
   // `_.map`.
   _.initial = function(array, n, guard) {
-    return slice.call(array, 0, array.length - ((n == null) || guard ? 1 : n));
+    return slice.call(array, 0, Math.max(0, array.length - (n == null || guard ? 1 : n)));
   };
 
   // Get the last element of an array. Passing **n** will return the last N


### PR DESCRIPTION
Fixes #1548.
