### PR TITLE
respect iterator return value of Infinity/-Infinity in _.min/_.max

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -301,6 +301,11 @@
 
     equal(3, _.max([1, 2, 3, 'test']), 'Finds correct max in array starting with num and containing a NaN');
     equal(3, _.max(['test', 1, 2, 3]), 'Finds correct max in array starting with NaN');
+
+    var a = {x: -Infinity};
+    var b = {x: -Infinity};
+    var iterator = function(o){ return o.x; };
+    equal(_.max([a, b], iterator), a, 'Respects iterator return value of -Infinity');
   });
 
   test('min', function() {
@@ -321,6 +326,11 @@
 
     equal(1, _.min([1, 2, 3, 'test']), 'Finds correct min in array starting with num and containing a NaN');
     equal(1, _.min(['test', 1, 2, 3]), 'Finds correct min in array starting with NaN');
+
+    var a = {x: Infinity};
+    var b = {x: Infinity};
+    var iterator = function(o){ return o.x; };
+    equal(_.min([a, b], iterator), a, 'Respects iterator return value of Infinity');
   });
 
   test('sortBy', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -232,7 +232,7 @@
     } else {
       _.each(obj, function(value, index, list) {
         computed = iterator ? iterator.call(context, value, index, list) : value;
-        if (computed > lastComputed) {
+        if (computed > lastComputed || (computed === -Infinity && result === -Infinity)) {
           result = value;
           lastComputed = computed;
         }
@@ -255,7 +255,7 @@
     } else {
       _.each(obj, function(value, index, list) {
         computed = iterator ? iterator.call(context, value, index, list) : value;
-        if (computed < lastComputed) {
+        if (computed < lastComputed || (computed === Infinity && result === Infinity)) {
           result = value;
           lastComputed = computed;
         }


### PR DESCRIPTION
A colleague and I were just bitten by a bug in this code:

``` javascript
var bestMatch = _.max(inPosteds, function(inPosted) {
  // only match to posted transactions that haven't been resolved
  if (inPosted._pendingTransaction) {
    return -Infinity;
  } else {
    return pendingSimilarity(
      pendingTransform(outPending),
      postedTransform(inPosted)
    );
  }
});
```

We were surprised to discover that `bestMatch` would in some cases be -Infinity rather than an object. This results from Underscore performing `>` comparisons against an initial max of -Infinity. Since -Infinity is not greater than -Infinity, the initial value is erroneously returned if the iterator returns -Infinity for each element in a nonempty collection.

I've implemented the least invasive fix, which is to use `>=` and `<=` in place of `>` and `<`. Note that this does change undocumented behaviour not covered by the test suite: the _last_ min/max element will be returned rather than the first. Consider a slightly modified version of the example from the documentation:

``` javascript
var stooges = [{name: 'moe', age: 40}, {name: 'larry', age: 50}, {name: 'curly', age: 50}];
_.max(stooges, function(stooge){ return stooge.age; });
// before => {name: 'larry', age: 50}
// after  => {name: 'curly', age: 50}
```

If we wish to preserve this undocumented behaviour, I'll add appropriate test cases and adjust the implementations of _.min and _.max accordingly. This may simply involve enumerating the given collection in reverse order.
