### PR TITLE
increases _.each performance by 5-10%

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -99,13 +99,18 @@
     iteratee = createCallback(iteratee, context);
     var i, length = obj.length;
     if (length === +length) {
-      for (i = 0; i < length; i++) {
+      i = 0;
+      while(i < length) {
         iteratee(obj[i], i, obj);
+        i++;
       }
     } else {
       var keys = _.keys(obj);
-      for (i = 0, length = keys.length; i < length; i++) {
+      i = 0;
+      length = keys.length;
+      while(i < length) {
         iteratee(obj[keys[i]], keys[i], obj);
+        i++;
       }
     }
     return obj;


### PR DESCRIPTION
i ran some javascript performance tests and while is definelty faster than for.
in my test this change increased the _.each performance by 5-10%
