### PR TITLE
Removed reference to jslitmus.js

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -14,7 +14,6 @@
     </div>
   </div>
   <script src="vendor/qunit.js"></script>
-  <script src="vendor/jslitmus.js"></script>
   <script src="../underscore.js"></script>
 
   <script src="collections.js"></script>


### PR DESCRIPTION
jslitmus doesn't seem to be actually used, in that tests run fine without it.
Moreover, it is missing from the vendor/ directory.
