### PR TITLE
Fixes #1739 - _.extend check for own properties

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -59,6 +59,11 @@
     result = _.extend({}, {a: void 0, b: null});
     deepEqual(_.keys(result), ['a', 'b'], 'extend copies undefined values');
 
+    var superObj = {a: 'b'};
+    var subObj = Object.create(superObj);
+    subObj.c = 'd';
+    deepEqual(_.keys(_.extend({}, subObj)), ['c'], 'extend ignores any properties but own from source');
+
     try {
       result = {};
       _.extend(result, null, undefined, {a: 1});

--- a/underscore.js
+++ b/underscore.js
@@ -916,7 +916,9 @@
     for (var i = 1, length = arguments.length; i < length; i++) {
       source = arguments[i];
       for (prop in source) {
-        obj[prop] = source[prop];
+        if (hasOwnProperty.call(source, prop)) {
+            obj[prop] = source[prop];
+        }
       }
     }
     return obj;


### PR DESCRIPTION
I believe _.extend is intended to remain primitive in nature (as per issue #123), so this may be an unnecessary change.

Checks for the source object's own properties before extending a property. It includes the code from Dimik's comment resolving issue #1739. One contributed test; All tests pass.

Screenshots highlight lines of code added to underscore.js and object tests:
<b>underscore.js:</b>
![screen shot 2014-08-01 at 2 08 24 pm](https://cloud.githubusercontent.com/assets/3682072/3785558/3201076e-19c6-11e4-97c8-409937a8fc84.png)
<b>test/objects.js:</b>
![screen shot 2014-07-31 at 7 54 28 pm](https://cloud.githubusercontent.com/assets/3682072/3774378/9ba9e610-1929-11e4-94e9-6f8565113aa7.png)
<b>Passing tests:</b>
![screen shot 2014-07-31 at 8 16 02 pm](https://cloud.githubusercontent.com/assets/3682072/3774399/3bcd7e40-192a-11e4-8025-1fc1e5fced0b.png)
