### PR TITLE
Add _.slice function

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -2,6 +2,50 @@
 
   module('Arrays');
 
+  test('slice', function() {
+    var array = [1, 2, 3],
+        zeros = [, null, undefined];
+
+    deepEqual(_.slice(array, 1), [2, 3], 'should work with a positive `start`');
+
+    var expected = _.map(zeros, _.constant(array));
+    var actual = _.map(zeros, function(start) {
+      return _.slice(array, start);
+    });
+    deepEqual(actual, expected);
+
+    var expected = _.map(zeros, _.constant(array));
+    var actual = _.map(zeros, function(start) {
+      return _.slice(array, 0, start);
+    });
+    deepEqual(actual, expected);
+
+    deepEqual(_.slice(array, 0, 0), [], 'Works with zeros');
+    deepEqual(_.slice(array, 1, 0), [], 'Works start > end');
+
+    actual = _.map([-1, -2, -3, -4, -10], _.partial(_.slice, array, _, null, null));
+    expected = [[3], [2, 3], array, array, array];
+    deepEqual(actual, expected, 'works with negative start');
+
+    actual = _.map([-1, -2, -3, -4, -10], _.partial(_.slice, array, 0, _, null));
+    expected = [[1, 2], [1], [], [], []];
+    deepEqual(actual, expected, 'works with negative start');
+
+
+    deepEqual(_.slice(array, null, null, 2), [1, 3], 'works with step values');
+    deepEqual(_.slice(array, null, null, 3), [1], 'works with step values');
+    deepEqual(_.slice(array, null, null, 10), [1], 'works with step values greater than length');
+    deepEqual(_.slice(array, null, null, -1), [3, 2, 1], 'works with negative step values');
+    deepEqual(_.slice(array, null, null, -2), [3, 1], 'works with negative step values');
+    deepEqual(_.slice(array, null, null, -10), [3], 'works with negative step values greater than length');
+
+    // test in IE < 9
+    try {
+      var actual = _.slice(document.childNodes);
+    } catch(ex) {}
+    deepEqual(actual, _.map(document.childNodes, _.identity), 'works on NodeList');
+  });
+
   test('first', function() {
     equal(_.first([1, 2, 3]), 1, 'can pull out the first element of an array');
     equal(_([1, 2, 3]).first(), 1, 'can perform OO-style "first()"');

--- a/test/arrays.js
+++ b/test/arrays.js
@@ -4,7 +4,8 @@
 
   test('slice', function() {
     var array = [1, 2, 3],
-        zeros = [, null, undefined];
+        zeros = [, null, undefined],
+        notNums = [{}, ['smt'], 'xxx', NaN, this, Boolean];
 
     deepEqual(_.slice(array, 1), [2, 3], 'should work with a positive `start`');
 
@@ -14,14 +15,15 @@
     });
     deepEqual(actual, expected);
 
-    var expected = _.map(zeros, _.constant(array));
-    var actual = _.map(zeros, function(start) {
+    expected = _.map(zeros, _.constant(array));
+    actual = _.map(zeros, function(start) {
       return _.slice(array, 0, start);
     });
-    deepEqual(actual, expected);
+    deepEqual(actual, expected, 'null & undefined treated as length');
 
-    deepEqual(_.slice(array, 0, 0), [], 'Works with zeros');
-    deepEqual(_.slice(array, 1, 0), [], 'Works start > end');
+    deepEqual(_.slice(array, 0, 0), [], 'Works with zeros as start and end');
+    deepEqual(_.slice(array, 2, 1), [], 'Works start > end');
+    deepEqual(_.slice(array, 2, 1, 2), [], 'Works start > end');
 
     actual = _.map([-1, -2, -3, -4, -10], _.partial(_.slice, array, _, null, null));
     expected = [[3], [2, 3], array, array, array];
@@ -31,6 +33,13 @@
     expected = [[1, 2], [1], [], [], []];
     deepEqual(actual, expected, 'works with negative start');
 
+    actual = _.map(notNums, _.partial(_.slice, array, _, null, null));
+    expected = _.map(notNums, _.constant(array));
+    deepEqual(actual, expected, 'NaN as start index treated as 0');
+
+    actual = _.map(notNums, _.partial(_.slice, array, null, _, null));
+    expected = _.map(notNums, _.constant([]));
+    deepEqual(actual, expected, 'NaN as end index treated as 0');
 
     deepEqual(_.slice(array, null, null, 2), [1, 3], 'works with step values');
     deepEqual(_.slice(array, null, null, 3), [1], 'works with step values');
@@ -39,10 +48,13 @@
     deepEqual(_.slice(array, null, null, -2), [3, 1], 'works with negative step values');
     deepEqual(_.slice(array, null, null, -10), [3], 'works with negative step values greater than length');
 
-    // test in IE < 9
-    try {
-      var actual = _.slice(document.childNodes);
-    } catch(ex) {}
+    actual = _.map(notNums.concat(zeros), _.partial(_.slice, array, null, null, _));
+    expected = _.map(notNums.concat(zeros), _.constant(array));
+    deepEqual(actual, expected, 'NaN as step treated as 1');
+
+    // test in IE < 9 (host object error avoidance)
+    actual = _.slice(document.childNodes);
+    deepEqual(_(document.childNodes).slice(), actual, 'OO-style slice');
     deepEqual(actual, _.map(document.childNodes, _.identity), 'works on NodeList');
   });
 

--- a/test/collections.js
+++ b/test/collections.js
@@ -631,18 +631,21 @@
     ok(!_.isArray(arguments), 'arguments object is not an array');
     ok(_.isArray(_.toArray(arguments)), 'arguments object converted into array');
     var a = [1, 2, 3];
-    ok(_.toArray(a) !== a, 'array is cloned');
-    deepEqual(_.toArray(a), [1, 2, 3], 'cloned array contains same elements');
+    notEqual(_.toArray(a), a, 'array is cloned');
+    deepEqual(_.toArray(a), a, 'cloned array contains same elements');
 
     var numbers = _.toArray({one : 1, two : 2, three : 3});
     deepEqual(numbers, [1, 2, 3], 'object flattened into array');
 
-    // test in IE < 9
-    try {
-      var actual = _.toArray(document.childNodes);
-    } catch(ex) { }
+    deepEqual(_.toArray({0: 1, 1: 2, length: 2}), [1, 2], 'works on array likes');
+    deepEqual(_.toArray('string'), ['s', 't', 'r', 'i', 'n', 'g'], 'converts string to array');
 
-    ok(_.isArray(actual), 'should not throw converting a node list');
+    // test in IE < 9
+    var actual;
+    try {
+      actual = _.toArray(document.childNodes);
+    } catch(ex) { }
+    deepEqual(actual, _.map(document.childNodes, _.identity), 'works on NodeList');
   });
 
   test('size', function() {

--- a/test/collections.js
+++ b/test/collections.js
@@ -638,7 +638,6 @@
     deepEqual(numbers, [1, 2, 3], 'object flattened into array');
 
     deepEqual(_.toArray({0: 1, 1: 2, length: 2}), [1, 2], 'works on array likes');
-    deepEqual(_.toArray('string'), ['s', 't', 'r', 'i', 'n', 'g'], 'converts string to array');
 
     // test in IE < 9
     var actual;

--- a/test/objects.js
+++ b/test/objects.js
@@ -183,6 +183,10 @@
     equal(_.clone(undefined), void 0, 'non objects should not be changed by clone');
     equal(_.clone(1), 1, 'non objects should not be changed by clone');
     equal(_.clone(null), null, 'non objects should not be changed by clone');
+
+    var toughArray = [1, 2, 3];
+    toughArray.slice = null;
+    deepEqual(_.clone(toughArray), [1, 2, 3], 'works on arrays without slice method');
   });
 
   test('isEqual', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -430,17 +430,18 @@
   // cloned subsequence of an array(-like).
   _.slice = function(collection, start, end, step) {
     var length = collection.length;
-    if (start == null) {
-      start = 0;
-    } else if (start < 0) {
+    start = +start || 0;
+    if (start < 0) {
       start = -start > length ? 0 : length + start;
     }
     if (end == null || end > length) {
       end = length;
     } else if (end < 0) {
-      end = length + end;
+      end += length;
+    } else {
+      end = +end || 0;
     }
-    step = !step ? 1 : step;
+    step = +step || 1;
     length = start < end ? Math.ceil((end - start) / Math.abs(step)) : 0;
     if (step < 0) {
       start = end - 1;


### PR DESCRIPTION
Add a slice function with the python contract `_.slice(collection, start, end, step)`

See https://docs.python.org/2/library/functions.html#slice. Like python slice, it doesn't do any coercing of inputs (besides 0 which is coerced to 1). Python will give an error for invalid inputs, this implementation doesn't bother and carries on. One nice benefit of the step feature is now we can do non destructive reversing `_.slice(arr, null, null, -1)`

Created some jsperf benchmarks the other day http://jsperf.com/cr-52768

I think it may make sense to add a `_.reverse` function after this which will also fix a bug `_(document.childNodes).reverse(); // Exception` 
