### PR TITLE
Use faster raw loop in _.values

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -876,11 +876,9 @@
 
   // Retrieve the values of an object's properties.
   _.values = function(obj) {
-    var keys = _.keys(obj);
-    var length = keys.length;
-    var values = Array(length);
-    for (var i = 0; i < length; i++) {
-      values[i] = obj[keys[i]];
+    var values = [];
+    for (var key in obj) {
+      if (_.has(obj, key)) values.push(obj[key]);
     }
     return values;
   };


### PR DESCRIPTION
It turns out the naïve raw `for ... in` loop is much faster than mucking with a sparse array and Object.keys (and should avoid looping over the object twice on older browsers with a shimmed `keys`)

http://jsperf.com/values-extraction/4
http://jsperf.com/underscore-vals
