### PR TITLE
Enable pluck like iterators in uniq

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -132,6 +132,9 @@
       strictEqual(index, 0);
       strictEqual(array, list);
     }, context);
+
+    deepEqual(_.uniq([{a: 1, b: 1}, {a: 1, b: 2}, {a: 1, b: 3}, {a: 2, b: 1}], 'a'), [{a: 1, b: 1}, {a: 2, b: 1}], 'can use pluck like iterator');
+    deepEqual(_.uniq([{0: 1, b: 1}, {0: 1, b: 2}, {0: 1, b: 3}, {0: 2, b: 1}], 0), [{0: 1, b: 1}, {0: 2, b: 1}], 'can use falsey pluck like iterator');
   });
 
   test('unique', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -54,8 +54,8 @@
   // Current version.
   _.VERSION = '1.6.0';
 
-  // Internal function that returns an efficient (for current engines) version 
-  // of the passed-in callback, to be repeatedly applied in other Underscore 
+  // Internal function that returns an efficient (for current engines) version
+  // of the passed-in callback, to be repeatedly applied in other Underscore
   // functions.
   var createCallback = function(func, context, argCount) {
     if (context === void 0) return func;
@@ -78,8 +78,8 @@
     };
   };
 
-  // A mostly-internal function to generate callbacks that can be applied 
-  // to each element in a collection, returning the desired result — either 
+  // A mostly-internal function to generate callbacks that can be applied
+  // to each element in a collection, returning the desired result — either
   // identity, an arbitrary callback, a property matcher, or a property accessor.
   _.iteratee = function(value, context, argCount) {
     if (value == null) return _.identity;
@@ -514,12 +514,12 @@
   // Aliased as `unique`.
   _.uniq = _.unique = function(array, isSorted, iterator, context) {
     if (array == null) return [];
-    if (_.isFunction(isSorted)) {
+    if (!_.isBoolean(isSorted)) {
       context = iterator;
       iterator = isSorted;
       isSorted = false;
     }
-    if (iterator) iterator = _.iteratee(iterator, context);
+    if (iterator != null) iterator = _.iteratee(iterator, context);
     var result = [];
     var seen = [];
     for (var i = 0, length = array.length; i < length; i++) {


### PR DESCRIPTION
Without requiring `_.uniq(obj, false, 'a')` now `_.uniq(obj, 'a')`

Resolves #1743
