### PR TITLE
_.max and _.min map arrays correctly [fix #2037]

### DIFF
--- a/test/chaining.js
+++ b/test/chaining.js
@@ -85,4 +85,13 @@
     deepEqual(o.filter(function(i) { return i > 2; }).value(), [3, 4]);
   });
 
+  test('#1562: Engine proxies for chained functions', function() {
+    var wrapped = _(512);
+    strictEqual(wrapped.toJSON(), 512);
+    strictEqual(wrapped.valueOf(), 512);
+    strictEqual(+wrapped, 512);
+    strictEqual(wrapped.toString(), '512');
+    strictEqual('' + wrapped, '512');
+  });
+
 }());

--- a/test/collections.js
+++ b/test/collections.js
@@ -563,6 +563,8 @@
     equal(3, _.max([1, 2, 3, 'test']), 'Finds correct max in array starting with num and containing a NaN');
     equal(3, _.max(['test', 1, 2, 3]), 'Finds correct max in array starting with NaN');
 
+    equal([3, 6], _.map([[1, 2, 3], [4, 5, 6]], _.max), 'Finds correct max in array when mapping through multiple arrays');
+
     var a = {x: -Infinity};
     var b = {x: -Infinity};
     var iterator = function(o){ return o.x; };
@@ -588,6 +590,8 @@
     equal(Infinity, _.min({}), 'Minimum value of an empty object');
     equal(Infinity, _.min([]), 'Minimum value of an empty array');
     equal(_.min({'a': 'a'}), Infinity, 'Minimum value of a non-numeric collection');
+
+    equal([1, 4], _.map([[1, 2, 3], [4, 5, 6]], _.min), 'Finds correct min in array when mapping through multiple arrays');
 
     var now = new Date(9999999999);
     var then = new Date(0);

--- a/test/collections.js
+++ b/test/collections.js
@@ -563,7 +563,7 @@
     equal(3, _.max([1, 2, 3, 'test']), 'Finds correct max in array starting with num and containing a NaN');
     equal(3, _.max(['test', 1, 2, 3]), 'Finds correct max in array starting with NaN');
 
-    equal([3, 6], _.map([[1, 2, 3], [4, 5, 6]], _.max), 'Finds correct max in array when mapping through multiple arrays');
+    deepEqual([3, 6], _.map([[1, 2, 3], [4, 5, 6]], _.max), 'Finds correct max in array when mapping through multiple arrays');
 
     var a = {x: -Infinity};
     var b = {x: -Infinity};
@@ -591,7 +591,7 @@
     equal(Infinity, _.min([]), 'Minimum value of an empty array');
     equal(_.min({'a': 'a'}), Infinity, 'Minimum value of a non-numeric collection');
 
-    equal([1, 4], _.map([[1, 2, 3], [4, 5, 6]], _.min), 'Finds correct min in array when mapping through multiple arrays');
+    deepEqual([1, 4], _.map([[1, 2, 3], [4, 5, 6]], _.min), 'Finds correct min in array when mapping through multiple arrays');
 
     var now = new Date(9999999999);
     var then = new Date(0);

--- a/underscore.js
+++ b/underscore.js
@@ -325,7 +325,7 @@
   _.max = function(obj, iteratee, context) {
     var result = -Infinity, lastComputed = -Infinity,
         value, computed;
-    if (iteratee == null && obj != null) {
+    if ((iteratee == null || typeof iteratee == 'number') && obj != null) {
       obj = isArrayLike(obj) ? obj : _.values(obj);
       for (var i = 0, length = obj.length; i < length; i++) {
         value = obj[i];
@@ -350,7 +350,7 @@
   _.min = function(obj, iteratee, context) {
     var result = Infinity, lastComputed = Infinity,
         value, computed;
-    if (iteratee == null && obj != null) {
+    if ((iteratee == null || typeof iteratee == 'number') && obj != null) {
       obj = isArrayLike(obj) ? obj : _.values(obj);
       for (var i = 0, length = obj.length; i < length; i++) {
         value = obj[i];

--- a/underscore.js
+++ b/underscore.js
@@ -1518,6 +1518,14 @@
     return this._wrapped;
   };
 
+  // Provide unwrapping proxy for some methods used in engine operations
+  // such as arithmetic and JSON stringification.
+  _.prototype.valueOf = _.prototype.toJSON = _.prototype.value;
+  
+  _.prototype.toString = function() {
+    return '' + this._wrapped;
+  };
+
   // AMD registration happens at the end for compatibility with AMD loaders
   // that may not enforce next-turn semantics on modules. Even though general
   // practice for AMD registration is to be anonymous, underscore registers


### PR DESCRIPTION
Currently, mapping over a nested array and using _.max or _.min produces unexpected results. 
![infinity](https://cloud.githubusercontent.com/assets/5640348/6101277/3c2170d4-afd6-11e4-8b25-cd6e6a0d4276.png)

This occurs because when _.max or _.min is passed into _.map, the internal function optimizeCb attempts to account for the fact that _.max and _.min have multiple arguments by trying to pass an index value into them. This creates a misalignment between the parameters being passed into _.max and _.min and the parameters they are actually expecting. _.max and _.min expect an iteratee to be passed in as a second argument, but instead _.map is passing an index. 

The result of this arguments mismatch makes _.min and _.max fail the following conditional which checks to see if an iteratee was passed.
![screen shot 2015-02-08 at 9 10 57 pm](https://cloud.githubusercontent.com/assets/5640348/6101333/3a8ada48-afd7-11e4-90e1-253685872050.png)

I have corrected the above conditional by including a following check to ignore the iteratee if it is a number:
![works](https://cloud.githubusercontent.com/assets/5640348/6101347/90681da4-afd7-11e4-9fb3-5a4964c3f668.png)

This additional conditional makes _.min and _.max produce the expected results with no side effects to their normal behavior. Nothing else has been changed and tests have been added to verify the code I have added is indeed valid and does not disrupt anything.
