### PR TITLE
Partition: pass key and object to predicate given context

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -657,6 +657,14 @@
     deepEqual(_.partition([1, 2, 3], predicate, {x: 2}), [[2], [1, 3]], 'partition takes a context argument');
 
     deepEqual(_.partition([{a: 1}, {b: 2}, {a: 1, b: 2}], {a: 1}), [[{a: 1}, {a: 1, b: 2}], [{b: 2}]], 'predicate can be object');
+
+    var object = {a: 1};
+    _.partition(object, function(val, key, obj) {
+      equal(val, 1);
+      equal(key, 'a');
+      equal(object, object);
+      equal(this, predicate);
+    }, predicate);
   });
 
 })();

--- a/underscore.js
+++ b/underscore.js
@@ -412,7 +412,7 @@
   // Split a collection into two arrays: one whose elements all satisfy the given
   // predicate, and one whose elements all do not satisfy the predicate.
   _.partition = function(obj, predicate, context) {
-    predicate = lookupIterator(predicate, context, 1);
+    predicate = lookupIterator(predicate, context);
     var pass = [], fail = [];
     _.each(obj, function(value, key, obj) {
       (predicate(value, key, obj) ? pass : fail).push(value);


### PR DESCRIPTION
Noticed this scouting about that this behaviour changed in #1593 and got confused somewhere
