### PR TITLE
define _.contains for array-likes in terms of _.indexOf

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -186,6 +186,7 @@
   // Aliased as `include`.
   _.contains = _.include = function(obj, target) {
     if (obj == null) return false;
+    if (obj.length === +obj.length) return _.indexOf(obj, target) >= 0;
     return _.some(obj, function(value) {
       return value === target;
     });


### PR DESCRIPTION
Closes #1552

You referred to array-likes, @jdalton, but I'm not sure how best to handle non-array array-likes. I'm open to suggestions. :)
