### PR TITLE
Use gulp.js instead of NPM scripts

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,44 @@
+var gulp = require('gulp');
+var qunit = require('gulp-qunit');
+var eslint = require('gulp-eslint');
+var uglify = require('gulp-uglify');
+var sourcemaps = require('gulp-sourcemaps');
+var rename = require('gulp-rename');
+var docco = require('docco');
+
+gulp.task('test', function() {
+  gulp.src('./test/index.html')
+    .pipe(qunit());
+});
+
+gulp.task('lint', function() {
+  gulp.src(['underscore.js'])
+    .pipe(eslint())
+    .pipe(eslint.format());
+});
+
+gulp.task('build', function() {
+  gulp.src('underscore.js')
+    .pipe(sourcemaps.init())
+      .pipe(uglify({
+        compress: {
+          evaluate: false
+        },
+        preserveComments: function (node, comment) {
+          // Preserve copyright notice
+          return comment.line < 5;
+        },
+        mangle: true
+      }))
+    .pipe(rename('underscore-min.js'))
+    .pipe(sourcemaps.write('./'))
+    .pipe(gulp.dest('./'));
+});
+
+gulp.task('doc', function() {
+  docco.document({
+    args: ['underscore.js']
+  });
+});
+
+gulp.task('default', ['lint', 'test', 'build', 'doc']);

--- a/package.json
+++ b/package.json
@@ -17,15 +17,13 @@
   "main": "underscore.js",
   "version": "1.6.0",
   "devDependencies": {
-    "docco": "0.6.x",
-    "phantomjs": "1.9.7-1",
-    "uglify-js": "2.4.x",
-    "eslint": "0.6.x"
-  },
-  "scripts": {
-    "test": "phantomjs test/vendor/runner.js test/index.html?noglobals=true && eslint underscore.js",
-    "build": "uglifyjs underscore.js -c \"evaluate=false\" --comments \"/    .*/\" -m --source-map underscore-min.map -o underscore-min.js",
-    "doc": "docco underscore.js"
+    "docco": "^0.6.3",
+    "gulp": "^3.8.5",
+    "gulp-eslint": "^0.1.7",
+    "gulp-qunit": "^0.3.3",
+    "gulp-rename": "^1.2.0",
+    "gulp-sourcemaps": "^0.4.4",
+    "gulp-uglify": "^0.3.1"
   },
   "licenses": [
     {


### PR DESCRIPTION
This commit makes building the project much easier and introduces a
more standardized way to build (minify), lint, document and test
Underscore.js using gulp.js. All npm-scripts have been replaced
with appropriate gulp-tasks.

In particular, the following changes have been made:
- Replace direct usage of PhantomJS with gulp-qunit.
  
  This removes the need to globally install the PhantomJS CLI.
  Further, the test/vendor/runner.js file is no longer needed (but
  still included for now).
  PhantomJS is no longer a dependency. The corresponding npm
  script is no longer needed and has been removed.
  To run the tests, execute "gulp test".
- Replace direct usage of eslint with gulp-eslint.
  
  Same as above. Remove need for global installation etc. Lint
  script (previously included in test-script) has been abstracted
  into its own task. Linting can be done using "gulp lint".
- Replace build script with appropriate gulp task.
  
  Same as above. Previously, the build was handled by the npm
  script "build". In compliance with [informal conventions](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit), the
  sourcemap file is now called "underscore-min.js.map" instead of
  "underscore-min.map". Project can be build (minification +
  generation of sourcemap) using "gulp build".
- Handle documentation through docco using gulpfile.
  
  docco is still a dependency, since a corresponding gulp-task for
  docco couldn't be found (WIP). Documentation can be generated
  using "gulp doc".
## Usage
- Install gulp.js globally using "npm install -g gulp".
  
  This is the only dependency which needs to be installed globally.
- Install dependencies using "npm install".
- Run tasks:
  
  Old -> New
  npm run-script test -> gulp test/ gulp lint
  npm run-script build -> gulp build
  npm run-script doc -> gulp doc
  Run all: -> gulp

This PR might seem like a lot of overhead, but it makes building, testing, linting and documenting the project much easier, especially for new collaborators that prefer building Underscore.JS themselves. Introducing gulp is a good choice in this case, since it removes the need to globally install all the dev dependencies. Otherwise, the globally installed dependencies might conflict with each other on different projects (e.g. if you need a previous version of uglify in order to build a different project [1]). Extending gulp is much easier and more readable than adding another npm-script. Further, testing is much easier now, since runner.js is obsolete.

  [1]: Another way of circumventing this problem would be to run the binary inside the node_modules directory explicitly (e.g. using ./node_modules/.bin/docco).
