### PR TITLE
Invoke shouldn't throw for null or undefined

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -406,7 +406,7 @@
     strictEqual(_.includes, _.contains, 'alias for includes');
   });
 
-  test('invoke', 3, function() {
+  test('invoke', 5, function() {
     var list = [[5, 1, 7], [3, 2, 1]];
     var result = _.invoke(list, 'sort');
     deepEqual(result[0], [1, 5, 7], 'first array sorted');
@@ -417,6 +417,12 @@
         deepEqual(_.toArray(arguments), [1, 2, 3], 'called with arguments');
       }
     }], 'method', 1, 2, 3);
+
+    deepEqual(_.invoke([{a: null}, {}, {a: _.constant(1)}], 'a'), [null, void 0, 1], 'handles null & undefined');
+
+    throws(function() {
+      _.invoke([{a: 1}], 'a');
+    }, TypeError, 'throws for non-functions');
   });
 
   test('invoke w/ function reference', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -291,7 +291,8 @@
     var args = slice.call(arguments, 2);
     var isFunc = _.isFunction(method);
     return _.map(obj, function(value) {
-      return (isFunc ? method : value[method]).apply(value, args);
+      var func = isFunc ? method : value[method];
+      return func == null ? func : func.apply(value, args);
     });
   };
 


### PR DESCRIPTION
This has been brought up before

 - https://github.com/jashkenas/underscore/pull/1520#issuecomment-37668674

I often need to do an invoke where some items may or may not have a function defined (should this only check if its defined?). So I do something like

```js
var someCollection = [...];

_.chain(someCollection).filter('update').invoke('update');
```

Anyway, this is consistent with the rest of the codebase if nothing else