### PR TITLE
Add _.assign function

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -131,6 +131,36 @@
     strictEqual(_.extend(undefined, {a: 1}), undefined, 'extending undefined results in undefined');
   });
 
+  test('assign', function() {
+    var result;
+    equal(_.assign({}, {a: 'b'}).a, 'b', 'can assign an object with the attributes of another');
+    equal(_.assign({a: 'x'}, {a: 'b'}).a, 'b', 'properties in source override destination');
+    equal(_.assign({x: 'x'}, {a: 'b'}).x, 'x', "properties not in source don't get overriden");
+    result = _.assign({x: 'x'}, {a: 'a'}, {b: 'b'});
+    deepEqual(result, {x: 'x', a: 'a', b: 'b'}, 'can assign from multiple source objects');
+    result = _.assign({x: 'x'}, {a: 'a', x: 2}, {a: 'b'});
+    deepEqual(result, {x: 2, a: 'b'}, 'assigning from multiple source objects last property trumps');
+    deepEqual(_.assign({}, {a: void 0, b: null}), {a: void 0, b: null}, 'assign copies undefined values');
+
+    var F = function() {};
+    F.prototype = {a: 'b'};
+    var subObj = new F();
+    subObj.c = 'd';
+    deepEqual(_.assign({}, subObj), {c: 'd'}, 'assign copies own properties from source');
+
+    result = {};
+    deepEqual(_.assign(result, null, undefined, {a: 1}), {a: 1}, 'should not error on `null` or `undefined` sources');
+
+    _.each(['a', 5, null, false], function(val) {
+      strictEqual(_.assign(val, {a: 1}), val, 'assigning non-objects results in returning the non-object value');
+    });
+
+    strictEqual(_.assign(undefined, {a: 1}), undefined, 'assigning undefined results in undefined');
+
+    result = _.assign({a: 1, 0: 2, 1: '5', length: 6}, {0: 1, 1: 2, length: 2});
+    deepEqual(result, {a: 1, 0: 1, 1: 2, length: 2}, 'assign should treat array-like objects like normal objects');
+  });
+
   test('pick', function() {
     var result;
     result = _.pick({a: 1, b: 2, c: 3}, 'a', 'c');

--- a/underscore.js
+++ b/underscore.js
@@ -90,6 +90,24 @@
     return cb(value, context);
   };
 
+  // An internal function for creating assigner functions.
+  var createAssigner = function(keysFunc) {
+    return function(obj) {
+      var length = arguments.length;
+      if (length < 2 || obj == null) return obj;
+      for (var index = 0; index < length; index++) {
+        var source = arguments[index],
+            keys = keysFunc(source),
+            l = keys.length;
+        for (var i = 0; i < l; i++) {
+          var key = keys[i];
+          obj[key] = source[key];
+        }
+      }
+      return obj;
+    };
+  };
+
   // Collection Functions
   // --------------------
 
@@ -944,17 +962,11 @@
   };
 
   // Extend a given object with all the properties in passed-in object(s).
-  _.extend = function(obj) {
-    if (!_.isObject(obj)) return obj;
-    var source, prop;
-    for (var i = 1, length = arguments.length; i < length; i++) {
-      source = arguments[i];
-      for (prop in source) {
-        obj[prop] = source[prop];
-      }
-    }
-    return obj;
-  };
+  _.extend = createAssigner(_.keysIn);
+
+  // Assigns a given object with all the own properties in the passed-in object(s)
+  // (https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/assign)
+  _.assign = createAssigner(_.keys);
 
   // Returns the first key on an object that passes a predicate test
   _.findKey = function(obj, predicate, context) {
@@ -1231,8 +1243,8 @@
       return obj == null ? void 0 : obj[key];
     };
   };
-  
-  // Generates a function for a given object that returns a given property (including those of ancestors) 
+
+  // Generates a function for a given object that returns a given property (including those of ancestors)
   _.propertyOf = function(obj) {
     return obj == null ? function(){} : function(key) {
       return obj[key];


### PR DESCRIPTION
@megawac [mentioned](https://github.com/jashkenas/underscore/pull/1907#discussion_r19318553) creating an alternative to `_.extend` but only adding own properties named `_.assign` to align with `Object.assign`. There wasn't an issue or pull request anywhere so here it is.

Since the 2.0 plan is to align `_.extend` with ES6's `Object.assign`, I can imagine this would just become an alias to extend.

I've created `baseAssign` here so that [other functions](https://github.com/jashkenas/underscore/pull/1907#discussion_r19317971) can take advantage of it. 

This implementation is a slimmed down (albeit less-performant) version of the one seen in lodash. Thanks @jdalton.
