### PR TITLE
wrap constants or objects passed to _.times in _.constant

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -98,6 +98,9 @@
     deepEqual(_.times(0, _.identity), []);
     deepEqual(_.times(-1, _.identity), []);
     deepEqual(_.times(parseFloat('-Infinity'), _.identity), []);
+    
+    // repeats constants
+    deepEqual([1,1,1], _.times(3, 1), 'repeats constants');
   });
 
   test('mixin', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -1320,7 +1320,7 @@
   // Run a function **n** times.
   _.times = function(n, iteratee, context) {
     var accum = Array(Math.max(0, n));
-    iteratee = optimizeCb(iteratee, context, 1);
+    iteratee = optimizeCb(iteratee, _.isFunction(context) ? context : _.constant(context), 1);
     for (var i = 0; i < n; i++) accum[i] = iteratee(i);
     return accum;
   };

--- a/underscore.js
+++ b/underscore.js
@@ -1320,7 +1320,8 @@
   // Run a function **n** times.
   _.times = function(n, iteratee, context) {
     var accum = Array(Math.max(0, n));
-    iteratee = optimizeCb(iteratee, _.isFunction(context) ? context : _.constant(context), 1);
+    if (!_.isFunction(iteratee)) iteratee = _.constant(iteratee);
+    iteratee = optimizeCb(iteratee, context, 1);
     for (var i = 0; i < n; i++) accum[i] = iteratee(i);
     return accum;
   };


### PR DESCRIPTION
so you can do stuff like this:

```js
_.times(3, 'Foo') // ['Foo', 'Foo', 'Foo']
```

which can be useful for indenting text, for instance

```js
_.times(level, '  ').join('') + line
```