### PR TITLE
Abstract _.pick and _.omit via pick wrapper

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -888,37 +888,33 @@
     return obj;
   };
 
-  // Return a copy of the object only containing the whitelisted properties.
-  _.pick = function(obj, iterator, context) {
-    var result = {}, key;
-    if (_.isFunction(iterator)) {
-      for (key in obj) {
-        var value = obj[key];
-        if (iterator.call(context, value, key, obj)) result[key] = value;
+  // internal wrapper around a key picker
+  var createPicker = function(negateResult) {
+    return function(obj, iterator, context) {
+      var result = {},
+          state, key;
+      if (_.isFunction(iterator)) {
+        iterator = createCallback(iterator, context);
+        for (key in obj) {
+          state = iterator(obj[key], key, obj);
+          if (negateResult ? !state : state) result[key] = obj[key];
+        }
+      } else {
+        var keys = _.invert(concat.apply([], slice.call(arguments, 1)));
+        for (key in obj) {
+          state = key in keys;
+          if (negateResult ? !state : state) result[key] = obj[key];
+        }
       }
-    } else {
-      var keys = concat.apply([], slice.call(arguments, 1));
-      for (var i = 0, length = keys.length; i < length; i++) {
-        key = keys[i];
-        if (key in obj) result[key] = obj[key];
-      }
-    }
-    return result;
+      return result;
+    };
   };
 
+  // Return a copy of the object only containing the whitelisted properties.
+  _.pick = createPicker(false);
+
    // Return a copy of the object without the blacklisted properties.
-  _.omit = function(obj, iterator, context) {
-    var keys;
-    if (_.isFunction(iterator)) {
-      iterator = _.negate(iterator);
-    } else {
-      keys = _.map(concat.apply([], slice.call(arguments, 1)), String);
-      iterator = function(value, key) {
-        return !_.contains(keys, key);
-      };
-    }
-    return _.pick(obj, iterator, context);
-  };
+  _.omit = createPicker(true);
 
   // Fill in a given object with default properties.
   _.defaults = function(obj) {


### PR DESCRIPTION
Use a function generator to create `_.pick` and `_.omit` as they're essentially [the same function](https://github.com/megawac/underscore/commit/f7d56a26971c69b9c58f8c9949e509f849b74b43#diff-0f36b362a0b81d6f4d4bfd8a7413c75dR899).

We can expect a major performance improvement from this changeset for all cases of `_.omit` with some perf hit on the properties as argument case for `_.pick`
