### PR TITLE
Add a message to TypeError from _.bind

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -38,6 +38,12 @@
     equal(newBoundf.hello, undefined, 'function should not be bound to the context, to comply with ECMAScript 5');
     equal(Boundf().hello, 'moe curly', "When called without the new operator, it's OK to be bound to the context");
     ok(newBoundf instanceof F, 'a bound instance is an instance of the original function');
+
+    raises(
+      function() { _.bind('notafunction'); },
+      function(actual) { return actual instanceof TypeError && actual.message !== ''; },
+      'throws an error when binding to a non-function'
+    );
   });
 
   test('partial', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -600,7 +600,7 @@
   _.bind = function(func, context) {
     var args, bound;
     if (nativeBind && func.bind === nativeBind) return nativeBind.apply(func, slice.call(arguments, 1));
-    if (!_.isFunction(func)) throw new TypeError;
+    if (!_.isFunction(func)) throw new TypeError('Bind must be called on a function');
     args = slice.call(arguments, 2);
     return bound = function() {
       if (!(this instanceof bound)) return func.apply(context, args.concat(slice.call(arguments)));


### PR DESCRIPTION
I've taken the exact error message that Chrome uses for the native `Function.prototype.bind`

![image](https://cloud.githubusercontent.com/assets/375744/2735535/0aad38c6-c661-11e3-868f-8b1c7c372f30.png)
