### PR TITLE
Enhanced isArray and isObject speed

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1060,14 +1060,13 @@
   };
 
   // Is a given value an array?
-  // Delegates to ECMA5's native Array.isArray
-  _.isArray = nativeIsArray || function(obj) {
-    return toString.call(obj) === '[object Array]';
+  _.isArray = function(obj) {
+    return obj.constructor === Array;
   };
 
   // Is a given variable an object?
   _.isObject = function(obj) {
-    return obj === Object(obj);
+    return obj.constructor === Object;
   };
 
   // Add some isType methods: isArguments, isFunction, isString, isNumber, isDate, isRegExp.


### PR DESCRIPTION
As you can see in these benchmarks, comparing the obj.constructor against the type constructor is at least twice as fast in both cases. It's not faster than typeof, but it's the only way since typeof doesn't know the difference between a "pure object" and an array.
http://jsperf.com/arrtc1337
http://jsperf.com/objtc1337
