### PR TITLE
Fix _.before() and _.after() used in an OOP style

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -511,9 +511,9 @@
   test('after', function() {
     var testAfter = function(afterAmount, timesCalled) {
       var afterCalled = 0;
-      var after = _.after(afterAmount, function() {
+      var after = _.after(function() {
         afterCalled++;
-      });
+      }, afterAmount);
       while (timesCalled--) after();
       return afterCalled;
     };
@@ -527,7 +527,7 @@
   test('before', function() {
     var testBefore = function(beforeAmount, timesCalled) {
       var beforeCalled = 0;
-      var before = _.before(beforeAmount, function() { beforeCalled++; });
+      var before = _.before(function() { beforeCalled++; }, beforeAmount);
       while (timesCalled--) before();
       return beforeCalled;
     };
@@ -538,7 +538,7 @@
     equal(testBefore(0, 1), 0, 'before(0) should not fire when first invoked');
 
     var context = {num: 0};
-    var increment = _.before(3, function(){ return ++this.num; });
+    var increment = _.before(function(){ return ++this.num; }, 3);
     _.times(10, increment, context);
     equal(increment(), 2, 'stores a memo to the last value');
     equal(context.num, 2, 'provides context');

--- a/underscore.js
+++ b/underscore.js
@@ -826,7 +826,7 @@
   };
 
   // Returns a function that will only be executed after being called N times.
-  _.after = function(times, func) {
+  _.after = function(func, times) {
     return function() {
       if (--times < 1) {
         return func.apply(this, arguments);
@@ -835,7 +835,7 @@
   };
 
   // Returns a function that will only be executed before being called N times.
-  _.before = function(times, func) {
+  _.before = function(func, times) {
     var memo;
     return function() {
       if (--times > 0) {
@@ -848,7 +848,7 @@
 
   // Returns a function that will be executed at most one time, no matter how
   // often you call it. Useful for lazy initialization.
-  _.once = _.partial(_.before, 2);
+  _.once = _.partial(_.before, _, 2);
 
   // Object Functions
   // ----------------


### PR DESCRIPTION
When using the `_.before()` and `_.after()` with the OOP style wrapper, it does not work.

Ex.

``` javascript
var func = _(function() {
    console.log("I should be executed on the third call");
}).after(3);
```

I have added tests that show this failure and a special exception to handling these specific functions as they seem to be the only outliers that do not conform to the standard argument ordering.
