### PR TITLE
Fix edge-case regression in max/min

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -392,6 +392,10 @@
   });
 
   test('max', function() {
+    equal(-Infinity, _.max(null), 'can handle null/undefined');
+    equal(-Infinity, _.max(undefined), 'can handle null/undefined');
+    equal(-Infinity, _.max(null, _.identity), 'can handle null/undefined');
+
     equal(3, _.max([1, 2, 3]), 'can perform a regular Math.max');
 
     var neg = _.max([1, 2, 3], function(num){ return -num; });
@@ -419,6 +423,10 @@
   });
 
   test('min', function() {
+    equal(Infinity, _.min(null), 'can handle null/undefined');
+    equal(Infinity, _.min(undefined), 'can handle null/undefined');
+    equal(Infinity, _.min(null, _.identity), 'can handle null/undefined');
+
     equal(1, _.min([1, 2, 3]), 'can perform a regular Math.min');
 
     var neg = _.min([1, 2, 3], function(num){ return -num; });

--- a/underscore.js
+++ b/underscore.js
@@ -277,7 +277,7 @@
   _.max = function(obj, iterator, context) {
     var result = -Infinity, lastComputed = -Infinity,
         value, computed;
-    if (iterator == null) {
+    if (iterator == null && obj != null) {
       obj = obj.length === +obj.length ? obj : _.values(obj);
       for (var i = 0, length = obj.length; i < length; i++) {
         value = obj[i];
@@ -302,7 +302,7 @@
   _.min = function(obj, iterator, context) {
     var result = Infinity, lastComputed = Infinity,
         value, computed;
-    if (iterator == null) {
+    if (iterator == null && obj != null) {
       obj = obj.length === +obj.length ? obj : _.values(obj);
       for (var i = 0, length = obj.length; i < length; i++) {
         value = obj[i];


### PR DESCRIPTION
In 1.6.0 and earlier `max` and `min` returned negative and positive infinity respectively. Currently it throws an exception if no iterator is provided, otherwise returns an infinity.

I think I prefer the exception but returning +-Infinity is fine too.

Currently

```
_.max(null) // => TypeError
_.max(null, _.identity) // => -Infinity
```
