### PR TITLE
Rework internal flatten function

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -79,6 +79,12 @@
   });
 
   test('flatten', function() {
+    deepEqual(_.flatten(null), [], 'Flattens supports null');
+    deepEqual(_.flatten(void 0), [], 'Flattens supports undefined');
+
+    deepEqual(_.flatten([[], [[]], []]), [], 'Flattens empty arrays');
+    deepEqual(_.flatten([[], [[]], []], true), [[]], 'Flattens empty arrays');
+
     var list = [1, [2], [3, [[[4]]]]];
     deepEqual(_.flatten(list), [1, 2, 3, 4], 'can flatten nested arrays');
     deepEqual(_.flatten(list, true), [1, 2, 3, [[[4]]]], 'can shallowly flatten nested arrays');
@@ -86,6 +92,11 @@
     deepEqual(result, [1, 2, 3, 4], 'works on an arguments object');
     list = [[1], [2], [3], [[4]]];
     deepEqual(_.flatten(list, true), [1, 2, 3, [4]], 'can shallowly flatten arrays containing only other arrays');
+
+    equal(_.flatten([_.range(10), _.range(10), 5, 1, 3], true).length, 23);
+    equal(_.flatten([_.range(10), _.range(10), 5, 1, 3]).length, 23);
+    equal(_.flatten([new Array(1000000), _.range(56000), 5, 1, 3]).length, 1056003, 'Flatten can handle massive collections');
+    equal(_.flatten([new Array(1000000), _.range(56000), 5, 1, 3], true).length, 1056003, 'Flatten can handle massive collections');
   });
 
   test('without', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -466,15 +466,19 @@
 
   // Internal implementation of a recursive `flatten` function.
   var flatten = function(input, shallow, strict, startIndex) {
-    var output = [], value;
-    for (var i = startIndex || 0, length = input.length; i < length; i++) {
+    var output = [], idx = 0, value;
+    for (var i = startIndex || 0, length = input && input.length; i < length; i++) {
       value = input[i];
-      if (!_.isArray(value) && !_.isArguments(value)) {
-        if (!strict) output.push(value);
-      } else {
+      if (value && value.length >= 0 && (_.isArray(value) || _.isArguments(value))) {
         //flatten current level of array or arguments object
         if (!shallow) value = flatten(value, shallow, strict);
-        push.apply(output, value);
+        var j = 0, len = value.length;
+        output.length += len;
+        while (j < len) {
+          output[idx++] = value[j++];
+        }
+      } else if (!strict) {
+        output[idx++] = value;
       }
     }
     return output;


### PR DESCRIPTION
Don't pray to the gods `.apply` can handle the size of the nested arrays

http://jsperf.com/new-flatten

Fixes #1875

~~For lodash speeds we'll need to change `push.apply` to something similar to [this clever logic](https://github.com/lodash/lodash/blob/master/lodash.js/#L1616-1619). Let me know if that's more desirable, I have it [already prepared](https://github.com/megawac/underscore/blob/flatten2/underscore.js#L465-483) and its in the jsperf~~
