### PR TITLE
Add comments and sparse array test for _.isEqual

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -203,6 +203,7 @@
 
     // Comparisons involving `NaN`.
     ok(_.isEqual(NaN, NaN), '`NaN` is equal to `NaN`');
+    ok(_.isEqual(Object(NaN), NaN), 'Object(`NaN`) is equal to `NaN`');
     ok(!_.isEqual(61, NaN), 'A number primitive is not equal to `NaN`');
     ok(!_.isEqual(new Number(79), NaN), 'A number object is not equal to `NaN`');
     ok(!_.isEqual(Infinity, NaN), '`Infinity` is not equal to `NaN`');

--- a/underscore.js
+++ b/underscore.js
@@ -970,7 +970,8 @@
         return '' + a === '' + b;
       case '[object Number]':
         // `NaN`s are equivalent, but non-reflexive.
-        if (a != a) return b != b;
+        // Object(NaN) is equivalent to NaN
+        if (a != +a) return b != +b;
         // An `egal` comparison is performed for other numeric values.
         return a == 0 ? 1 / a == 1 / b : a == +b;
       case '[object Date]':


### PR DESCRIPTION
Add some comments for some confusing `_.isEqual` lines and spec sparse array handling (this handling is consistent with `v1.5-v1.6`)
