### PR TITLE
update _.has to return false for null/undefined

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -620,6 +620,8 @@
     var child = {};
     child.prototype = obj;
     ok(_.has(child, "foo") == false, "has() does not check the prototype chain for a property.");
+    strictEqual(_.has(null, 'foo'), false, 'has() returns false for null');
+    strictEqual(_.has(undefined, 'foo'), false, 'has() returns false for undefined');
   });
 
   test("matches", function() {

--- a/underscore.js
+++ b/underscore.js
@@ -1038,7 +1038,7 @@
   // there isn't any inspectable "Arguments" type.
   if (!_.isArguments(arguments)) {
     _.isArguments = function(obj) {
-      return !!(obj && _.has(obj, 'callee'));
+      return _.has(obj, 'callee');
     };
   }
 
@@ -1077,7 +1077,7 @@
   // Shortcut function for checking if an object has a given property directly
   // on itself (in other words, not on a prototype).
   _.has = function(obj, key) {
-    return hasOwnProperty.call(obj, key);
+    return obj != null && hasOwnProperty.call(obj, key);
   };
 
   // Utility Functions


### PR DESCRIPTION
As discussed in #1623.

The current behaviour (throwing a TypeError) is not helpful, and likely not deliberate.
