### PR TITLE
Support custom random number generator in random() and shuffle()

### DIFF
--- a/index.html
+++ b/index.html
@@ -733,10 +733,13 @@ _.countBy([1, 2, 3, 4, 5], function(num) {
 </pre>
 
       <p id="shuffle">
-        <b class="header">shuffle</b><code>_.shuffle(list)</code>
+        <b class="header">shuffle</b><code>_.shuffle(list, [randomFn])</code>
         <br />
         Returns a shuffled copy of the <b>list</b>, using a version of the
         <a href="http://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle">Fisher-Yates shuffle</a>.
+        The function <b>randomFn</b> (which has to return a number between 0 
+        inclusive and 1 exclusive) is used as a random number generator. 
+        If <b>randomFn</b> is not specified, uses <tt>Math.random</tt>.
       </p>
       <pre>
 _.shuffle([1, 2, 3, 4, 5, 6]);
@@ -1688,11 +1691,14 @@ obj.initialize = _.noop;
 _(3).times(function(n){ genie.grantWishNumber(n); });</pre>
 
       <p id="random">
-        <b class="header">random</b><code>_.random(min, max)</code>
+        <b class="header">random</b><code>_.random(min, max, [randomFn])</code>
         <br />
         Returns a random integer between <b>min</b> and <b>max</b>, inclusive.
         If you only pass one argument, it will return a number between <tt>0</tt>
         and that number.
+        The function <b>randomFn</b> (which has to return a number between 0 
+        inclusive and 1 exclusive) is used as a random number generator. 
+        If <b>randomFn</b> is not specified, uses <tt>Math.random</tt>.
       </p>
       <pre>
 _.random(0, 100);

--- a/test/collections.js
+++ b/test/collections.js
@@ -642,6 +642,9 @@
     shuffled = _.shuffle({a: 1, b: 2, c: 3, d: 4});
     equal(shuffled.length, 4);
     deepEqual(shuffled.sort(), [1, 2, 3, 4], 'works on objects');
+
+		shuffled = _.shuffle(numbers, function() { return 0.5; });
+		deepEqual(shuffled, [0, 2, 4, 6, 8, 9, 5, 3, 7, 1], 'works with custom random function');
   });
 
   test('sample', function() {

--- a/test/utility.js
+++ b/test/utility.js
@@ -71,6 +71,8 @@
     ok(_.some(array, function() {
       return _.random(Number.MAX_VALUE) > 0;
     }), 'should produce a random number when passed `Number.MAX_VALUE`');
+
+		equal(_.random(0, 5, function () { return 0.5; }), 3, 'should work with custom random function');
   });
 
   test('now', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -311,12 +311,12 @@
 
   // Shuffle a collection, using the modern version of the
   // [Fisher-Yates shuffle](http://en.wikipedia.org/wiki/Fisher–Yates_shuffle).
-  _.shuffle = function(obj) {
+  _.shuffle = function(obj, randomFn) {
     var set = obj && obj.length === +obj.length ? obj : _.values(obj);
     var length = set.length;
     var shuffled = Array(length);
     for (var index = 0, rand; index < length; index++) {
-      rand = _.random(0, index);
+      rand = _.random(0, index, randomFn);
       if (rand !== index) shuffled[index] = shuffled[rand];
       shuffled[rand] = set[index];
     }
@@ -1262,12 +1262,13 @@
   };
 
   // Return a random integer between min and max (inclusive).
-  _.random = function(min, max) {
+  _.random = function(min, max, randomFn) {
+    randomFn = randomFn || Math.random;
     if (max == null) {
       max = min;
       min = 0;
     }
-    return min + Math.floor(Math.random() * (max - min + 1));
+    return min + Math.floor(randomFn() * (max - min + 1));
   };
 
   // A (possibly faster) way to get the current timestamp as an integer.


### PR DESCRIPTION
I added support for specifying a custom random generator function to random() and shuffle(). This is useful if you want to make functions that use these functions yield predictable results (by passing in a stable/predictable generator), without influencing other invocations of Math.random, and vice versa, without having other invocations of Math.random influence their result.
