### PR TITLE
proposal: bindAll should throw a reference error if a given method is undefined

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -81,8 +81,8 @@
     };
 
     raises(function() { _.bindAll(moe); }, Error, 'throws an error for bindAll with no functions named');
-
-    raises(function() { _.bindAll(moe, "sayBye"); }, ReferenceError, 'throws an error for bindAll if the given function is undefined');
+    raises(function() { _.bindAll(moe, "sayBye"); }, TypeError, 'throws an error for bindAll if the given key is undefined');
+    raises(function() { _.bindAll(moe, "name"); }, TypeError, 'throws an error for bindAll if the given key is not a function');
 
     _.bindAll(moe, 'sayHi', 'sayLast');
     curly.sayHi = moe.sayHi;

--- a/underscore.js
+++ b/underscore.js
@@ -673,8 +673,7 @@
     if (length <= 1) throw Error('bindAll must be passed function names');
     for (; i < length; i++) {
       key = arguments[i];
-      if (_.isUndefined(obj[key])) throw ReferenceError(key + ' is not defined');
-      obj[key] = createCallback(obj[key], obj, Infinity);
+      obj[key] = _.bind(obj[key], obj);
     }
     return obj;
   };


### PR DESCRIPTION
If a given method is undefined, createCallback is going to return a function that will eventually throw an error when it is called. This is because createCallback returns a function that will evaluate to undefined.apply. If that's true, then it would be nice to catch these errors when we do the binding instead of when we call the unusable functions.

Here's an example...
https://gist.github.com/smarden1/b08f84fd3b1c363d403d

Additionally, I like getting the erroneous method name in my exception as bindAll can take a long list of functions and hunting down the erroneous one in that list is a bummer.
