### PR TITLE
Move partion to collection methods

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -409,6 +409,17 @@
     return obj.length === +obj.length ? obj.length : _.keys(obj).length;
   };
 
+  // Split a collection into two arrays: one whose elements all satisfy the given
+  // predicate, and one whose elements all do not satisfy the predicate.
+  _.partition = function(obj, predicate, context) {
+    predicate = lookupIterator(predicate, context, 1);
+    var pass = [], fail = [];
+    _.each(obj, function(value, key, obj) {
+      (predicate(value, key, obj) ? pass : fail).push(value);
+    });
+    return [pass, fail];
+  };
+
   // Array Functions
   // ---------------
 
@@ -477,17 +488,6 @@
   // Return a version of the array that does not contain the specified value(s).
   _.without = function(array) {
     return _.difference(array, slice.call(arguments, 1));
-  };
-
-  // Split an array into two arrays: one whose elements all satisfy the given
-  // predicate, and one whose elements all do not satisfy the predicate.
-  _.partition = function(obj, predicate, context) {
-    predicate = lookupIterator(predicate, context, 1);
-    var pass = [], fail = [];
-    _.each(obj, function(value, key, obj) {
-      (predicate(value, key, obj) ? pass : fail).push(value);
-    });
-    return [pass, fail];
   };
 
   // Produce a duplicate-free version of the array. If the array has already


### PR DESCRIPTION
Extremely minor, but was bugging me: moves the `_.partiion` method out of `Arrays` and adjust the comment.

Small item missed in #1479
