### PR TITLE
Matches keeps an internal reference to spec object

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -660,6 +660,9 @@
     equal(_.matches({hair: true})(moe), true, 'Returns a boolean');
     equal(_.matches({hair: true})(curly), false, 'Returns a boolean');
 
+    equal(_.matches({__x__: undefined})(5), false, 'can match undefined props on primitives');
+    equal(_.matches({__x__: undefined})({__x__: undefined}), true, 'can match undefined props');
+
     equal(_.matches({})(null), true, 'Empty spec called with null object returns true');
     equal(_.matches({a: 1})(null), false, 'Non-empty spec called with null object returns false');
 
@@ -692,13 +695,18 @@
     ok(_.matches(Prototest)({x: 5, y: 1}), 'spec can be a function');
 
     // #1729
-    var o = { 'b': 1 };
+    var o = {'b': 1};
     var m = _.matches(o);
 
-    equal(m({ 'b': 1 }), true);
+    equal(m({'b': 1}), true);
     o.b = 2;
     o.a = 1;
-    equal(m({ 'b': 1 }), true, 'changing spec object doesnt change matches result');
+    equal(m({'b': 1}), true, 'changing spec object doesnt change matches result');
+
+
+    //null edge cases
+    var oCon = _.matches({'constructor': Object});
+    deepEqual(_.map([null, undefined, 5, {}], oCon), [false, false, false, true], 'doesnt fasley match constructor on undefined/null');
   });
 
 }());

--- a/underscore.js
+++ b/underscore.js
@@ -1181,10 +1181,11 @@
     var pairs = _.pairs(attrs), length = pairs.length;
     return function(obj) {
       if (obj === attrs) return true;
+      if (obj == null) return !length;
       obj = Object(obj);
       for (var i = 0; i < length; i++) {
         var pair = pairs[i], key = pair[0];
-        if (!(key in obj) || pair[1] !== obj[key]) return false;
+        if (pair[1] !== obj[key] || !(key in obj)) return false;
       }
       return true;
     };


### PR DESCRIPTION
Fixes #1729
