### PR TITLE
Add a navigational link to the sidebar for _.before

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,6 +260,7 @@
       <li>- <a href="#debounce">debounce</a></li>
       <li>- <a href="#once">once</a></li>
       <li>- <a href="#after">after</a></li>
+      <li>- <a href="#before">before</a></li>
       <li>- <a href="#wrap">wrap</a></li>
       <li>- <a href="#negate">negate</a></li>
       <li>- <a href="#compose">compose</a></li>


### PR DESCRIPTION
`_.before` is in the docs, but not the nav bar.

![screen shot 2014-08-26 at 10 53 46 pm](https://cloud.githubusercontent.com/assets/933676/4054787/6726d2c4-2d95-11e4-9d15-72753da43062.png)
