### PR TITLE
Add check to createAssigner function so that _.defaults can use it (fixes #1984)

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -95,7 +95,7 @@
   };
 
   // An internal function for creating assigner functions.
-  var createAssigner = function(keysFunc) {
+  var createAssigner = function(keysFunc, undefinedOnly) {
     return function(obj) {
       var length = arguments.length;
       if (length < 2 || obj == null) return obj;
@@ -105,7 +105,7 @@
             l = keys.length;
         for (var i = 0; i < l; i++) {
           var key = keys[i];
-          obj[key] = source[key];
+          if (!undefinedOnly || obj[key] === void 0) obj[key] = source[key];
         }
       }
       return obj;
@@ -1050,16 +1050,7 @@
   };
 
   // Fill in a given object with default properties.
-  _.defaults = function(obj) {
-    if (!_.isObject(obj)) return obj;
-    for (var i = 1, length = arguments.length; i < length; i++) {
-      var source = arguments[i];
-      for (var prop in source) {
-        if (obj[prop] === void 0) obj[prop] = source[prop];
-      }
-    }
-    return obj;
-  };
+  _.defaults = createAssigner(_.keysIn, true);
 
   // Creates an object that inherits from the given prototype object.
   // If additional properties are provided then they will be added to the


### PR DESCRIPTION
This commit expands the functionality of the `createAssigner` internal function so that it can be used by `_.defaults` in essentially the same way that it is already used by `_.extend` and `_.assign`. The expansion allows `createAssigner` to receive a second argument indicating whether or not the function that it returns should only assign properties and their values to a given object if the properties are undefined on that object. If `true` (or a truthy value) is passed as the value of that argument, the returned function does just that -- it only assigns properties to a given object if they are undefined on that object; otherwise, `createAssigner` returns a function that assigns properties whether they exist on the object or not (the default functionality). This modification allows `_.defaults` to enjoy the same fixes related to for-in loops as those enjoyed by `_.extend` and `_.assign`. 

See discussion at #1984 for additional details.