### PR TITLE
Only coerce address to a string once

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -698,7 +698,7 @@
   _.memoize = function(func, hasher) {
     var memoize = function(key) {
       var cache = memoize.cache;
-      var address = hasher ? hasher.apply(this, arguments) : key;
+      var address = '' + (hasher ? hasher.apply(this, arguments) : key);
       if (!_.has(cache, address)) cache[address] = func.apply(this, arguments);
       return cache[address];
     };


### PR DESCRIPTION
Can be a bit faster for when the address is any sort of non string. In that case `toString` is called 2-3 times on the object

http://jsperf.com/memoizel/2
