### PR TITLE
Spec null object case for _.pick and _.omit

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -81,7 +81,8 @@
     deepEqual(result, {1: 'b'}, 'can pick numeric properties');
 
     deepEqual(_.pick(null, 'a', 'b'), {}, 'non objects return empty object');
-    deepEqual(_.pick(5, 'a', 'b'), {}, 'non objects return empty object');
+    deepEqual(_.pick(undefined, 'toString'), {}, 'null/undefined return empty object');
+    deepEqual(_.pick(5, 'toString', 'b'), {toString: Number.prototype.toString}, 'can iterate primitives');
 
     var data = {a: 1, b: 2, c: 3};
     var callback = function(value, key, object) {
@@ -114,7 +115,8 @@
     deepEqual(result, {1: 'b'}, 'can omit numeric properties');
 
     deepEqual(_.omit(null, 'a', 'b'), {}, 'non objects return empty object');
-    deepEqual(_.omit(5, 'a', 'b'), {}, 'non objects return empty object');
+    deepEqual(_.omit(undefined, 'toString'), {}, 'null/undefined return empty object');
+    deepEqual(_.omit(5, 'toString', 'b'), {}, 'returns empty object for primitives');
 
     var data = {a: 1, b: 2, c: 3};
     var callback = function(value, key, object) {

--- a/underscore.js
+++ b/underscore.js
@@ -896,7 +896,8 @@
   // Return a copy of the object only containing the whitelisted properties.
   _.pick = function(obj, iterator, context) {
     var result = {}, key;
-    if (!_.isObject(obj)) return result;
+    if (obj == null) return result;
+    obj = Object(obj);
     if (_.isFunction(iterator)) {
       iterator = createCallback(iterator, context);
       for (key in obj) {


### PR DESCRIPTION
Found a commit that went missing in a past PR (#1649) with a bunch of cases :) 
https://github.com/megawac/underscore/commit/05f7e58c991abd2a4e6ef0118b5b263569869c41

Currently pick will throw when given null/undefined/primitive and *args
