### PR TITLE
Uniq test for unequivalent object literals

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -119,6 +119,9 @@
     var result = (function(){ return _.uniq(arguments); }(1, 2, 1, 3, 1, 4));
     deepEqual(result, [1, 2, 3, 4], 'works on an arguments object');
 
+    var a = {}, b = {}, c = {};
+    deepEqual(_.uniq([a, b, a, b, c]), [a, b, c], 'works on values that can be tested for equivalency but not ordered');
+
     deepEqual(_.uniq(null), []);
 
     var context = {};


### PR DESCRIPTION
The exact implementation of the _.uniq function may be unclear to people wishing to improve the algorithm.  
Rather than add extra lines of comments to the underscore.js file, a simple test should make the input/output expectations for _.uniq crystal clear.

``` sh
var a = {}, b = {}, c = {};
deepEqual(_.uniq([a, b, a, b, c]), [a, b, c], 'works on values that can be tested for equivalency but not ordered');
```
