### PR TITLE
Use value in object case of contains

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -225,10 +225,8 @@
   // Aliased as `include`.
   _.contains = _.include = function(obj, target) {
     if (obj == null) return false;
-    if (obj.length === +obj.length) return _.indexOf(obj, target) >= 0;
-    return _.some(obj, function(value) {
-      return value === target;
-    });
+    if (obj.length !== +obj.length) obj = _.values(obj);
+    return _.indexOf(obj, target) >= 0;
   };
 
   // Invoke a method (with arguments) on every item in a collection.


### PR DESCRIPTION
As suggested by @jdalton [here](https://github.com/jashkenas/underscore/pull/1587#discussion_r14004776) as an alternative to current or `_.findKey` (if implemented in #1587)

http://jsperf.com/reduce-right-optimi/7
