### PR TITLE
Fixing issue with sorting which fails when different datatypes are given...

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -504,15 +504,15 @@
     deepEqual(_.sortBy(collection, 'x'), collection, 'sortBy accepts property string');
 
     var collectionWithDifferentDatatypes = [
-      new Pair("1", 100), new Pair("1", 1),
-      new Pair("1", 2), new Pair("1", 200)
+      new Pair('1', 100), new Pair('1', 1),
+      new Pair('1', 2), new Pair('1', 200)
     ];
 
     var sortedList = _.sortBy(collectionWithDifferentDatatypes, function(pair) {
       return [pair.x, pair.y];
     });
 
-    var expectedSortedList = [  new Pair("1", 1), new Pair("1", 2), new Pair("1", 100), new Pair("1", 200) ];
+    var expectedSortedList = [new Pair('1', 1), new Pair('1', 2), new Pair('1', 100), new Pair('1', 200)];
 
     deepEqual(sortedList, expectedSortedList, 'sortBy should sort it');
 

--- a/test/collections.js
+++ b/test/collections.js
@@ -503,6 +503,19 @@
 
     deepEqual(_.sortBy(collection, 'x'), collection, 'sortBy accepts property string');
 
+    var collectionWithDifferentDatatypes = [
+      new Pair("1", 100), new Pair("1", 1),
+      new Pair("1", 2), new Pair("1", 200)
+    ];
+
+    var sortedList = _.sortBy(collectionWithDifferentDatatypes, function(pair) {
+      return [pair.x, pair.y];
+    });
+
+    var expectedSortedList = [  new Pair("1", 1), new Pair("1", 2), new Pair("1", 100), new Pair("1", 200) ];
+
+    deepEqual(sortedList, expectedSortedList, 'sortBy should sort it');
+
     list = ['q', 'w', 'e', 'r', 't', 'y'];
     deepEqual(_.sortBy(list), ['e', 'q', 'r', 't', 'w', 'y'], 'uses _.identity if iterator is not specified');
   });

--- a/underscore.js
+++ b/underscore.js
@@ -347,6 +347,10 @@
       var a = left.criteria;
       var b = right.criteria;
       if (a !== b) {
+        for (var index = 0; index < _.keys(a).length; index++) {
+          if (a[index] > b[index] || a === void 0) return 1;
+          if (a[index] < b[index] || b === void 0) return -1;
+        }
         if (a > b || a === void 0) return 1;
         if (a < b || b === void 0) return -1;
       }


### PR DESCRIPTION
... in the sortby list.

Fixing sorting issue mentioned below :

If i have objects like these : 
`[{"1", 100}, {"1", 1}, {"1", 2}, {"1", 200}]`
If i sort the elements using both the columns then the result should be :
`[{"1", 1}, {"1", 2}, {"1", 100}, {"1", 200}]`
But in the current code the result that is displayed is :
`[{"1", 1}, {"1", 100}, {"1", 2}, {"1", 200}]`
