### PR TITLE
remove constant condition in _.min and _.max

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -271,7 +271,7 @@
     } else {
       iterator = lookupIterator(iterator, context);
       _.each(obj, function(value, index, list) {
-        computed = iterator ? iterator(value, index, list) : value;
+        computed = iterator(value, index, list);
         if (computed > lastComputed || computed === -Infinity && result === -Infinity) {
           result = value;
           lastComputed = computed;
@@ -295,7 +295,7 @@
     } else {
       iterator = lookupIterator(iterator, context);
       _.each(obj, function(value, index, list) {
-        computed = iterator ? iterator(value, index, list) : value;
+        computed = iterator(value, index, list);
         if (computed < lastComputed || computed === Infinity && result === Infinity) {
           result = value;
           lastComputed = computed;


### PR DESCRIPTION
An alternative approach would be to leave the condition in and conditionally do the `iterator = lookupIterator(iterator, context);` assignment. I don't know which one would be more performant.
