### PR TITLE
making _.unescape be able to unescape ' and ` escaped in Dec format

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -138,8 +138,8 @@
     equal(_.unescape(str), str, 'can unescape &amp;');
 
     // test unescape of ' and ` symbols escaped in Dec format
-    equal(_.unescape("&#39;"), "'", 'can unescape &#39;');
-    equal(_.unescape("&#96;"), '`', 'can unescape &#96;');
+    equal(_.unescape('&#39;'), '\'', 'can unescape &#39;');
+    equal(_.unescape('&#96;'), '`', 'can unescape &#96;');
   });
 
   test('template', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -1262,9 +1262,9 @@
     '`': '&#x60;'
   };
   var unescapeMap = _.invert(escapeMap);
-  // Also adding ' and ` symbols escaped in Dec format
-  unescapeMap["&#39;"] = "'";
-  unescapeMap["&#96;"] = '`';
+  // Some server side frameworks (e.g. Django) escape ' and ` symbols in decimal format. So adding them for _.unescape.
+  unescapeMap['&#39;'] = '\'';
+  unescapeMap['&#96;'] = '`';
 
   // Functions for escaping and unescaping strings to/from HTML interpolation.
   var createEscaper = function(map) {


### PR DESCRIPTION
Let's have underscore unescape &amp;#39; and &amp;#96; These are valid HTML entities for ' and ` symbols.
Any browser works both with Dec and Hex representation of these symbols.

The issue is that Django web framework escapes ' and `  using Dec approach. And most probably other frameworks may do the same way.

So in such situation it's necessary to write some additional code which should probably be inside of the library.
