### PR TITLE
Map optimization : each boiler

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -112,13 +112,20 @@
   };
 
   // Return the results of applying the iterator to each element.
-  _.map = _.collect = function(obj, iterator, context) {
-    var results = [];
-    if (obj == null) return results;
+   _.map = _.collect = function(obj, iterator, context) {
+    if (obj == null) return [];
     iterator = lookupIterator(iterator, context);
-    _.each(obj, function(value, index, list) {
-      results.push(iterator(value, index, list));
-    });
+    var length = obj.length,
+        currentKey, keys;
+    if (length !== +length) {
+      keys = _.keys(obj);
+      length = keys.length;
+    }
+    var results = Array(length);
+    for (var index = 0; index < length; index++) {
+      currentKey = keys ? keys[index] : index;
+      results[index] = iterator(obj[currentKey], currentKey, obj);
+    }
     return results;
   };
 


### PR DESCRIPTION
Was playing with this pattern a couple weeks ago and look forward to hearing thoughts from other contributors as we're sacrificing terseness for speed via with boilerplate. I've applied this pattern to some of the [other methods in this branch](https://github.com/megawac/underscore/compare/funhouse) + some thoughts from @jdalton (see comments at the bottom for the relevant jsperf post changes for other functions ).

Figured I would open the conversation as its one of the most used functions in the lib and optimizations here pay dividends. Relevant jsperf below

http://jsperf.com/pr-1689/9

Also, I'm mixed about this change and can agree if we reject this :)
