### PR TITLE
Add _.findKey and _.findIndex

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -388,6 +388,14 @@
     }), -1);
 
     equal(_.findIndex(null, _.noop), -1);
+    strictEqual(_.findIndex(objects, function(a) {
+      return a.foo === null;
+    }), -1);
+    _.findIndex([{a: 1}], function(a, key, obj) {
+      equal(key, 0);
+      deepEqual(obj, [{a: 1}]);
+      strictEqual(this, objects, 'called with context');
+    }, objects);
 
     var sparse = [];
     sparse[20] = {'a': 2, 'b': 2};

--- a/test/collections.js
+++ b/test/collections.js
@@ -204,6 +204,25 @@
 
     var result = _.find([1, 2, 3], function(num){ return num * 2 === 4; });
     equal(result, 2, 'found the first "2" and broke the loop');
+
+    var obj = {
+      a: {x: 1, z: 3},
+      b: {x: 2, z: 2},
+      c: {x: 3, z: 4},
+      d: {x: 4, z: 1}
+    };
+
+    deepEqual(_.find(obj, {x: 2}), {x: 2, z: 2}, 'works on objects');
+    deepEqual(_.find(obj, {x: 2, z: 1}), void 0);
+    deepEqual(_.find(obj, function(x) {
+      return x.x === 4;
+    }), {x: 4, z: 1});
+
+    _.findIndex([{a: 1}], function(a, key, obj) {
+      equal(key, 0);
+      deepEqual(obj, [{a: 1}]);
+      strictEqual(this, _, 'called with context');
+    }, _);
   });
 
   test('detect', function() {

--- a/test/objects.js
+++ b/test/objects.js
@@ -692,6 +692,7 @@
     var oCon = _.matches({'constructor': Object});
     deepEqual(_.map([null, undefined, 5, {}], oCon), [false, false, false, true], 'doesnt fasley match constructor on undefined/null');
   });
+
   test('findKey', function() {
     var objects = {
       a: {'a': 0, 'b': 0},
@@ -716,6 +717,16 @@
     strictEqual(_.findKey([1, 2, 3, 4, 5, 6], function(obj) {
       return obj === 3;
     }), '2', 'Keys are strings');
+
+    strictEqual(_.findKey(objects, function(a) {
+      return a.foo === null;
+    }), undefined);
+
+    _.findKey({a: {a: 1}}, function(a, key, obj) {
+      equal(key, 'a');
+      deepEqual(obj, {a: {a: 1}});
+      strictEqual(this, objects, 'called with context');
+    }, objects);
 
     var array = [1, 2, 3, 4];
     array.match = 55;

--- a/underscore.js
+++ b/underscore.js
@@ -175,7 +175,7 @@
     } else {
       key = _.findKey(obj, predicate, context);
     }
-    return key === void 0 || key === -1 ? void 0 : obj[key];
+    if (key !== void 0 && key !== -1) return obj[key];
   };
 
   // Return all the elements that pass a truth test.


### PR DESCRIPTION
As mentioned in #413, these methods are useful internally and complements `_.indexOf` and `_.find`.

If #1582 is merged, `_.findIndex` should be identical to [`lodash.findIndex`](http://lodash.com/docs#findIndex)  and `_.findKey` should be identical to [`lodash.findKey`](http://lodash.com/docs#findKey)
