### PR TITLE
Simplification of memoize given no hasher

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -115,6 +115,16 @@
     upper.cache = {foo: 'BAR', bar: 'FOO'};
     equal(upper('foo'), 'BAR');
     equal(upper('bar'), 'FOO');
+
+    var hashed = _.memoize(function(key) {
+      //https://github.com/jashkenas/underscore/pull/1679#discussion_r13736209
+      ok(/[a-z]+/.test(key), 'hasher doesn\'t change keys');
+      return key;
+    }, function(key) {
+      return key.toUpperCase();
+    });
+    hashed('yep');
+    deepEqual(hashed.cache, {'YEP': 'yep'}, 'takes a hasher');
   });
 
   asyncTest('delay', 2, function() {

--- a/underscore.js
+++ b/underscore.js
@@ -679,11 +679,10 @@
 
   // Memoize an expensive function by storing its results.
   _.memoize = function(func, hasher) {
-    if (!hasher) hasher = _.identity;
-    var memoize = function() {
+    var memoize = function(key) {
       var cache = memoize.cache;
-      var key = hasher.apply(this, arguments);
-      if (!_.has(cache, key)) cache[key] = func.apply(this, arguments);
+      var address = hasher ? hasher.apply(this, arguments) : key;
+      if (!_.has(cache, address)) cache[address] = func.apply(this, arguments);
       return cache[key];
     };
     memoize.cache = {};


### PR DESCRIPTION
Simplifies the expected case for _.memoize
