### PR TITLE
Update _.map docs to explain guarded iteratees

### DIFF
--- a/index.html
+++ b/index.html
@@ -471,13 +471,15 @@ _.each({one: 1, two: 2, three: 3}, alert);
         through a transformation function (<b>iteratee</b>). The <tt>iteratee</tt>
         is passed three arguments: the <tt>value</tt>, then the <tt>index</tt>
         (or <tt>key</tt>) of the iteration, and finally a reference to the entire
-        <tt>list</tt>.
+        <tt>list</tt>. Selective <b>Underscore</b> functions marked as <tt>guarded</tt> can be used as an <tt>iteratee</tt> to <b>_.map</b>.
       </p>
       <pre>
 _.map([1, 2, 3], function(num){ return num * 3; });
 =&gt; [3, 6, 9]
 _.map({one: 1, two: 2, three: 3}, function(num, key){ return num * 3; });
-=&gt; [3, 6, 9]</pre>
+=&gt; [3, 6, 9]
+_.map([[1, 2], [3, 4]], _.first);
+=&gt; [1, 3]</pre>
 
       <p id="reduce">
         <b class="header">reduce</b><code>_.reduce(list, iteratee, [memo], [context])</code>


### PR DESCRIPTION
I am a regular user of Underscore and only after reading through the Underscore source code did I learn about _.map being able to handle guarded functions as iteratees. If I have been unaware of guarded functions while using Underscore regularly then chances are there are many other engineers who are equally unaware of this great functionality.

Below is a screen shot of the annotated _.map function documentation in index.html. No other changes have been made besides this. 

![screen shot 2015-02-08 at 7 47 20 pm](https://cloud.githubusercontent.com/assets/5640348/6100801/a98894dc-afcb-11e4-8cc8-ff8272402ec5.png)
