### PR TITLE
Add _.before() function to negate _.after()

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -425,7 +425,7 @@
     increment();
     equal(num, 1);
 
-    equal(increment(), 1, 'stores a memo to the last value')
+    equal(increment(), 1, 'stores a memo to the last value');
   });
 
   test('Recursive onced function.', 1, function() {
@@ -482,6 +482,26 @@
     equal(testAfter(5, 4), 0, 'after(N) should not fire unless called N times');
     equal(testAfter(0, 0), 0, 'after(0) should not fire immediately');
     equal(testAfter(0, 1), 1, 'after(0) should fire when first invoked');
+  });
+
+  test('before', function() {
+    var testBefore = function(beforeAmount, timesCalled) {
+      var beforeCalled = 0;
+      var before = _.before(beforeAmount, function() { beforeCalled++; });
+      while (timesCalled--) before();
+      return beforeCalled;
+    };
+
+    equal(testBefore(5, 5), 4, 'before(N) should not fire after being called N times');
+    equal(testBefore(5, 4), 4, 'before(N) should fire before being called N times');
+    equal(testBefore(0, 0), 0, 'before(0) should not fire immediately');
+    equal(testBefore(0, 1), 0, 'before(0) should not fire when first invoked');
+
+    var context = {num: 0};
+    var increment = _.before(3, function(){ return ++this.num; });
+    _.times(10, increment, context);
+    equal(increment(), 2, 'stores a memo to the last value');
+    equal(context.num, 2, 'provides context');
   });
 
 })();

--- a/underscore.js
+++ b/underscore.js
@@ -776,19 +776,6 @@
     };
   };
 
-  // Returns a function that will be executed at most one time, no matter how
-  // often you call it. Useful for lazy initialization.
-  _.once = function(func) {
-    var ran = false, memo;
-    return function() {
-      if (ran) return memo;
-      ran = true;
-      memo = func.apply(this, arguments);
-      func = null;
-      return memo;
-    };
-  };
-
   // Returns the first function passed as an argument to the second,
   // allowing you to adjust arguments, run code before and after, and
   // conditionally execute the original function.
@@ -824,6 +811,22 @@
       }
     };
   };
+
+  // Returns a function that will only be executed before being called N times.
+  _.before = function(times, func) {
+    var memo;
+    return function() {
+      if (--times > 0) {
+        memo = func.apply(this, arguments);
+      }
+      else func = null;
+      return memo;
+    };
+  };
+
+  // Returns a function that will be executed at most one time, no matter how
+  // often you call it. Useful for lazy initialization.
+  _.once = _.partial(_.before, 2);
 
   // Object Functions
   // ----------------


### PR DESCRIPTION
I'm not sure if this PR belongs in this repository or the contributing repository, please let me know if I need to move it.

I couldn't find any simple way to limit the number of times a function runs using existing underscore functions. I came up with a non-underscore solution, and it turned out I reverse engineered something similar to the `_.after()` function.

Unlike `_.after()`, which only runs a function after it has been called n times, `_.before()` runs a function _until_ it has been called n times.

An example usage of this behavior is adding items to a list. I set up a function to add the items to the list, but I want to limit the number of times an item is added. An underscore alternative would be something like using `_.after()` and null the function after n calls.
