### PR TITLE
Allow nested checks in _.has

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -730,7 +730,7 @@
   });
 
   test('has', function () {
-    var obj = {foo: 'bar', func: function(){}};
+    var obj = {foo: 'bar', func: function(){}, bar: {foo: 'bar', one: {again: 'bar'}}};
     ok(_.has(obj, 'foo'), 'has() checks that the object has a property.');
     ok(!_.has(obj, 'baz'), "has() returns false if the object doesn't have the property.");
     ok(_.has(obj, 'func'), 'has() works for functions too.');
@@ -741,6 +741,10 @@
     ok(!_.has(child, 'foo'), 'has() does not check the prototype chain for a property.');
     strictEqual(_.has(null, 'foo'), false, 'has() returns false for null');
     strictEqual(_.has(undefined, 'foo'), false, 'has() returns false for undefined');
+		ok(_.has(obj, 'bar.foo'), 'has() can access child properties');
+		ok(_.has(obj, 'bar.one.again', 'has() can access nested child properties'));
+		ok(!_.has(obj, 'bar.one.two'), 'has() checks that the nested child property exists');
+		ok(!_.has(obj, 'bar.two.one'), 'has() checked that one child exists');
   });
 
   test('matches', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -122,6 +122,13 @@
     return result;
   };
 
+	// An internal function to resolve object from string of properties.
+	var resolveObject = function(obj, path) {
+		return [obj || self].concat(path.split('.')).reduce(function(prev, curr) {
+			return prev[curr];
+		});
+	};
+
   // Collection Functions
   // --------------------
 
@@ -1239,6 +1246,12 @@
   // Shortcut function for checking if an object has a given property directly
   // on itself (in other words, not on a prototype).
   _.has = function(obj, key) {
+    if (_.isString(key) && key.indexOf('.') !== -1) {
+      var keys = key.split('.');
+      key = keys.pop();
+      var path = keys.join('.');
+      obj = resolveObject(obj, path);
+    }
     return obj != null && hasOwnProperty.call(obj, key);
   };
 


### PR DESCRIPTION
Adds some basic support to be able to do something like this:
```
var obj = {foo: {bar: "Hello"}};
console.assert(_.has(obj, 'foo.bar'));
console.assert(!_.has(obj, 'foo.foo'));
```