### PR TITLE
Refactor _.some using _.every

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -226,17 +226,9 @@
   _.some = _.any = function(obj, predicate, context) {
     if (obj == null) return false;
     predicate = lookupIterator(predicate, context);
-    var length = obj.length;
-    var index, currentKey, keys;
-    if (length !== +length) {
-      keys = _.keys(obj);
-      length = keys.length;
-    }
-    for (index = 0; index < length; index++) {
-      currentKey = keys ? keys[index] : index;
-      if (predicate(obj[currentKey], currentKey, obj)) return true;
-    }
-    return false;
+    return !_.every(obj, function(val, key) {
+      return !predicate(val, key);
+    });
   };
 
   // Determine if the array or object contains a given value (using `===`).


### PR DESCRIPTION
All tests pass. I only refactored the _.some function.

Before:
- Iterate over collection, return true as soon as any predicate function returns true.
- Code redundancy in _.every and _.some (ll. 208 - 214)

``` javascript
var length = obj.length;
var index, currentKey, keys;
if (length !== +length) {
  keys = _.keys(obj);
  length = keys.length;
}
```

After:
- Check if _reversed_ truth test fails on every item inside collection.

Advantages: Cleaner, shorter, reuse of _.every, no additional corner case checks inside _.some
