### PR TITLE
Fix changelog for _.escape: function no longer escapes slash '/'

### DIFF
--- a/index.html
+++ b/index.html
@@ -2190,6 +2190,9 @@ _([1, 2, 3]).value();
             in terms of <tt>_.keys</tt> (which includes, significantly,
             <tt>each</tt> on objects). Also for <tt>debounce</tt> in a tight loop.
           </li>
+          <li>
+            The <tt>_.escape</tt> function no longer escapes '/'.
+          </li>
         </ul>
       </p>
 


### PR DESCRIPTION
Changed in version 1.5.2
Related issue: #1189
