### PR TITLE
tweak _.isArguments fallback

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1038,7 +1038,7 @@
   // there isn't any inspectable "Arguments" type.
   if (!_.isArguments(arguments)) {
     _.isArguments = function(obj) {
-      return !!(obj && _.has(obj, 'callee'));
+      return obj != null && _.has(obj, 'callee');
     };
   }
 


### PR DESCRIPTION
The line in question should be read: _Return true if **obj** has a "callee" property._

In the existing code, `obj &&` serves as a guard to avoid passing null or undefined to _.has. The consequence is that `!!` is required to ensure the function returns a Boolean in all cases.

There are several reasons to prefer `obj != null &&` as the guard:
- it makes it clear that the left && operand is simply a guard (it's irrelevant whether `obj` is logical true);
- it makes it easier to see why a guard is necessary; and
- it obviates the need for coercion.
