### PR TITLE
Object-preserving map() function: mapValues

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -801,4 +801,58 @@
     strictEqual(_.findKey(array, function(x) { return x === 55; }), 'match', 'matches array-likes keys');
   });
 
+
+  test('mapValues', function() {
+   var obj = {'a': 1, 'b': 2};
+   var objects = {
+      a: {'a': 0, 'b': 0},
+      b: {'a': 1, 'b': 1},
+      c: {'a': 2, 'b': 2}
+    };
+
+    deepEqual(_.mapValues(obj, function(val) {
+      return val * 2;
+    }), {'a': 2, 'b': 4}, 'simple objects');
+
+    deepEqual(_.mapValues(objects, function(val) {
+      return _.reduce(val, function(memo,v){
+       return memo + v;
+      },0);
+    }), {'a': 0, 'b': 2, 'c': 4}, 'nested objects');
+
+    deepEqual(_.mapValues(obj, function(val,key,obj) {
+      return obj[key] * 2;
+    }), {'a': 2, 'b': 4}, 'correct keys');
+
+    deepEqual(_.mapValues([1,2], function(val) {
+      return val * 2;
+    }), {'0': 2, '1': 4}, 'check behavior for arrays');
+
+    deepEqual(_.mapValues(obj, function(val) {
+      return val * this.multiplier;
+    }, {multiplier : 3}), {'a': 3, 'b': 6}, 'keep context');
+
+    deepEqual(_.mapValues({a: 1}, function() {
+      return this.length;
+    }, [1,2]), {'a': 2}, 'called with context');
+
+    var ids = _.mapValues({length: 2, 0: {id: '1'}, 1: {id: '2'}}, function(n){
+      return n.id;
+    });
+    deepEqual(ids, {'length': undefined, '0': '1', '1': '2'}, 'Check with array-like objects');
+
+    // Passing a property name like _.pluck.
+    var people = {'a': {name : 'moe', age : 30}, 'b': {name : 'curly', age : 50}};
+    deepEqual(_.mapValues(people, 'name'), {'a': 'moe', 'b': 'curly'}, 'predicate string map to object properties');
+
+    _.each([null, void 0, 1, 'abc', [], {}, undefined], function(val){
+      deepEqual(_.mapValues(val, _.identity), {}, 'mapValue identity');
+    });
+
+    var Proto = function(){this.a = 1;};
+    Proto.prototype.b = 1;
+    var protoObj = new Proto();
+    deepEqual(_.mapValues(protoObj, _.identity), {a: 1}, 'ignore inherited values from prototypes');
+
+  });
 }());

--- a/underscore.js
+++ b/underscore.js
@@ -930,6 +930,22 @@
     return values;
   };
 
+  // Returns the results of applying the iteratee to each element of the object
+  // In contrast to _.map it returns an object
+  _.mapValues = function(obj, iteratee, context) {
+    if (obj == null) return {};
+    iteratee = cb(iteratee, context);
+    var keys =  _.keys(obj),
+          length = keys.length,
+          results = {},
+          currentKey;
+      for (var index = 0; index < length; index++) {
+        currentKey = keys[index];
+        results[currentKey] = iteratee(obj[currentKey], currentKey, obj);
+      }
+      return results;
+  };
+
   // Convert an object into a list of `[key, value]` pairs.
   _.pairs = function(obj) {
     var keys = _.keys(obj);


### PR DESCRIPTION
This adds the `mapValues` methods.

It works exactly like `map`, but preserves the object.

```
_.map2({a: 1, b: 2}, function(val, key) {
    return val * 2;
});
=> {a: 2, b: 4}
```

There are at least three issues about this function (#220 #1867 #1887), and as I also do this frequently it would be awesome to get this into underscore.