### PR TITLE
_.has(obj, key) returns false if obj is falsy

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1140,7 +1140,7 @@
   // Shortcut function for checking if an object has a given property directly
   // on itself (in other words, not on a prototype).
   _.has = function(obj, key) {
-    return obj != null && hasOwnProperty.call(obj, key);
+    return !!obj && hasOwnProperty.call(obj, key);
   };
 
   // Utility Functions


### PR DESCRIPTION
This should enable developers to remove lines like:

``` javascript
if (obj && _.has(obj, 'key')) // ...
```

Enabling simpler if statements like:

``` javascript
if (_.has(obj, 'key')) // ...
```
