### PR TITLE
Flatten array-likes, not strings

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -97,6 +97,14 @@
     equal(_.flatten([_.range(10), _.range(10), 5, 1, 3]).length, 23);
     equal(_.flatten([new Array(1000000), _.range(56000), 5, 1, 3]).length, 1056003, 'Flatten can handle massive collections');
     equal(_.flatten([new Array(1000000), _.range(56000), 5, 1, 3], true).length, 1056003, 'Flatten can handle massive collections');
+
+    equal(_.flatten({length: 2, 0: 0, 1: {length: 1, 0: _.range(10)}}).length, 11, 'can flatten array-likes');
+    equal(_.flatten({length: 2, 0: 0, 1: {length: 1, 0: _.range(10)}}, true).length, 2, 'can flatten array-likes');
+
+    equal(_.flatten('testing').length, 1, 'does not flatten strings to chars');
+    equal(_.flatten('testing', true).length, 1, 'does not flatten strings to chars');
+    equal(_.flatten(['testing']).length, 1, 'does not flatten strings to chars');
+    equal(_.flatten(['testing'], true).length, 1, 'does not flatten strings to chars');
   });
 
   test('without', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -185,7 +185,7 @@
   _.reduceRight = _.foldr = function(obj, iteratee, memo, context) {
     if (obj == null) obj = [];
     iteratee = optimizeCb(iteratee, context, 4);
-    var keys = obj.length !== + obj.length && _.keys(obj),
+    var keys = obj.length !== +obj.length && _.keys(obj),
         index = (keys || obj).length,
         currentKey;
     if (arguments.length < 3) {
@@ -499,10 +499,12 @@
 
   // Internal implementation of a recursive `flatten` function.
   var flatten = function(input, shallow, strict, startIndex) {
+    if (input == null) return [];
+    if (_.isString(input)) return [input];
     var output = [], idx = 0, value;
-    for (var i = startIndex || 0, length = input && input.length; i < length; i++) {
+    for (var i = startIndex || 0, length = input.length; i < length; i++) {
       value = input[i];
-      if (value && value.length >= 0 && (_.isArray(value) || _.isArguments(value))) {
+      if (value && value.length === +value.length && !_.isString(value)) {
         //flatten current level of array or arguments object
         if (!shallow) value = flatten(value, shallow, strict);
         var j = 0, len = value.length;


### PR DESCRIPTION
I noticed a bit of an inconsistency with `_.flatten` on strings.

``` javascript
_.flatten('testing'); // => ["t", "e", "s", "t", "i", "n", "g"]
_.flatten('testing', true); // => ["t", "e", "s", "t", "i", "n", "g"]
_.flatten(['testing']); // => ["testing"]
_.flatten(['testing'], true); // => ["testing"]
```

This fixes it so flatten does not convert a string to its corresponding chars. Array-likes can now also be flattened, but that's more of a side-effect that can be removed from the PR if that's not wanted.
