### PR TITLE
_.matches only validates own properties[fix #1986]

### DIFF
--- a/index.html
+++ b/index.html
@@ -471,13 +471,15 @@ _.each({one: 1, two: 2, three: 3}, alert);
         through a transformation function (<b>iteratee</b>). The <tt>iteratee</tt>
         is passed three arguments: the <tt>value</tt>, then the <tt>index</tt>
         (or <tt>key</tt>) of the iteration, and finally a reference to the entire
-        <tt>list</tt>.
+        <tt>list</tt>. Selective <b>Underscore</b> functions marked as <tt>guarded</tt> can be used as an <tt>iteratee</tt> to <b>_.map</b>.
       </p>
       <pre>
 _.map([1, 2, 3], function(num){ return num * 3; });
 =&gt; [3, 6, 9]
 _.map({one: 1, two: 2, three: 3}, function(num, key){ return num * 3; });
-=&gt; [3, 6, 9]</pre>
+=&gt; [3, 6, 9]
+_.map([[1, 2], [3, 4]], _.first);
+=&gt; [1, 3]</pre>
 
       <p id="reduce">
         <b class="header">reduce</b><code>_.reduce(list, iteratee, [memo], [context])</code>

--- a/test/objects.js
+++ b/test/objects.js
@@ -753,6 +753,11 @@
     var moe = {name: 'Moe Howard', hair: true};
     var curly = {name: 'Curly Howard', hair: false};
     var stooges = [moe, curly];
+    var car = {speed: 50};
+    var toyota = Object.create(car);
+
+    equal(_.matches({speed: 50})(toyota), false, 'should only match own properties');
+    equal(_.matches({speed: 50})(car), true, 'should only match own properties');
 
     equal(_.matches({hair: true})(moe), true, 'Returns a boolean');
     equal(_.matches({hair: true})(curly), false, 'Returns a boolean');

--- a/underscore.js
+++ b/underscore.js
@@ -1297,7 +1297,7 @@
       obj = new Object(obj);
       for (var i = 0; i < length; i++) {
         var pair = pairs[i], key = pair[0];
-        if (pair[1] !== obj[key] || !(key in obj)) return false;
+        if (pair[1] !== obj[key] || !(obj.hasOwnProperty(key))) return false;
       }
       return true;
     };


### PR DESCRIPTION
I have changed `_.matches` to only match properties which are declared
directly on the object being passed to the predicate function generated
by `_.matches`.

I have accomplished this by testing the property on the object passed in
using the method `hasOwnProperty` method instead of the `in` operator.

I have included specs to demonstrate how this functionality works and
when it should return `true` or `false`.
