### PR TITLE
Add ability to rename keys when calling _.pick

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -79,6 +79,8 @@
     deepEqual(result, {a: 1, b: 2}, 'can restrict properties to those named in mixed args');
     result = _.pick(['a', 'b'], 1);
     deepEqual(result, {1: 'b'}, 'can pick numeric properties');
+    result = _.pick({a: 1, b: 2, c: 3, d: 4}, 'a', {b: 'beta', c: 'gamma'}, 'd');
+    deepEqual(result, {a: 1, beta: 2, gamma: 3, d: 4}, 'can rename properties by passing an object');
 
     deepEqual(_.pick(null, 'a', 'b'), {}, 'non objects return empty object');
     deepEqual(_.pick(undefined, 'toString'), {}, 'null/undefined return empty object');
@@ -113,6 +115,8 @@
     deepEqual(result, {a: 1}, 'can omit properties named in an array');
     result = _.omit(['a', 'b'], 0);
     deepEqual(result, {1: 'b'}, 'can omit numeric properties');
+    result = _.omit({a: 1, b: 2, c: 3}, 'a', {b: 'beta'});
+    deepEqual(result, {c: 3}, 'can omit properties even when passed in an object');
 
     deepEqual(_.omit(null, 'a', 'b'), {}, 'non objects return empty object');
     deepEqual(_.omit(undefined, 'toString'), {}, 'null/undefined return empty object');

--- a/underscore.js
+++ b/underscore.js
@@ -916,7 +916,13 @@
       obj = Object(obj);
       for (var i = 0, length = keys.length; i < length; i++) {
         key = keys[i];
-        if (key in obj) result[key] = obj[key];
+        if (_.isObject(key)) {
+          _.each(key, function(newName, oldName) {
+            if (oldName in obj) result[newName] = obj[oldName];
+          });
+        } else if (key in obj) {
+          result[key] = obj[key];
+        }
       }
     }
     return result;
@@ -927,7 +933,16 @@
     if (_.isFunction(iterator)) {
       iterator = _.negate(iterator);
     } else {
-      var keys = _.map(concat.apply([], slice.call(arguments, 1)), String);
+      var keys = _.map(slice.call(arguments, 1), function(key) {
+        if (_.isArray(key)) {
+          return _.map(key, String);
+        } else if (_.isObject(key)) {
+          return _.keys(key);
+        } else {
+          return String(key);
+        }
+      });
+      keys = concat.apply([], keys);
       iterator = function(value, key) {
         return !_.contains(keys, key);
       };


### PR DESCRIPTION
Typically, `_.pick` takes an object and a list of keys and returns an
object with just these keys and their values.

However, often times, I need some keys to be renamed. E.g. when getting
a few attributes from one model to send to the API of another model. (I'm
talking Backbone models, but it would apply to anything of course)

Right now, I would do something like that:

``` js
var modelAttr = _.pick(myUser, 'id', 'name');
modelAttr.userEmail = myUser.get('email');

// => {id: '1234', name: 'Jane Doe', userEmail: 'jane@doe.org'}
```

What I'm suggesting is being able to rename keys if needed, like so:

``` js
var modelAttr = _.pick(myUser, 'id', 'name', {email: 'userEmail'});

// => {id: '1234', name: 'Jane Doe', userEmail: 'jane@doe.org'}
```

I also changed `_.omit` since it mirrors what `_.pick` does and both
could be used with the same options to get the complements of each
other. Of course, in this case, the object values are unused.
