### PR TITLE
Patch cross domain object check

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -952,10 +952,21 @@
     }
     // Objects with different constructors are not equivalent, but `Object`s
     // from different frames are.
-    var aCtor = a.constructor, bCtor = b.constructor;
-    if (aCtor !== bCtor && !(_.isFunction(aCtor) && (aCtor instanceof aCtor) &&
-                             _.isFunction(bCtor) && (bCtor instanceof bCtor))
-                        && ('constructor' in a && 'constructor' in b)) {
+    var aCtor, aHasCtor, bCtor, bHasCtor;
+
+    try {
+      aCtor = a.constructor;
+      aHasCtor = 'constructor' in a;
+    } catch (e) {}
+
+    try {
+      bCtor = b.constructor;
+      bHasCtor = 'constructor' in b;
+    } catch (e) {}
+
+    if (aCtor !== bCtor && aHasCtor && bHasCtor &&
+      !(_.isFunction(aCtor) && (aCtor instanceof aCtor) &&
+        _.isFunction(bCtor) && (bCtor instanceof bCtor))) {
       return false;
     }
     // Add the first object to the stack of traversed objects.


### PR DESCRIPTION
I need to add protections to the `constructor` check since it's you can't access it across frames. Unsure how to even add a unit test for this though.

The situation occurs when checking `window.parent` from within an cross origin iframe.

On a side note, I'm not sure the existing check is 100% correct. If the two constructors are not equal, why do we assume both have to have constructors? What if only one has a constructor, this check if fail when we want it to succeed? I can adjust this logic to be correct, but thought it might be a little out of scope.
