### PR TITLE
remove unneeded checking of result variable in _.every and _.some.

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -202,7 +202,8 @@
     if (obj == null) return result;
     predicate = lookupIterator(predicate, context);
     _.each(obj, function(value, index, list) {
-      if (!(result = predicate(value, index, list))) return breaker;
+      result = predicate(value, index, list);
+      if (!result) return breaker;
     });
     return !!result;
   };
@@ -214,7 +215,8 @@
     if (obj == null) return result;
     predicate = lookupIterator(predicate, context);
     _.each(obj, function(value, index, list) {
-      if (result = predicate(value, index, list)) return breaker;
+      result = predicate(value, index, list);
+      if (result) return breaker;
     });
     return !!result;
   };


### PR DESCRIPTION
`_.some` and `_.every` can be faster by removing unneeded checking of `result` variable. [jsPerf](http://jsperf.com/optimize-every)
