### PR TITLE
Loosen clock skew check on debounce

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -767,7 +767,7 @@
     var later = function() {
       var last = _.now() - timestamp;
 
-      if (last < wait && last > 0) {
+      if (last < wait && last >= 0) {
         timeout = setTimeout(later, wait - last);
       } else {
         timeout = null;


### PR DESCRIPTION
In fa352605, a sanity check was added to debounce to make sure our clock hadn't skewed earlier. If the debounced function is getting called under load, though, the last called ts can be the same as the current ts when the timeout runs. That causes `last` to be 0, and currently causes the debounced function to fire.

I wasn't sure how to add a test for this since it is so timing related, but I was able to see it pretty clearly by adding some logging statements inside the `later` function.
