### PR TITLE
Add _.call (for use when chaining)

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1413,6 +1413,11 @@
     instance._chain = true;
     return instance;
   };
+  
+  // Call a function with the value and return the result
+  _.prototype.call = function(obj, fn, context) {
+    return fn.call(context, obj);
+  }l
 
   // OOP
   // ---------------

--- a/underscore.js
+++ b/underscore.js
@@ -1417,7 +1417,7 @@
   // Call a function with the value and return the result
   _.prototype.call = function(obj, fn, context) {
     return fn.call(context, obj);
-  }l
+  };
 
   // OOP
   // ---------------


### PR DESCRIPTION
When chaining it would be useful to be able to pass the whole object through a function, kind of like _.tap except the value is replaced with the return of the function.

Implementation is trivial and of course it doesn't make much sense when not chaining.

Anyone think this is a good idea?
