### PR TITLE
Adds a test case when we call _.pluck() to objects passing an undefined property as an argument.

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -405,6 +405,7 @@
   test('pluck', function() {
     var people = [{name: 'moe', age: 30}, {name: 'curly', age: 50}];
     deepEqual(_.pluck(people, 'name'), ['moe', 'curly'], 'pulls names out of objects');
+    deepEqual(_.pluck(people, 'address'), [undefined, undefined], 'pulls address of objects');
     //compat: most flexible handling of edge cases
     deepEqual(_.pluck([{'[object Object]': 1}], {}), [1]);
   });


### PR DESCRIPTION
Hi.
I've added a test case to `_.pluck()` function in order to ensure return values from it as the specification.
In my opinion, it is intuitive that `_.pluck(objs, key)` returns an empty array in the case when each element of `objs` doesn't have `key` as its property, but it would be better to avoid changing the behavior.
