### PR TITLE
remove optimisation for uncommon case in _.matches

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1180,7 +1180,6 @@
   _.matches = function(attrs) {
     var pairs = _.pairs(attrs), length = pairs.length;
     return function(obj) {
-      if (obj === attrs) return true;
       if (obj == null) return !length;
       obj = Object(obj);
       for (var i = 0; i < length; i++) {


### PR DESCRIPTION
As noted by @jdalton in https://github.com/jashkenas/underscore/pull/1730#discussion_r14662677.
