### PR TITLE
fix eslint warnings

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -593,8 +593,8 @@
 
   test('indexBy', function() {
     var parity = _.indexBy([1, 2, 3, 4, 5], function(num){ return num % 2 === 0; });
-    equal(parity.true, 4);
-    equal(parity.false, 5);
+    equal(parity['true'], 4);
+    equal(parity['false'], 5);
 
     var list = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
     var grouped = _.indexBy(list, 'length');
@@ -611,8 +611,8 @@
 
   test('countBy', function() {
     var parity = _.countBy([1, 2, 3, 4, 5], function(num){ return num % 2 === 0; });
-    equal(parity.true, 2);
-    equal(parity.false, 3);
+    equal(parity['true'], 2);
+    equal(parity['false'], 3);
 
     var list = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
     var grouped = _.countBy(list, 'length');


### PR DESCRIPTION
While working on another PR, I noticed these warnings and thought it would be better to fix separately.

Before:

```
$ npm test

> underscore@1.7.0 test /Users/max/Sites/underscore
> phantomjs test/vendor/runner.js test/index.html?noglobals=true && eslint underscore.js test/*.js test/vendor/runner.js

Took 6057ms to run 1119 tests. 1119 passed, 0 failed.

underscore.js
   886:21  warning  Gratuitous parentheses around expression  no-extra-parens
  1121:14  warning  Gratuitous parentheses around expression  no-extra-parens

test/collections.js
  596:10  warning  ['true'] is better written in dot notation   dot-notation
  597:10  warning  ['false'] is better written in dot notation  dot-notation
  614:10  warning  ['true'] is better written in dot notation   dot-notation
  615:10  warning  ['false'] is better written in dot notation  dot-notation

✖ 6 problems
```

After:

```
$ npm test

> underscore@1.7.0 test /Users/max/Sites/underscore
> phantomjs test/vendor/runner.js test/index.html?noglobals=true && eslint underscore.js test/*.js test/vendor/runner.js

Took 5973ms to run 1119 tests. 1119 passed, 0 failed.

test/collections.js
  596:10  warning  ['true'] is better written in dot notation   dot-notation
  597:10  warning  ['false'] is better written in dot notation  dot-notation
  614:10  warning  ['true'] is better written in dot notation   dot-notation
  615:10  warning  ['false'] is better written in dot notation  dot-notation

✖ 4 problems
```
