### PR TITLE
Update description of _.isEmpty.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1437,8 +1437,9 @@ _.isEqual(moe, clone);
       <p id="isEmpty">
         <b class="header">isEmpty</b><code>_.isEmpty(object)</code>
         <br />
-        Returns <i>true</i> if an enumerable <b>object</b> contains no values
-        (no enumerable own-properties).
+        Returns <i>true</i> if an enumerable <b>object</b> contains no
+        values (no enumerable own-properties). For strings and array-like
+        objects <tt>_.isEmpty</tt> checks if the length property is 0.
       </p>
       <pre>
 _.isEmpty([1, 2, 3]);


### PR DESCRIPTION
The HTML documentation did not make it clear how `_.isEmpty` works for strings and arrays vs. objects. The distinction is clear in the annotated source, so I tried to make it reflect that.
