### PR TITLE
Update index.html to clarify template precompilation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1818,10 +1818,11 @@ _.template("Using 'with': <%= data.answer %>", {answer: 'no'}, {variable: 'data'
         a stack trace, something that is not possible when compiling templates on the client.
         The <b>source</b> property is available on the compiled template
         function for easy precompilation.
-        For example, using a pre-compiler with ERB-style delimiters:
+        For example, using a pre-compiler with ERB-style delimiters,
+        the source can be made to populate a script tag:
       </p>
 
-      <pre>&lt;script type="text/template"&gt;
+      <pre>&lt;script&gt;
   JST.project = <%= _.template(jstText).source %>;
 &lt;/script&gt;</pre>
 


### PR DESCRIPTION
The example code for template precompilation using _.template().source is unclear to those unfamiliar with precompilation:

```
<script>
  JST.project = <%= _.template(jstText).source %>;
</script>
```

This fix changes adds two things to clarify. It adds a type attribute to the script tag to clarify its use and make similar examples easier to find, and it adds a brief description of the example so it is more clear what is being shown (changes below):

```
For example, using a pre-compiler with ERB-style delimiters:

<script>
  JST.project = <%= _.template(jstText).source %>;
</script>
```
