### PR TITLE
fix _.contains to accept {length:2}

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -240,7 +240,7 @@
   // Aliased as `include`.
   _.contains = _.include = function(obj, target) {
     if (obj == null) return false;
-    if (obj.length !== +obj.length) obj = _.values(obj);
+    if (_.isObject(obj)) obj = _.values(obj);
     return _.indexOf(obj, target) >= 0;
   };
 


### PR DESCRIPTION
In the old `_.contains` implementation, it doesn't take object that has a number-type 'length' property like:

```
 var obj = {
      length: 2, 
      name: 'ruler', 
      unit:'cm'
 };
```

I just think it might be easier for people using underscore to not care if 'length' is some kind of reserved word they can't use. So I just changed `obj.length !== +obj.length` to `_.isObject(obj)`.

There's a lot of places using `obj.length !== +obj.length`, I find the one in `_.contains` needed most to be changed. Because the semantic tells me, all it does is checking if an object contains some value or not, people using it might find it unbelievable when `_contains(obj, 'ruler')` returns false .
