### PR TITLE
Adding _.combine method that create all possible combinations from given arrays

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -149,16 +149,6 @@
     setTimeout(function(){ ok(delayed, 'delayed the function'); start(); }, 150);
   });
 
-  asyncTest('delayMethod', 2, function() {
-    var obj = { test: function(a,b){ this.called = a+b; } };
-    _.delayMethod(obj,"test",100,"a","b");
-    _.delay(function(){ ok(!obj.called, "didn't call the method quite yet"); }, 50);
-    _.delay(function(){
-      ok(obj.called==="ab", "called with correct context and arguments");
-      start();
-    }, 150);
-  });
-
   asyncTest('defer', 1, function() {
     var deferred = false;
     _.defer(function(bool){ deferred = bool; }, true);

--- a/underscore.js
+++ b/underscore.js
@@ -722,12 +722,6 @@
     }, wait);
   };
 
-  // Further syntactic sugar for delaying a method on an object
-  _.delayMethod = function(obj, methodname, wait) {
-    var args = slice.call(arguments, 3);
-    return setTimeout(function(){ return obj[methodname].apply(obj, args); }, wait);
-  };
-
   // Defers a function, scheduling it to run after the current call stack has
   // cleared.
   _.defer = function(func) {


### PR DESCRIPTION
This pull request implements a feature I've been missing; it returns all possible combinations of elements from the given arrays. Here's an example:

```
_.combine([1,2,3],["a","b"],[”foo","bar","baz"]);
// => [ [1,"a","foo"],[1,"a","bar"],[1,"a","baz"],[1,"b","foo"],[1,"b","bar"],[1,"b","baz"],[2,"a","foo"],[2,"a","bar"],[2,"a","baz"],[2,"b","foo"],[2,"b","bar"],[2,"b","baz"]]
```

Somewhat related to `zip` but not quite the same.

I was surprised to find no previous discussions on this here or on Underscore-contrib - perhaps it's less useful than I thought? I've used it somewhat often, and as the code to perform it is rather messy, I thought it might be a good fit for inclusion.
