### PR TITLE
update _.keys to treat sparse array-likes as dense

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -511,6 +511,8 @@
     } catch(ex) { }
 
     ok(_.isArray(actual), 'should not throw converting a node list');
+
+    ok('0' in _.toArray(Array(1)), 'should produce a dense copy');
   });
 
   test('size', function() {

--- a/test/objects.js
+++ b/test/objects.js
@@ -156,6 +156,8 @@
     equal(_.clone(undefined), void 0, 'non objects should not be changed by clone');
     equal(_.clone(1), 1, 'non objects should not be changed by clone');
     equal(_.clone(null), null, 'non objects should not be changed by clone');
+
+    ok('0' in _.clone(Array(1)), 'should produce a dense copy');
   });
 
   test('isEqual', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -367,7 +367,6 @@
   // Safely create a real, live array from anything iterable.
   _.toArray = function(obj) {
     if (!obj) return [];
-    if (_.isArray(obj)) return slice.call(obj);
     if (obj.length === +obj.length) return _.map(obj, _.identity);
     return _.values(obj);
   };
@@ -903,7 +902,7 @@
   // Create a (shallow-cloned) duplicate of an object.
   _.clone = function(obj) {
     if (!_.isObject(obj)) return obj;
-    return _.isArray(obj) ? obj.slice() : _.extend({}, obj);
+    return _.isArray(obj) ? _.toArray(obj) : _.extend({}, obj);
   };
 
   // Invokes interceptor with the obj, and then returns obj.


### PR DESCRIPTION
I removed this change from #1525 before it was merged. For consistency, _.keys should treat sparse arrays as dense (as _.map et al. now do).

I'm sure you'll have much to say about this change, @jdalton. I look forward to your feedback. :)
