### PR TITLE
Handle no arguments case in _.zip

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -197,6 +197,9 @@
 
     var empty = _.zip([]);
     deepEqual(empty, [], 'unzipped empty');
+
+    deepEqual(_.zip(null), [], 'handles null');
+    deepEqual(_.zip(), [], '_.zip() returns []');
   });
 
   test('object', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -549,8 +549,9 @@
 
   // Zip together multiple lists into a single array -- elements that share
   // an index go together.
-  _.zip = function() {
-    var length = Math.max(0, _.max(arguments, 'length').length);
+  _.zip = function(array) {
+    if (array == null) return [];
+    var length = _.max(arguments, 'length').length;
     var results = Array(length);
     for (var i = 0; i < length; i++) {
       results[i] = _.pluck(arguments, i);


### PR DESCRIPTION
Backwards compat case broken in #1678; closes #1680
