### PR TITLE
_.intersection should work with if the first arg is null.

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -204,11 +204,13 @@
     result = _.intersection([2, 4, 3, 1], [1, 2, 3]);
     deepEqual(result, [2, 3, 1], 'preserves order of first array');
     result = _.intersection(null, [1, 2, 3]);
-    equal(Object.prototype.toString.call(result), '[object Array]', 'returns an empty array when passed null as first argument');
-    equal(result.length, 0, 'returns an empty array when passed null as first argument');
-    result = _.intersection([1, 2, 3], null);
-    equal(Object.prototype.toString.call(result), '[object Array]', 'returns an empty array when passed null as argument beyond the first');
-    equal(result.length, 0, 'returns an empty array when passed null as argument beyond the first');
+    deepEqual(result, [1, 2, 3], 'ignores a null value when it is the first item passed');
+    result = _.intersection([1, 2], null, [2, 3])
+    deepEqual(result, [2], 'ignores null values when they are passed as arguments beyond the first');
+    result = _.intersection([1, 2], [2, 3], null)
+    deepEqual(result, [2], 'ignores a null value when it is passed as the last argument');
+    result = _.intersection(null, null);
+    deepEqual(result, [], 'only passing null values returns an empty array');
   });
 
   test('union', function() {

--- a/test/arrays.js
+++ b/test/arrays.js
@@ -213,6 +213,12 @@
     deepEqual(result, [2], 'ignores a null value when it is passed as the last argument');
     result = _.intersection(null, null);
     deepEqual(result, [], 'only passing null values returns an empty array');
+    result = _.intersection({}, [1, 2], [2, 3]);
+    deepEqual(result, [2], 'ignores an object when it is the first item passed');
+    result = _.intersection({}, [1, 2], {}, [2, 3]);
+    deepEqual(result, [2], 'ignores objects when they are passed as the first argument, and arguments beyond');
+    result = _.intersection('', [1, 2], '', [2, 3]);
+    deepEqual(result, [2], 'ignores strings when they are passed as the first argument, and arguments beyond');
   });
 
   test('union', function() {

--- a/test/arrays.js
+++ b/test/arrays.js
@@ -205,9 +205,11 @@
     deepEqual(result, [2, 3, 1], 'preserves order of first array');
     result = _.intersection(null, [1, 2, 3]);
     deepEqual(result, [1, 2, 3], 'ignores a null value when it is the first item passed');
-    result = _.intersection([1, 2], null, [2, 3])
+    result = _.intersection([1, 2], null, [2, 3]);
     deepEqual(result, [2], 'ignores null values when they are passed as arguments beyond the first');
-    result = _.intersection([1, 2], [2, 3], null)
+    result = _.intersection(null, [1, 2], null, [2, 3]);
+    deepEqual(result, [2], 'ignores null values when they are passed as the first argument, and as arguments beyond');
+    result = _.intersection([1, 2], [2, 3], null);
     deepEqual(result, [2], 'ignores a null value when it is passed as the last argument');
     result = _.intersection(null, null);
     deepEqual(result, [], 'only passing null values returns an empty array');

--- a/underscore.js
+++ b/underscore.js
@@ -571,19 +571,19 @@
 
   // Produce an array that contains every item shared between all the
   // passed-in arrays.
-  _.intersection = function(array) {
-    if (array == null) {
-      if (arguments.length === 0) return [];
-      return _.intersection.apply(arguments[1], Array.prototype.slice.call(arguments, 1));
-    }
+  _.intersection = function() {
+    var array = _.filter(arguments, function(value) {
+      return isArrayLike(value) && (_.isArray(value) || _.isArguments(value));
+    });
+    if (array.length === 0) return [];
+    var firstItem = array.shift();
     var result = [];
-    var argsLength = arguments.length;
-    for (var i = 0, length = array.length; i < length; i++) {
-      var item = array[i];
+    var argsLength = array.length;
+    for (var i = 0, length = firstItem.length; i < length; i++) {
+      var item = firstItem[i];
       if (_.contains(result, item)) continue;
-      for (var j = 1; j < argsLength; j++) {
-        if (arguments[j] == null) continue;
-        if (!_.contains(arguments[j], item)) break;
+      for (var j = 0; j < argsLength; j++) {
+        if (!_.contains(array[j], item)) break;
       }
       if (j === argsLength) result.push(item);
     }

--- a/underscore.js
+++ b/underscore.js
@@ -572,13 +572,17 @@
   // Produce an array that contains every item shared between all the
   // passed-in arrays.
   _.intersection = function(array) {
-    if (array == null) return [];
+    if (array == null) {
+      if (arguments.length === 0) return [];
+      return _.intersection.apply(arguments[1], Array.prototype.slice.call(arguments, 1));
+    }
     var result = [];
     var argsLength = arguments.length;
     for (var i = 0, length = array.length; i < length; i++) {
       var item = array[i];
       if (_.contains(result, item)) continue;
       for (var j = 1; j < argsLength; j++) {
+        if (arguments[j] == null) continue;
         if (!_.contains(arguments[j], item)) break;
       }
       if (j === argsLength) result.push(item);


### PR DESCRIPTION
Patch for issue #1583 - _.intersection should work with arrays regardless of if the first arg is an array.

