### PR TITLE
extend the extend method to be able working correctly with getters and setters of a property

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -925,7 +925,7 @@
     for (var i = 1, length = arguments.length; i < length; i++) {
       source = arguments[i];
       for (prop in source) {
-         Object.defineProperty(obj, prop, Object.getOwnPropertyDescriptor(source, prop));
+         defProp(obj, prop, Object.getProp(source, prop));
       }
     }
     return obj;


### PR DESCRIPTION
example: 

``` javascript
_.extend({},{get foo() {return this.bar()}})
```

Since current implementation does direct assignment involving getter invocation, in the best case it'll assign result of getter function or like in example above will throw exception. 
