### PR TITLE
Added period for consistency in comment block.

### DIFF
--- a/docs/public/stylesheets/normalize.css
+++ b/docs/public/stylesheets/normalize.css
@@ -260,7 +260,7 @@ legend {
 /*
  * 1. Corrects font family not being inherited in all browsers.
  * 2. Corrects font size not being inherited in all browsers.
- * 3. Addresses margins set differently in Firefox 4+, Safari 5, and Chrome
+ * 3. Addresses margins set differently in Firefox 4+, Safari 5, and Chrome.
  */
 
 button,


### PR DESCRIPTION
The preceding sentences at lines 261 and 262 have periods to indicate the end of the statement. The end of the sentence at line 263 doesn't end with a period, as does every other sentence in the document that is commented out.