### PR TITLE
Update _.range docs to clarify end is exclusive [fix #2002]

### DIFF
--- a/index.html
+++ b/index.html
@@ -1020,7 +1020,7 @@ _.sortedIndex(stooges, {name: 'larry', age: 50}, 'age');
         A function to create flexibly-numbered lists of integers, handy for
         <tt>each</tt> and <tt>map</tt> loops. <b>start</b>, if omitted, defaults
         to <i>0</i>; <b>step</b> defaults to <i>1</i>. Returns a list of integers
-        from <b>start</b> to <b>stop</b>, incremented (or decremented) by <b>step</b>,
+        from <b>start</b> (inclusive) to <b>stop</b> (exclusive), incremented (or decremented) by <b>step</b>,
         exclusive. Note that ranges that <b>stop</b> before they <b>start</b>
         are considered to be zero-length instead of negative — if you'd like a
         negative range, use a negative <b>step</b>.


### PR DESCRIPTION
I have updated the documentation for _.range to clarify explicitly that the end value _.range accepts is exclusive and the start value is inclusive. Attached is a screen shot of the changes:

![screen shot 2015-02-08 at 5 27 13 pm](https://cloud.githubusercontent.com/assets/5640348/6099882/103aa372-afb9-11e4-9b12-841b2bb026df.png)
