### PR TITLE
_.memoize suggestions

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -671,12 +671,14 @@
   };
 
   // Memoize an expensive function by storing its results.
-  _.memoize = function(func, hasher) {
+_.memoize = function(func, hasher) {
     if (!hasher) hasher = _.identity;
     var memoize = function() {
       var cache = memoize.cache;
-      var key = hasher.apply(this, arguments);
-      if (!_.has(cache, key)) cache[key] = func.apply(this, arguments);
+      var args = Array.prototype.slice.call(arguments);
+      if (hasher === _.identity) var key = hasher.apply(this,[args]);
+      else var key = hasher.apply(this, args);
+      if (!_.has(cache, key)) cache[key] = func.apply(this, args);
       return cache[key];
     };
     memoize.cache = {};


### PR DESCRIPTION
Fixed bug on _.memoize.  _.memoize did not work correctly on a a multi-argument function when a hash was not provided.  Previously, it was only including the first argument into the cache.  The update provides a conditional statement to det
ermine if hasher===_.identity.  If it does, then the appropriate code is applied
 to include the entire arguments array into the cache.
-All tests passed with new implementation
-Previously, a function like var add = function(a,b){return a+b;} if used with m
emoize, var fastAdd = _.memoize(add), fastAdd(2,3) would give the same response
as fastAdd(2,6) or fastAdd(2,7) after fastAdd had been implemented on arguments
where the first values were equal.  The new implementation fixes this issue.
