### PR TITLE
Fix invalid extend test: _.keys uses hasOwnProp

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -63,7 +63,7 @@
     F.prototype = {a: 'b'};
     var subObj = new F();
     subObj.c = 'd';
-    deepEqual(_.keys(_.extend({}, subObj)), ['c'], 'extend ignores any properties but own from source');
+    deepEqual(_.extend({}, subObj), {c: 'd'}, 'extend ignores any properties but own from source');
 
     try {
       result = {};


### PR DESCRIPTION
Fix test to check for the change made in #1770. Currently this test would pass both before and after that change since `_.keys` uses `hasOwnProperty` anyway.
