### PR TITLE
Simply assert that a TypeError is raised

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -39,11 +39,7 @@
     equal(Boundf().hello, 'moe curly', "When called without the new operator, it's OK to be bound to the context");
     ok(newBoundf instanceof F, 'a bound instance is an instance of the original function');
 
-    raises(
-      function() { _.bind('notafunction'); },
-      function(actual) { return actual instanceof TypeError && actual.message !== ''; },
-      'throws an error when binding to a non-function'
-    );
+    raises(function() { _.bind('notafunction'); }, TypeError, 'throws an error when binding to a non-function');
   });
 
   test('partial', function() {


### PR DESCRIPTION
Testing against the actual message for any amount of detail is a bit too specific, imo. There's a chance that this could break by a native implementation tomorrow if someone decides to throw the error without passing one since it's not defined in the EMCAScript spec (http://es5.github.io/#x15.3.4.5).

See: https://github.com/mattrobenolt/underscore/commit/430ded46e1f3619fb724af8563d1adbabf512d59#commitcomment-6056683 for context and conversation.

/cc @jdalton @michaelficarra
