### PR TITLE
Added _.pluckWhere method and tests

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -381,6 +381,15 @@
     deepEqual(_.pluck([{'[object Object]': 1}], {}), [1]);
   });
 
+  test('pluckWhere', function() {
+    var people = [{name: 'moe', age: 30},{name: 'larry', age: 40},{name: 'curly', age: 50}];
+    function test(person) {
+      if (person.age < 35){ return 'name'; }
+      if (person.age < 45){ return 'age'; }
+    }
+    deepEqual(_.pluckWhere(people,test), ['moe',40]);
+  });
+
   test('where', function() {
     var list = [{a: 1, b: 2}, {a: 2, b: 2}, {a: 1, b: 3}, {a: 1, b: 4}];
     var result = _.where(list, {a: 1});

--- a/underscore.js
+++ b/underscore.js
@@ -247,6 +247,18 @@
     return _.map(obj, _.property(key));
   };
 
+  // Convenience version of a common use case of 'reduce' : fetch a property
+  // at a key determined by a callback if the key is truthy
+  _.pluckWhere = function(obj,iteratee,context) {
+    var currentKey;
+    iteratee = cb(iteratee,context);
+    return _.reduce(obj,function(results,value,key,obj){
+      currentKey = iteratee(value,key,obj);
+      if (currentKey || currentKey === 0 || currentKey === '')results.push(value[currentKey]);
+      return results;
+    },[]);
+  };
+
   // Convenience version of a common use case of `filter`: selecting only objects
   // containing specific `key:value` pairs.
   _.where = function(obj, attrs) {


### PR DESCRIPTION
`_.pluckWhere` is an alternate to `_.pluck` using a callback to determine whether to pluck a key and, if so, which key.  Useful for plucking diagonally across an array of arrays or for filtering plucked values
