### PR TITLE
Add "Guarded" on _.map iteratee's [fix #2036]

### DIFF
--- a/index.html
+++ b/index.html
@@ -471,7 +471,8 @@ _.each({one: 1, two: 2, three: 3}, alert);
         through a transformation function (<b>iteratee</b>). The <tt>iteratee</tt>
         is passed three arguments: the <tt>value</tt>, then the <tt>index</tt>
         (or <tt>key</tt>) of the iteration, and finally a reference to the entire
-        <tt>list</tt>. Selective <b>Underscore</b> functions marked as <tt>guarded</tt> can be used as an <tt>iteratee</tt> to <b>_.map</b>.
+        <tt>list</tt>. Selective <b>Underscore</b> functions marked as <tt>guarded</tt>
+        can be used as an <tt>iteratee</tt> to <b>_.map</b>.
       </p>
       <pre>
 _.map([1, 2, 3], function(num){ return num * 3; });

--- a/index.html
+++ b/index.html
@@ -471,13 +471,15 @@ _.each({one: 1, two: 2, three: 3}, alert);
         through a transformation function (<b>iteratee</b>). The <tt>iteratee</tt>
         is passed three arguments: the <tt>value</tt>, then the <tt>index</tt>
         (or <tt>key</tt>) of the iteration, and finally a reference to the entire
-        <tt>list</tt>.
+        <tt>list</tt>. Selective <b>Underscore</b> functions marked as <tt>guarded</tt> can be used as an <tt>iteratee</tt> to <b>_.map</b>.
       </p>
       <pre>
 _.map([1, 2, 3], function(num){ return num * 3; });
 =&gt; [3, 6, 9]
 _.map({one: 1, two: 2, three: 3}, function(num, key){ return num * 3; });
-=&gt; [3, 6, 9]</pre>
+=&gt; [3, 6, 9]
+_.map([[1, 2], [3, 4]], _.first);
+=&gt; [1, 3]</pre>
 
       <p id="reduce">
         <b class="header">reduce</b><code>_.reduce(list, iteratee, [memo], [context])</code>

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
       font-size: 16px;
       line-height: 30px;
     }
-    span.alias {
+    span.alias, span.guard {
       font-size: 14px;
       font-style: italic;
       margin-left: 20px;
@@ -753,6 +753,7 @@ _.shuffle([1, 2, 3, 4, 5, 6]);
 
       <p id="sample">
         <b class="header">sample</b><code>_.sample(list, [n])</code>
+        <span class="guard"><b>Guarded</b></span>
         <br />
         Produce a random sample from the <b>list</b>. Pass a number to
         return <b>n</b> random elements from the list. Otherwise a single random
@@ -810,6 +811,7 @@ _.partition([0, 1, 2, 3, 4, 5], isOdd);
       <p id="first">
         <b class="header">first</b><code>_.first(array, [n])</code>
         <span class="alias">Alias: <b>head</b>, <b>take</b></span>
+        <span class="guard"><b>Guarded</b></span>
         <br />
         Returns the first element of an <b>array</b>. Passing <b>n</b> will
         return the first <b>n</b> elements of the array.
@@ -821,6 +823,7 @@ _.first([5, 4, 3, 2, 1]);
 
       <p id="initial">
         <b class="header">initial</b><code>_.initial(array, [n])</code>
+        <span class="guard"><b>Guarded</b></span>
         <br />
         Returns everything but the last entry of the array. Especially useful on
         the arguments object. Pass <b>n</b> to exclude the last <b>n</b> elements
@@ -833,6 +836,7 @@ _.initial([5, 4, 3, 2, 1]);
 
       <p id="last">
         <b class="header">last</b><code>_.last(array, [n])</code>
+        <span class="guard"><b>Guarded</b></span>
         <br />
         Returns the last element of an <b>array</b>. Passing <b>n</b> will return
         the last <b>n</b> elements of the array.
@@ -845,6 +849,7 @@ _.last([5, 4, 3, 2, 1]);
       <p id="rest">
         <b class="header">rest</b><code>_.rest(array, [index])</code>
         <span class="alias">Alias: <b>tail, drop</b></span>
+        <span class="guard"><b>Guarded</b></span>
         <br />
         Returns the <b>rest</b> of the elements in an array. Pass an <b>index</b>
         to return the values of the array from that index onward.


### PR DESCRIPTION
Certain underscore methods can be used as iteratee's to _.map. These
methods can be referred to as 'Guarded' methods. In pull request #2036 I
have requested that this functionality be included in the documentation
for _.map on index.html. I am following up with that pull request with
this one, which includes documentation that states exactly which methods
are guarded methods.

I am attempting to inform other Underscore developers of this great
functionality by marking appropriate functions as "Guarded" within
index.html. This "Guarded" statement uses the same CSS stylings as
span.alias.

Nothing has been changed besides the appropriate documentation shifts
described above. Screenshots will be included in pull request.

![screen shot 2015-02-09 at 11 10 47 am](https://cloud.githubusercontent.com/assets/5640348/6113733/4918811a-b04e-11e4-8f9f-9f5228a10aac.png)
![screen shot 2015-02-09 at 11 11 23 am](https://cloud.githubusercontent.com/assets/5640348/6113734/491e48f2-b04e-11e4-845f-0a7a9b100a88.png)
![screen shot 2015-02-09 at 11 11 34 am](https://cloud.githubusercontent.com/assets/5640348/6113735/49249572-b04e-11e4-850e-8cb0b7c6f227.png)
