### PR TITLE
Correct style issues.

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -3,16 +3,16 @@
   module('Arrays');
 
   test('first', function() {
-    equal(_.first([1,2,3]), 1, 'can pull out the first element of an array');
+    equal(_.first([1, 2, 3]), 1, 'can pull out the first element of an array');
     equal(_([1, 2, 3]).first(), 1, 'can perform OO-style "first()"');
     deepEqual(_.first([1, 2, 3], 0), [], 'can pass an index to first');
     deepEqual(_.first([1, 2, 3], 2), [1, 2], 'can pass an index to first');
     deepEqual(_.first([1, 2, 3], 5), [1, 2, 3], 'can pass an index to first');
     var result = (function(){ return _.first(arguments); })(4, 3, 2, 1);
     equal(result, 4, 'works on an arguments object.');
-    result = _.map([[1,2,3],[1,2,3]], _.first);
+    result = _.map([[1, 2, 3], [1, 2, 3]], _.first);
     deepEqual(result, [1, 1], 'works well with _.map');
-    result = (function() { return _.take([1,2,3], 2); })();
+    result = (function() { return _.take([1, 2, 3], 2); })();
     deepEqual(result, [1, 2], 'aliased as take');
 
     equal(_.first(null), undefined, 'handles nulls');
@@ -26,7 +26,7 @@
     deepEqual(_.rest(numbers, 2), [3, 4], 'rest can take an index');
     var result = (function(){ return _(arguments).tail(); })(1, 2, 3, 4);
     deepEqual(result, [2, 3, 4], 'aliased as tail and works on arguments object');
-    result = _.map([[1,2,3],[1,2,3]], _.rest);
+    result = _.map([[1, 2, 3], [1, 2, 3]], _.rest);
     deepEqual(_.flatten(result), [2, 3, 2, 3], 'works well with _.map');
     result = (function(){ return _(arguments).drop(); })(1, 2, 3, 4);
     deepEqual(result, [2, 3, 4], 'aliased as drop and works on arguments object');
@@ -38,18 +38,18 @@
     deepEqual(_.initial([1, 2, 3, 4], 6), [], 'initial can take a large index');
     var result = (function(){ return _(arguments).initial(); })(1, 2, 3, 4);
     deepEqual(result, [1, 2, 3], 'initial works on arguments object');
-    result = _.map([[1,2,3],[1,2,3]], _.initial);
+    result = _.map([[1, 2, 3], [1, 2, 3]], _.initial);
     deepEqual(_.flatten(result), [1, 2, 1, 2], 'initial works with _.map');
   });
 
   test('last', function() {
-    equal(_.last([1,2,3]), 3, 'can pull out the last element of an array');
+    equal(_.last([1, 2, 3]), 3, 'can pull out the last element of an array');
     deepEqual(_.last([1, 2, 3], 0), [], 'can pass an index to last');
     deepEqual(_.last([1, 2, 3], 2), [2, 3], 'can pass an index to last');
     deepEqual(_.last([1, 2, 3], 5), [1, 2, 3], 'can pass an index to last');
     var result = (function(){ return _(arguments).last(); })(1, 2, 3, 4);
     equal(result, 4, 'works on an arguments object');
-    result = _.map([[1,2,3],[1,2,3]], _.last);
+    result = _.map([[1, 2, 3], [1, 2, 3]], _.last);
     deepEqual(result, [3, 3], 'works well with _.map');
 
     equal(_.last(null), undefined, 'handles nulls');
@@ -64,10 +64,10 @@
 
   test('flatten', function() {
     var list = [1, [2], [3, [[[4]]]]];
-    deepEqual(_.flatten(list), [1,2,3,4], 'can flatten nested arrays');
-    deepEqual(_.flatten(list, true), [1,2,3,[[[4]]]], 'can shallowly flatten nested arrays');
+    deepEqual(_.flatten(list), [1, 2, 3, 4], 'can flatten nested arrays');
+    deepEqual(_.flatten(list, true), [1, 2, 3, [[[4]]]], 'can shallowly flatten nested arrays');
     var result = (function(){ return _.flatten(arguments); })(1, [2], [3, [[[4]]]]);
-    deepEqual(result, [1,2,3,4], 'works on an arguments object');
+    deepEqual(result, [1, 2, 3, 4], 'works on an arguments object');
     list = [[1], [2], [3], [[4]]];
     deepEqual(_.flatten(list, true), [1, 2, 3, [4]], 'can shallowly flatten arrays containing only other arrays');
   });
@@ -90,7 +90,7 @@
     list = [1, 1, 1, 2, 2, 3];
     deepEqual(_.uniq(list, true), [1, 2, 3], 'can find the unique values of a sorted array faster');
 
-    list = [{name:'moe'}, {name:'curly'}, {name:'larry'}, {name:'curly'}];
+    list = [{name: 'moe'}, {name: 'curly'}, {name: 'larry'}, {name: 'curly'}];
     var iterator = function(value) { return value.name; };
     deepEqual(_.map(_.uniq(list, false, iterator), iterator), ['moe', 'curly', 'larry'], 'can find the unique values of an array using a custom iterator');
 
@@ -161,16 +161,19 @@
 
   test('zip', function() {
     var names = ['moe', 'larry', 'curly'], ages = [30, 40, 50], leaders = [true];
-    var stooges = _.zip(names, ages, leaders);
-    equal(String(stooges), 'moe,30,true,larry,40,,curly,50,', 'zipped together arrays of different lengths');
+    deepEqual(_.zip(names, ages, leaders), [
+      ['moe', 30, true],
+      ['larry', 40, undefined],
+      ['curly', 50, undefined]
+    ], 'zipped together arrays of different lengths');
 
-    stooges = _.zip(['moe',30, 'stooge 1'],['larry',40, 'stooge 2'],['curly',50, 'stooge 3']);
-    deepEqual(stooges, [['moe','larry','curly'],[30,40,50], ['stooge 1', 'stooge 2', 'stooge 3']], 'zipped pairs');
+    stooges = _.zip(['moe', 30, 'stooge 1'], ['larry', 40, 'stooge 2'], ['curly', 50, 'stooge 3']);
+    deepEqual(stooges, [['moe', 'larry', 'curly'], [30, 40, 50], ['stooge 1', 'stooge 2', 'stooge 3']], 'zipped pairs');
 
     // In the case of difference lengths of the tuples undefineds
     // should be used as placeholder
-    stooges = _.zip(['moe',30],['larry',40],['curly',50, 'extra data']);
-    deepEqual(stooges, [['moe','larry','curly'],[30,40,50], [undefined, undefined, 'extra data']], 'zipped pairs with empties');
+    stooges = _.zip(['moe', 30], ['larry', 40], ['curly', 50, 'extra data']);
+    deepEqual(stooges, [['moe', 'larry', 'curly'], [30, 40, 50], [undefined, undefined, 'extra data']], 'zipped pairs with empties');
 
     var empty = _.zip([]);
     deepEqual(empty, [], 'unzipped empty');

--- a/test/chaining.js
+++ b/test/chaining.js
@@ -21,7 +21,7 @@
   });
 
   test('select/reject/sortBy', function() {
-    var numbers = [1,2,3,4,5,6,7,8,9,10];
+    var numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     numbers = _(numbers).chain().select(function(n) {
       return n % 2 === 0;
     }).reject(function(n) {
@@ -33,7 +33,7 @@
   });
 
   test('select/reject/sortBy in functional style', function() {
-    var numbers = [1,2,3,4,5,6,7,8,9,10];
+    var numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     numbers = _.chain(numbers).select(function(n) {
       return n % 2 === 0;
     }).reject(function(n) {
@@ -45,7 +45,7 @@
   });
 
   test('reverse/concat/unshift/pop/map', function() {
-    var numbers = [1,2,3,4,5];
+    var numbers = [1, 2, 3, 4, 5];
     numbers = _(numbers).chain()
       .reverse()
       .concat([5, 5, 5])

--- a/test/collections.js
+++ b/test/collections.js
@@ -221,10 +221,10 @@
   });
 
   test('include', function() {
-    ok(_.include([1,2,3], 2), 'two is in the array');
-    ok(!_.include([1,3,9], 2), 'two is not in the array');
-    ok(_.contains({moe:1, larry:3, curly:9}, 3) === true, '_.include on objects checks their values');
-    ok(_([1,2,3]).include(2), 'OO-style include');
+    ok(_.include([1, 2, 3], 2), 'two is in the array');
+    ok(!_.include([1, 3, 9], 2), 'two is not in the array');
+    ok(_.contains({moe: 1, larry: 3, curly: 9}, 3) === true, '_.include on objects checks their values');
+    ok(_([1, 2, 3]).include(2), 'OO-style include');
   });
 
   test('invoke', function() {
@@ -280,10 +280,10 @@
     result = _.findWhere(list, {b: 4});
     deepEqual(result, {a: 1, b: 4});
 
-    result = _.findWhere(list, {c:1})
+    result = _.findWhere(list, {c: 1})
     ok(_.isUndefined(result), 'undefined when not found');
 
-    result = _.findWhere([], {c:1});
+    result = _.findWhere([], {c: 1});
     ok(_.isUndefined(result), 'undefined when searching empty list');
   });
 
@@ -297,7 +297,7 @@
     equal(-Infinity, _.max([]), 'Maximum value of an empty array');
     equal(_.max({'a': 'a'}), -Infinity, 'Maximum value of a non-numeric collection');
 
-    equal(299999, _.max(_.range(1,300000)), 'Maximum value of a too-big array');
+    equal(299999, _.max(_.range(1, 300000)), 'Maximum value of a too-big array');
 
     equal(3, _.max([1, 2, 3, 'test']), 'Finds correct max in array starting with num and containing a NaN');
     equal(3, _.max(['test', 1, 2, 3]), 'Finds correct max in array starting with NaN');
@@ -317,7 +317,7 @@
     var then = new Date(0);
     equal(_.min([now, then]), then);
 
-    equal(1, _.min(_.range(1,300000)), 'Minimum value of a too-big array');
+    equal(1, _.min(_.range(1, 300000)), 'Minimum value of a too-big array');
 
     equal(1, _.min([1, 2, 3, 'test']), 'Finds correct min in array starting with num and containing a NaN');
     equal(1, _.min(['test', 1, 2, 3]), 'Finds correct min in array starting with NaN');
@@ -391,12 +391,12 @@
     equal(grouped['3'].length, 1);
 
     var matrix = [
-      [1,2],
-      [1,3],
-      [2,3]
+      [1, 2],
+      [1, 3],
+      [2, 3]
     ];
-    deepEqual(_.groupBy(matrix, 0), {1: [[1,2], [1,3]], 2: [[2,3]]})
-    deepEqual(_.groupBy(matrix, 1), {2: [[1,2]], 3: [[1,3], [2,3]]})
+    deepEqual(_.groupBy(matrix, 0), {1: [[1, 2], [1, 3]], 2: [[2, 3]]})
+    deepEqual(_.groupBy(matrix, 1), {2: [[1, 2]], 3: [[1, 3], [2, 3]]})
   });
 
   test('indexBy', function() {
@@ -488,7 +488,7 @@
   test('toArray', function() {
     ok(!_.isArray(arguments), 'arguments object is not an array');
     ok(_.isArray(_.toArray(arguments)), 'arguments object converted into array');
-    var a = [1,2,3];
+    var a = [1, 2, 3];
     ok(_.toArray(a) !== a, 'array is cloned');
     deepEqual(_.toArray(a), [1, 2, 3], 'cloned array contains same elements');
 
@@ -522,11 +522,11 @@
 
   test('partition', function() {
     var list = [0, 1, 2, 3, 4, 5];
-    deepEqual(_.partition(list, function(x) { return x < 4; }), [[0,1,2,3],[4,5]], 'handles bool return values');
-    deepEqual(_.partition(list, function(x) { return x & 1; }), [[1,3,5],[0,2,4]], 'handles 0 and 1 return values');
-    deepEqual(_.partition(list, function(x) { return x - 3; }), [[0,1,2,4,5],[3]], 'handles other numeric return values');
-    deepEqual(_.partition(list, function(x) { return x > 1 ? null : true; }), [[0,1],[2,3,4,5]], 'handles null return values');
-    deepEqual(_.partition(list, function(x) { if(x < 2) return true; }), [[0,1],[2,3,4,5]], 'handles undefined return values');
+    deepEqual(_.partition(list, function(x) { return x < 4; }), [[0, 1, 2, 3], [4, 5]], 'handles bool return values');
+    deepEqual(_.partition(list, function(x) { return x & 1; }), [[1, 3, 5], [0, 2, 4]], 'handles 0 and 1 return values');
+    deepEqual(_.partition(list, function(x) { return x - 3; }), [[0, 1, 2, 4, 5], [3]], 'handles other numeric return values');
+    deepEqual(_.partition(list, function(x) { return x > 1 ? null : true; }), [[0, 1], [2, 3, 4, 5]], 'handles null return values');
+    deepEqual(_.partition(list, function(x) { if(x < 2) return true; }), [[0, 1], [2, 3, 4, 5]], 'handles undefined return values');
     deepEqual(_.partition({a: 1, b: 2, c: 3}, function(x) { return x > 1; }), [[2, 3], [1]], 'handles objects');
 
     deepEqual(_.partition(list, function(x, index) { return index % 2; }), [[1, 3, 5], [0, 2, 4]], 'can reference the array index');

--- a/test/functions.js
+++ b/test/functions.js
@@ -355,7 +355,7 @@
       equal(counter, 2, 'incr was debounced successfully');
       start();
       _.now = origNowFunc;
-    },200);
+    }, 200);
   });
 
   test('once', function() {

--- a/test/objects.js
+++ b/test/objects.js
@@ -44,19 +44,19 @@
 
   test('extend', function() {
     var result;
-    equal(_.extend({}, {a:'b'}).a, 'b', 'can extend an object with the attributes of another');
-    equal(_.extend({a:'x'}, {a:'b'}).a, 'b', 'properties in source override destination');
-    equal(_.extend({x:'x'}, {a:'b'}).x, 'x', "properties not in source don't get overriden");
-    result = _.extend({x:'x'}, {a:'a'}, {b:'b'});
-    ok(_.isEqual(result, {x:'x', a:'a', b:'b'}), 'can extend from multiple source objects');
-    result = _.extend({x:'x'}, {a:'a', x:2}, {a:'b'});
-    ok(_.isEqual(result, {x:2, a:'b'}), 'extending from multiple source objects last property trumps');
+    equal(_.extend({}, {a: 'b'}).a, 'b', 'can extend an object with the attributes of another');
+    equal(_.extend({a: 'x'}, {a: 'b'}).a, 'b', 'properties in source override destination');
+    equal(_.extend({x: 'x'}, {a: 'b'}).x, 'x', "properties not in source don't get overriden");
+    result = _.extend({x: 'x'}, {a: 'a'}, {b: 'b'});
+    ok(_.isEqual(result, {x: 'x', a: 'a', b: 'b'}), 'can extend from multiple source objects');
+    result = _.extend({x: 'x'}, {a: 'a', x: 2}, {a: 'b'});
+    ok(_.isEqual(result, {x: 2, a: 'b'}), 'extending from multiple source objects last property trumps');
     result = _.extend({}, {a: void 0, b: null});
     deepEqual(_.keys(result), ['a', 'b'], 'extend copies undefined values');
 
     try {
       result = {};
-      _.extend(result, null, undefined, {a:1});
+      _.extend(result, null, undefined, {a: 1});
     } catch(ex) {}
 
     equal(result.a, 1, 'should not error on `null` or `undefined` sources');
@@ -129,7 +129,7 @@
 
     try {
       options = {};
-      _.defaults(options, null, undefined, {a:1});
+      _.defaults(options, null, undefined, {a: 1});
     } catch(ex) {}
 
     equal(options.a, 1, 'should not error on `null` or `undefined` sources');
@@ -350,7 +350,7 @@
     // More circular objects #767.
     a = {everything: 'is checked', but: 'this', is: 'not'};
     a.but = a;
-    b = {everything: 'is checked', but: {that:'object'}, is: 'not'};
+    b = {everything: 'is checked', but: {that: 'object'}, is: 'not'};
     ok(!_.isEqual(a, b), 'Comparison of circular references with non-circular object references are not equal');
 
     // Cyclic Structures.
@@ -453,7 +453,7 @@
     ok(!_.isArguments(_.isArguments), 'a function is not an arguments object');
     ok(_.isArguments(args), 'but the arguments object is an arguments object');
     ok(!_.isArguments(_.toArray(args)), 'but not when it\'s converted into an array');
-    ok(!_.isArguments([1,2,3]), 'and not vanilla arrays.');
+    ok(!_.isArguments([1, 2, 3]), 'and not vanilla arrays.');
     ok(_.isArguments(iArguments), 'even from another frame');
   });
 
@@ -596,7 +596,7 @@
     equal(intercepted, 1, 'passes tapped object to interceptor');
     equal(returned, 1, 'returns tapped object');
 
-    returned = _([1,2,3]).chain().
+    returned = _([1, 2, 3]).chain().
       map(function(n){ return n * 2; }).
       max().
       tap(interceptor).

--- a/test/utility.js
+++ b/test/utility.js
@@ -67,11 +67,11 @@
   test('times', function() {
     var vals = [];
     _.times(3, function (i) { vals.push(i); });
-    ok(_.isEqual(vals, [0,1,2]), 'is 0 indexed');
+    ok(_.isEqual(vals, [0, 1, 2]), 'is 0 indexed');
     //
     vals = [];
     _(3).times(function(i) { vals.push(i); });
-    ok(_.isEqual(vals, [0,1,2]), 'works as a wrapper');
+    ok(_.isEqual(vals, [0, 1, 2]), 'works as a wrapper');
     // collects return values
     ok(_.isEqual([0, 1, 2], _.times(3, function(i) { return i; })), 'collects return values');
 


### PR DESCRIPTION
- Use space in array/object literals.
- Convert a forgotten deepEqual candidate.
