### PR TITLE
Remove use of multiline Strings in tests

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -483,22 +483,24 @@
   document.body.appendChild(iframe);
   var iDoc = (iDoc = iframe.contentDocument || iframe.contentWindow).document || iDoc;
   iDoc.write(
-    '<script>\
-      parent.iElement   = document.createElement("div");\
-      parent.iArguments = (function(){ return arguments; })(1, 2, 3);\
-      parent.iArray     = [1, 2, 3];\
-      parent.iString    = new String("hello");\
-      parent.iNumber    = new Number(100);\
-      parent.iFunction  = (function(){});\
-      parent.iDate      = new Date();\
-      parent.iRegExp    = /hi/;\
-      parent.iNaN       = NaN;\
-      parent.iNull      = null;\
-      parent.iBoolean   = new Boolean(false);\
-      parent.iUndefined = undefined;\
-      parent.iObject     = {};\
-      parent.iError     = new Error();\
-    </script>'
+    [
+    '<script>',
+      'parent.iElement   = document.createElement("div");',
+      'parent.iArguments = (function(){ return arguments; })(1, 2, 3);',
+      'parent.iArray     = [1, 2, 3];',
+      'parent.iString    = new String("hello");',
+      'parent.iNumber    = new Number(100);',
+      'parent.iFunction  = (function(){});',
+      'parent.iDate      = new Date();',
+      'parent.iRegExp    = /hi/;',
+      'parent.iNaN       = NaN;',
+      'parent.iNull      = null;',
+      'parent.iBoolean   = new Boolean(false);',
+      'parent.iUndefined = undefined;',
+      'parent.iObject     = {};',
+      'parent.iError     = new Error();',
+    '</script>'
+    ].join('\n')
   );
   iDoc.close();
 


### PR DESCRIPTION
We're getting lint errors ([see travis logs](https://travis-ci.org/jashkenas/underscore/builds/34279317)) because of multi line strings. Its supported by most environments (as far back as IE6 I think) but it can break some parsers and is disallowed in many projects ([Google style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml?showone=Multiline_string_literals#Multiline_string_literals)). I'd say we should just avoid it instead of fixing eslint

/cc @michaelficarra 
