### PR TITLE
Fix and test for _.extend (fixes #2023)

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -119,6 +119,8 @@
     var subObj = new F();
     subObj.c = 'd';
     deepEqual(_.extend({}, subObj), {a: 'b', c: 'd'}, 'extend copies all properties from source');
+    _.extend(subObj, {});
+    ok(!subObj.hasOwnProperty('a'), "extend does not convert destination object's 'in' properties to 'own' properties");
 
     try {
       result = {};

--- a/underscore.js
+++ b/underscore.js
@@ -99,7 +99,7 @@
     return function(obj) {
       var length = arguments.length;
       if (length < 2 || obj == null) return obj;
-      for (var index = 0; index < length; index++) {
+      for (var index = 1; index < length; index++) {
         var source = arguments[index],
             keys = keysFunc(source),
             l = keys.length;


### PR DESCRIPTION
`_.extend` was iterating over the original (destination) object, going through its 'in' properties on the prototype chain, and putting all of those properties on the destination object (making them 'own' properties). That shouldn't happen. This fix modifies the `createAssigner` internal function (currently used by `_.extend`, `_.assign`, and `_.defaults`) so that the function it returns does not iterate over the destination object itself at all. Iterating over the original object seems unnecessary for any of the methods using createAssigner.

A test is included that makes sure that `_.extend` does not commit the aforementioned offense anymore. 