### PR TITLE
Update forEach array check

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -100,7 +100,7 @@
     if (obj == null) return obj;
     iteratee = optimizeCb(iteratee, context);
     var i, length = obj.length;
-    if (length === +length) {
+    if (Array.isArray(obj)) {
       for (i = 0; i < length; i++) {
         iteratee(obj[i], i, obj);
       }


### PR DESCRIPTION
Currently forEach is checking to see if the object has a property length and that length is a number. I've changed it to use Array.isArray because an object could be assigned a property length that is a number, that does not represent the number of properties in the object itself. Under those circumstance the object (as a hash table) would be handled as an array.
