### PR TITLE
Deep extend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 raw
 node_modules
+.idea

--- a/test/objects.js
+++ b/test/objects.js
@@ -68,6 +68,9 @@
     equal(_.deepExtend({a:'x'}, {a:'b', subkey: { a:'c' }}).subkey.a, 'c', 'properties in source override destination');
     equal(_.deepExtend({x:'x', subkey: { a:'c' }}, {a:'b', subkey: { a:'b' }}).subkey.a, 'b', "properties not in source don't get overriden");
     equal(_.deepExtend({x:'x', subkey: { a:'c' }}, {a:'b', subkey: { a:'b', b: 'c' }}).subkey.b, 'c', "object in source can extended");
+    equal(_.deepExtend({x:'x', subkey: [{ a:'c' },{b:'c'}]}, {a:'b', subkey: [{a:'b', b: 'd'},{g: 'd'}]}).subkey[1].g, 'd', "extend key with array inside");
+    equal(_.deepExtend({c:{ d:[{a:'b'}]}},{a:'b',b:'c',c:{ d:[{f:'g'}]}}).c.d[0].f, 'g', "extending array");
+
     result = _.deepExtend({x:'x'}, {a:'a'}, {b:'b'});
     ok(_.isEqual(result, {x:'x', a:'a', b:'b'}), 'can extend from multiple source objects');
     result = _.deepExtend({x:'x'}, {a:'a', x:2}, {a:'b'});

--- a/underscore.js
+++ b/underscore.js
@@ -856,10 +856,9 @@
     _.each(slice.call(arguments, 1), function(source) {
       if(source) {
         for(var prop in source) {
-          if(typeof source[prop] == 'object') {
-            if(typeof obj[prop] == 'undefined')
-              obj[key] = {};
-
+          if(_.isObject(source[prop]) || _.isArray(source[prop])) {
+            if(_.isUndefined(obj[prop]))
+              obj[key] = _.isObject(source[prop]) ? {}:[];
               _.deepExtend(obj[prop],source[prop]);
             } else {
               _.extend(obj,source);


### PR DESCRIPTION
Hello!
This commit added new function, for extending big object as:

``` js

var source = {
   auto: 1,
   moto: 1,
   boat: {
      fly: 0,
      cry: 1,
      subkey: {
      //... and so on
      }
   }
}

var object = {
   auto: 0,
   moto: 1,
   boat: {
      fly: 1,
      cry: 0,
      dry: {
          subkey: {
             //... and so on
          }
      },
      subkey: {
      //... and so on
      }
   }
}

```
