### PR TITLE
Expose the memoize cache.

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -100,6 +100,16 @@
     var fastO = _.memoize(o);
     equal(o('toString'), 'toString', 'checks hasOwnProperty');
     equal(fastO('toString'), 'toString', 'checks hasOwnProperty');
+
+    // Expose the cache.
+    var i = 0;
+    var f = _.memoize(function() {
+      return ++i;
+    });
+    equal(f('x'), 1);
+    equal(f('x'), 1);
+    f.cache = {};
+    equal(f('x'), 2);
   });
 
   asyncTest('delay', 2, function() {

--- a/underscore.js
+++ b/underscore.js
@@ -641,12 +641,15 @@
 
   // Memoize an expensive function by storing its results.
   _.memoize = function(func, hasher) {
-    var memo = {};
-    hasher || (hasher = _.identity);
-    return function() {
+    if (!hasher) hasher = _.identity;
+    var memoize = function() {
+      var cache = memoize.cache;
       var key = hasher.apply(this, arguments);
-      return _.has(memo, key) ? memo[key] : (memo[key] = func.apply(this, arguments));
+      if (_.has(cache, key)) return cache[key];
+      return cache[key] = func.apply(this, arguments);
     };
+    memoize.cache = {};
+    return memoize;
   };
 
   // Delays a function for the given number of milliseconds, and then calls


### PR DESCRIPTION
Perhaps this goes without saying, but this implementation makes changes to implementation breaking.  For instance, using a `Map` instead of an object.
