### PR TITLE
Release func in _.before and _.once

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -836,7 +836,8 @@
     return function() {
       if (--times > 0) {
         memo = func.apply(this, arguments);
-      } else {
+      }
+      if (times <= 1) {
         func = null;
       }
       return memo;


### PR DESCRIPTION
`func` isn't released until the _before_ function is called n times, when it's possible to release it after n-1 times. Since `_.once` uses `_.before`, this means that a _onced_ function isn't released until the 2nd time you call it.
