### PR TITLE
add iteration fixes of _.keys to _.isEmpty

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -562,6 +562,10 @@
     var args = function(){ return arguments; };
     ok(_.isEmpty(args()), 'empty arguments object is empty');
     ok(!_.isEmpty(args('')), 'non-empty arguments object is not empty');
+
+    // covers collecting non-enumerable properties in IE < 9
+    var nonEnumProp = {'toString': 5};
+    ok(!_.isEmpty(nonEnumProp), 'non-enumerable property is not empty');
   });
 
   test('isElement', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -1143,12 +1143,22 @@
     return eq(a, b, [], []);
   };
 
+  /**
+  * Used as the maximum length of an array-like value.
+  * See the [ES6 spec](http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tolength)
+  * for more details.
+  */
+  var MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
+  function isLength(value) {
+    return typeof value == 'number' && value > -1 && value <= MAX_SAFE_INTEGER;
+  }
+
   // Is a given array, string, or object empty?
   // An "empty" object has no enumerable own-properties.
   _.isEmpty = function(obj) {
     if (obj == null) return true;
     var length = obj.length;
-    if (typeof length == 'number') return length === 0;
+    if (isLength(length) && (_.isArray(obj) || _.isString(obj) || _.isArguments(obj))) return length === 0;
     // Ahem, IE < 9.
     if (!hasEnumBug) {
       for (var key in obj) if (_.has(obj, key)) return false;

--- a/underscore.js
+++ b/underscore.js
@@ -1147,7 +1147,8 @@
   // An "empty" object has no enumerable own-properties.
   _.isEmpty = function(obj) {
     if (obj == null) return true;
-    if (_.isArray(obj) || _.isString(obj) || _.isArguments(obj)) return obj.length === 0;
+    var length = obj.length;
+    if (typeof length == 'number') return length === 0;
     // Ahem, IE < 9.
     if (!hasEnumBug) {
       for (var key in obj) if (_.has(obj, key)) return false;

--- a/underscore.js
+++ b/underscore.js
@@ -1143,11 +1143,8 @@
     return eq(a, b, [], []);
   };
 
-  /**
-  * Used as the maximum length of an array-like value.
-  * See the [ES6 spec](http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tolength)
-  * for more details.
-  */
+  // Used as the maximum length of an array-like value.
+  // See the [ES6 spec](http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tolength) for more details.
   var MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
   function isLength(value) {
     return typeof value == 'number' && value > -1 && value <= MAX_SAFE_INTEGER;

--- a/underscore.js
+++ b/underscore.js
@@ -1149,6 +1149,18 @@
     if (obj == null) return true;
     if (_.isArray(obj) || _.isString(obj) || _.isArguments(obj)) return obj.length === 0;
     for (var key in obj) if (_.has(obj, key)) return false;
+    // Ahem, IE < 9.
+    if (hasEnumBug) {
+      var nonEnumIdx = nonEnumerableProps.length;
+      var proto = typeof obj.constructor === 'function' ? FuncProto : ObjProto;
+
+      while (nonEnumIdx--) {
+        var prop = nonEnumerableProps[nonEnumIdx];
+        if (prop === 'constructor' ? _.has(obj, prop) : prop in obj && obj[prop] !== proto[prop]) {
+          return false;
+        }
+      }
+    }
     return true;
   };
 

--- a/underscore.js
+++ b/underscore.js
@@ -1159,13 +1159,7 @@
     if (obj == null) return true;
     var length = obj.length;
     if (isLength(length) && (_.isArray(obj) || _.isString(obj) || _.isArguments(obj))) return length === 0;
-    // Ahem, IE < 9.
-    if (!hasEnumBug) {
-      for (var key in obj) if (_.has(obj, key)) return false;
-    } else {
-      return _.keys(obj).length === 0;
-    }
-    return true;
+    return _.keys(obj).length === 0;
   };
 
   // Is a given value a DOM element?

--- a/underscore.js
+++ b/underscore.js
@@ -1148,18 +1148,11 @@
   _.isEmpty = function(obj) {
     if (obj == null) return true;
     if (_.isArray(obj) || _.isString(obj) || _.isArguments(obj)) return obj.length === 0;
-    for (var key in obj) if (_.has(obj, key)) return false;
     // Ahem, IE < 9.
-    if (hasEnumBug) {
-      var nonEnumIdx = nonEnumerableProps.length;
-      var proto = typeof obj.constructor === 'function' ? FuncProto : ObjProto;
-
-      while (nonEnumIdx--) {
-        var prop = nonEnumerableProps[nonEnumIdx];
-        if (prop === 'constructor' ? _.has(obj, prop) : prop in obj && obj[prop] !== proto[prop]) {
-          return false;
-        }
-      }
+    if (!hasEnumBug) {
+      for (var key in obj) if (_.has(obj, key)) return false;
+    } else {
+      return _.keys(obj).length === 0;
     }
     return true;
   };


### PR DESCRIPTION
This is an attempt to fix #1983 

I tried reusing parts of _.keys that made sense to detect if an object was truly empty in IE < 9