### PR TITLE
Throttle: Only clear timeouts if they exist

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -744,7 +744,7 @@
       context = this;
       args = arguments;
       if (remaining <= 0 || remaining > wait) {
-        if(timeout) {
+        if (timeout) {
           clearTimeout(timeout);
           timeout = null;
         }


### PR DESCRIPTION
Not sure if this is a real performance issue, but every call to clearTimeout is shown in Chrome Timeline.
