### PR TITLE
Do not explicitly name the `define` export

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1405,7 +1405,7 @@
   // an AMD load request. Those cases could generate an error when an
   // anonymous define() is called outside of a loader request.
   if (typeof define === 'function' && define.amd) {
-    define('underscore', [], function() {
+    define([], function() {
       return _;
     });
   }


### PR DESCRIPTION
Require.js will set the name of the package before it is needed.
This is useful with Underscore specifically for when you want to
override the defaults for things such as `_.templateSettings`.
