### PR TITLE
replaced paragraph symbols with section symbols

### DIFF
--- a/docs/docco.css
+++ b/docs/docco.css
@@ -210,7 +210,7 @@ ul.sections > li > div {
 
 /*---------------------- Low resolutions (> 320px) ---------------------*/
 @media only screen and (min-width: 320px) {
-  .pilwrap { display: none; }
+  .sswrap { display: none; }
 
   ul.sections > li > div {
     display: block;
@@ -327,12 +327,12 @@ ul.sections > li > div {
     box-shadow: none;
   }
 
-  .pilwrap {
+  .sswrap {
     position: relative;
     display: inline;
   }
 
-  .pilcrow {
+  .ss {
     font: 12px Arial;
     text-decoration: none;
     color: #454545;
@@ -342,14 +342,14 @@ ul.sections > li > div {
     opacity: 0;
     -webkit-transition: opacity 0.2s linear;
   }
-    .for-h1 .pilcrow {
+    .for-h1 .ss {
       top: 47px;
     }
-    .for-h2 .pilcrow, .for-h3 .pilcrow, .for-h4 .pilcrow {
+    .for-h2 .ss, .for-h3 .ss, .for-h4 .ss {
       top: 35px;
     }
 
-  ul.sections > li > div.annotation:hover .pilcrow {
+  ul.sections > li > div.annotation:hover .ss {
     opacity: 1;
   }
 }

--- a/docs/underscore.html
+++ b/docs/underscore.html
@@ -24,8 +24,8 @@
         <li id="section-1">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-1">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-1">&#167;</a>
               </div>
               <pre><code>Underscore.js <span class="hljs-number">1.7</span><span class="hljs-number">.0</span>
 http:<span class="hljs-comment">//underscorejs.org</span>
@@ -43,8 +43,8 @@ Underscore may be freely distributed under the MIT license.
         <li id="section-2">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-2">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-2">&#167;</a>
               </div>
               <h2 id="baseline-setup">Baseline setup</h2>
 
@@ -56,8 +56,8 @@ Underscore may be freely distributed under the MIT license.
         <li id="section-3">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-3">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-3">&#167;</a>
               </div>
               
             </div>
@@ -68,8 +68,8 @@ Underscore may be freely distributed under the MIT license.
         <li id="section-4">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-4">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-4">&#167;</a>
               </div>
               <p>Establish the root object, <code>window</code> in the browser, or <code>exports</code> on the server.</p>
 
@@ -83,8 +83,8 @@ Underscore may be freely distributed under the MIT license.
         <li id="section-5">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-5">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-5">&#167;</a>
               </div>
               <p>Save the previous value of the <code>_</code> variable.</p>
 
@@ -98,8 +98,8 @@ Underscore may be freely distributed under the MIT license.
         <li id="section-6">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-6">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-6">&#167;</a>
               </div>
               <p>Save bytes in the minified (but not gzipped) version:</p>
 
@@ -113,8 +113,8 @@ Underscore may be freely distributed under the MIT license.
         <li id="section-7">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-7">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-7">&#167;</a>
               </div>
               <p>Create quick reference variables for speed access to core prototypes.</p>
 
@@ -133,8 +133,8 @@ Underscore may be freely distributed under the MIT license.
         <li id="section-8">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-8">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-8">&#167;</a>
               </div>
               <p>All <strong>ECMAScript 5</strong> native function implementations that we hope to use
 are declared here.</p>
@@ -152,8 +152,8 @@ are declared here.</p>
         <li id="section-9">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-9">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-9">&#167;</a>
               </div>
               <p>Create a safe reference to the Underscore object for use below.</p>
 
@@ -171,8 +171,8 @@ are declared here.</p>
         <li id="section-10">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-10">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-10">&#167;</a>
               </div>
               <p>Export the Underscore object for <strong>Node.js</strong>, with
 backwards-compatibility for the old <code>require()</code> API. If we’re in
@@ -195,8 +195,8 @@ the browser, add <code>_</code> as a global object.</p>
         <li id="section-11">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-11">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-11">&#167;</a>
               </div>
               <p>Current version.</p>
 
@@ -210,8 +210,8 @@ the browser, add <code>_</code> as a global object.</p>
         <li id="section-12">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-12">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-12">&#167;</a>
               </div>
               <p>Internal function that returns an efficient (for current engines) version
 of the passed-in callback, to be repeatedly applied in other Underscore
@@ -246,8 +246,8 @@ functions.</p>
         <li id="section-13">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-13">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-13">&#167;</a>
               </div>
               <p>A mostly-internal function to generate callbacks that can be applied
 to each element in a collection, returning the desired result — either
@@ -268,8 +268,8 @@ identity, an arbitrary callback, a property matcher, or a property accessor.</p>
         <li id="section-14">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-14">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-14">&#167;</a>
               </div>
               <h2 id="collection-functions">Collection Functions</h2>
 
@@ -281,8 +281,8 @@ identity, an arbitrary callback, a property matcher, or a property accessor.</p>
         <li id="section-15">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-15">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-15">&#167;</a>
               </div>
               
             </div>
@@ -293,8 +293,8 @@ identity, an arbitrary callback, a property matcher, or a property accessor.</p>
         <li id="section-16">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-16">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-16">&#167;</a>
               </div>
               <p>The cornerstone, an <code>each</code> implementation, aka <code>forEach</code>.
 Handles raw objects in addition to array-likes. Treats all
@@ -325,8 +325,8 @@ sparse array-likes as if they were dense.</p>
         <li id="section-17">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-17">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-17">&#167;</a>
               </div>
               <p>Return the results of applying the iteratee to each element.</p>
 
@@ -354,8 +354,8 @@ sparse array-likes as if they were dense.</p>
         <li id="section-18">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-18">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-18">&#167;</a>
               </div>
               <p><strong>Reduce</strong> builds up a single result from a list of values, aka <code>inject</code>,
 or <code>foldl</code>.</p>
@@ -385,8 +385,8 @@ or <code>foldl</code>.</p>
         <li id="section-19">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-19">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-19">&#167;</a>
               </div>
               <p>The right-associative version of reduce, also known as <code>foldr</code>.</p>
 
@@ -415,8 +415,8 @@ or <code>foldl</code>.</p>
         <li id="section-20">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-20">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-20">&#167;</a>
               </div>
               <p>Return the first value which passes a truth test. Aliased as <code>detect</code>.</p>
 
@@ -440,8 +440,8 @@ or <code>foldl</code>.</p>
         <li id="section-21">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-21">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-21">&#167;</a>
               </div>
               <p>Return all the elements that pass a truth test.
 Aliased as <code>select</code>.</p>
@@ -464,8 +464,8 @@ Aliased as <code>select</code>.</p>
         <li id="section-22">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-22">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-22">&#167;</a>
               </div>
               <p>Return all the elements for which a truth test fails.</p>
 
@@ -481,8 +481,8 @@ Aliased as <code>select</code>.</p>
         <li id="section-23">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-23">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-23">&#167;</a>
               </div>
               <p>Determine whether all of the elements match a truth test.
 Aliased as <code>all</code>.</p>
@@ -508,8 +508,8 @@ Aliased as <code>all</code>.</p>
         <li id="section-24">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-24">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-24">&#167;</a>
               </div>
               <p>Determine if at least one element in the object matches a truth test.
 Aliased as <code>any</code>.</p>
@@ -535,8 +535,8 @@ Aliased as <code>any</code>.</p>
         <li id="section-25">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-25">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-25">&#167;</a>
               </div>
               <p>Determine if the array or object contains a given value (using <code>===</code>).
 Aliased as <code>include</code>.</p>
@@ -555,8 +555,8 @@ Aliased as <code>include</code>.</p>
         <li id="section-26">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-26">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-26">&#167;</a>
               </div>
               <p>Invoke a method (with arguments) on every item in a collection.</p>
 
@@ -576,8 +576,8 @@ Aliased as <code>include</code>.</p>
         <li id="section-27">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-27">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-27">&#167;</a>
               </div>
               <p>Convenience version of a common use case of <code>map</code>: fetching a property.</p>
 
@@ -593,8 +593,8 @@ Aliased as <code>include</code>.</p>
         <li id="section-28">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-28">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-28">&#167;</a>
               </div>
               <p>Convenience version of a common use case of <code>filter</code>: selecting only objects
 containing specific <code>key:value</code> pairs.</p>
@@ -611,8 +611,8 @@ containing specific <code>key:value</code> pairs.</p>
         <li id="section-29">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-29">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-29">&#167;</a>
               </div>
               <p>Convenience version of a common use case of <code>find</code>: getting the first object
 containing specific <code>key:value</code> pairs.</p>
@@ -629,8 +629,8 @@ containing specific <code>key:value</code> pairs.</p>
         <li id="section-30">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-30">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-30">&#167;</a>
               </div>
               <p>Return the maximum element (or element-based computation).</p>
 
@@ -666,8 +666,8 @@ containing specific <code>key:value</code> pairs.</p>
         <li id="section-31">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-31">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-31">&#167;</a>
               </div>
               <p>Return the minimum element (or element-based computation).</p>
 
@@ -703,8 +703,8 @@ containing specific <code>key:value</code> pairs.</p>
         <li id="section-32">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-32">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-32">&#167;</a>
               </div>
               <p>Shuffle a collection, using the modern version of the
 <a href="http://en.wikipedia.org/wiki/Fisher–Yates_shuffle">Fisher-Yates shuffle</a>.</p>
@@ -729,8 +729,8 @@ containing specific <code>key:value</code> pairs.</p>
         <li id="section-33">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-33">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-33">&#167;</a>
               </div>
               <p>Sample <strong>n</strong> random values from a collection.
 If <strong>n</strong> is not specified, returns a single random element.
@@ -752,8 +752,8 @@ The internal <code>guard</code> argument allows it to work with <code>map</code>
         <li id="section-34">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-34">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-34">&#167;</a>
               </div>
               <p>Sort the object’s values by a criterion produced by an iteratee.</p>
 
@@ -784,8 +784,8 @@ The internal <code>guard</code> argument allows it to work with <code>map</code>
         <li id="section-35">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-35">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-35">&#167;</a>
               </div>
               <p>An internal function used for aggregate “group by” operations.</p>
 
@@ -809,8 +809,8 @@ The internal <code>guard</code> argument allows it to work with <code>map</code>
         <li id="section-36">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-36">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-36">&#167;</a>
               </div>
               <p>Groups the object’s values by a criterion. Pass either a string attribute
 to group by, or a function that returns the criterion.</p>
@@ -827,8 +827,8 @@ to group by, or a function that returns the criterion.</p>
         <li id="section-37">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-37">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-37">&#167;</a>
               </div>
               <p>Indexes the object’s values by a criterion, similar to <code>groupBy</code>, but for
 when you know that your index values will be unique.</p>
@@ -845,8 +845,8 @@ when you know that your index values will be unique.</p>
         <li id="section-38">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-38">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-38">&#167;</a>
               </div>
               <p>Counts instances of an object that group by a certain criterion. Pass
 either a string attribute to count by, or a function that returns the
@@ -864,8 +864,8 @@ criterion.</p>
         <li id="section-39">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-39">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-39">&#167;</a>
               </div>
               <p>Use a comparator function to figure out the smallest index at which
 an object should be inserted so as to maintain order. Uses binary search.</p>
@@ -889,8 +889,8 @@ an object should be inserted so as to maintain order. Uses binary search.</p>
         <li id="section-40">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-40">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-40">&#167;</a>
               </div>
               <p>Safely create a real, live array from anything iterable.</p>
 
@@ -909,8 +909,8 @@ an object should be inserted so as to maintain order. Uses binary search.</p>
         <li id="section-41">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-41">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-41">&#167;</a>
               </div>
               <p>Return the number of elements in an object.</p>
 
@@ -927,8 +927,8 @@ an object should be inserted so as to maintain order. Uses binary search.</p>
         <li id="section-42">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-42">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-42">&#167;</a>
               </div>
               <p>Split a collection into two arrays: one whose elements all satisfy the given
 predicate, and one whose elements all do not satisfy the predicate.</p>
@@ -950,8 +950,8 @@ predicate, and one whose elements all do not satisfy the predicate.</p>
         <li id="section-43">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-43">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-43">&#167;</a>
               </div>
               <h2 id="array-functions">Array Functions</h2>
 
@@ -963,8 +963,8 @@ predicate, and one whose elements all do not satisfy the predicate.</p>
         <li id="section-44">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-44">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-44">&#167;</a>
               </div>
               
             </div>
@@ -975,8 +975,8 @@ predicate, and one whose elements all do not satisfy the predicate.</p>
         <li id="section-45">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-45">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-45">&#167;</a>
               </div>
               <p>Get the first element of an array. Passing <strong>n</strong> will return the first N
 values in the array. Aliased as <code>head</code> and <code>take</code>. The <strong>guard</strong> check
@@ -997,8 +997,8 @@ allows it to work with <code>_.map</code>.</p>
         <li id="section-46">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-46">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-46">&#167;</a>
               </div>
               <p>Returns everything but the last entry of the array. Especially useful on
 the arguments object. Passing <strong>n</strong> will return all the values in
@@ -1017,8 +1017,8 @@ the array, excluding the last N. The <strong>guard</strong> check allows it to w
         <li id="section-47">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-47">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-47">&#167;</a>
               </div>
               <p>Get the last element of an array. Passing <strong>n</strong> will return the last N
 values in the array. The <strong>guard</strong> check allows it to work with <code>_.map</code>.</p>
@@ -1037,8 +1037,8 @@ values in the array. The <strong>guard</strong> check allows it to work with <co
         <li id="section-48">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-48">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-48">&#167;</a>
               </div>
               <p>Returns everything but the first entry of the array. Aliased as <code>tail</code> and <code>drop</code>.
 Especially useful on the arguments object. Passing an <strong>n</strong> will return
@@ -1057,8 +1057,8 @@ check allows it to work with <code>_.map</code>.</p>
         <li id="section-49">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-49">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-49">&#167;</a>
               </div>
               <p>Trim out all falsy values from an array.</p>
 
@@ -1074,8 +1074,8 @@ check allows it to work with <code>_.map</code>.</p>
         <li id="section-50">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-50">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-50">&#167;</a>
               </div>
               <p>Internal implementation of a recursive <code>flatten</code> function.</p>
 
@@ -1104,8 +1104,8 @@ check allows it to work with <code>_.map</code>.</p>
         <li id="section-51">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-51">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-51">&#167;</a>
               </div>
               <p>Flatten out an array, either recursively (by default), or just one level.</p>
 
@@ -1121,8 +1121,8 @@ check allows it to work with <code>_.map</code>.</p>
         <li id="section-52">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-52">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-52">&#167;</a>
               </div>
               <p>Return a version of the array that does not contain the specified value(s).</p>
 
@@ -1138,8 +1138,8 @@ check allows it to work with <code>_.map</code>.</p>
         <li id="section-53">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-53">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-53">&#167;</a>
               </div>
               <p>Produce a duplicate-free version of the array. If the array has already
 been sorted, you have the option of using a faster algorithm.
@@ -1181,8 +1181,8 @@ Aliased as <code>unique</code>.</p>
         <li id="section-54">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-54">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-54">&#167;</a>
               </div>
               <p>Produce an array that contains the union: each distinct element from all of
 the passed-in arrays.</p>
@@ -1199,8 +1199,8 @@ the passed-in arrays.</p>
         <li id="section-55">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-55">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-55">&#167;</a>
               </div>
               <p>Produce an array that contains every item shared between all the
 passed-in arrays.</p>
@@ -1228,8 +1228,8 @@ passed-in arrays.</p>
         <li id="section-56">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-56">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-56">&#167;</a>
               </div>
               <p>Take the difference between one array and a number of other arrays.
 Only the elements present in just the first array will remain.</p>
@@ -1249,8 +1249,8 @@ Only the elements present in just the first array will remain.</p>
         <li id="section-57">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-57">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-57">&#167;</a>
               </div>
               <p>Zip together multiple lists into a single array — elements that share
 an index go together.</p>
@@ -1273,8 +1273,8 @@ an index go together.</p>
         <li id="section-58">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-58">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-58">&#167;</a>
               </div>
               <p>Converts lists into objects. Pass either a single array of <code>[key, value]</code>
 pairs, or two parallel arrays of the same length — one of keys, and one of
@@ -1301,8 +1301,8 @@ the corresponding values.</p>
         <li id="section-59">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-59">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-59">&#167;</a>
               </div>
               <p>Return the position of the first occurrence of an item in an array,
 or -1 if the item is not included in the array.
@@ -1342,8 +1342,8 @@ for <strong>isSorted</strong> to use binary search.</p>
         <li id="section-60">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-60">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-60">&#167;</a>
               </div>
               <p>Generate an integer Array containing an arithmetic progression. A port of
 the native Python <code>range()</code> function. See
@@ -1374,8 +1374,8 @@ the native Python <code>range()</code> function. See
         <li id="section-61">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-61">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-61">&#167;</a>
               </div>
               <h2 id="function-ahem-functions">Function (ahem) Functions</h2>
 
@@ -1387,8 +1387,8 @@ the native Python <code>range()</code> function. See
         <li id="section-62">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-62">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-62">&#167;</a>
               </div>
               
             </div>
@@ -1399,8 +1399,8 @@ the native Python <code>range()</code> function. See
         <li id="section-63">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-63">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-63">&#167;</a>
               </div>
               <p>Reusable constructor function for prototype setting.</p>
 
@@ -1414,8 +1414,8 @@ the native Python <code>range()</code> function. See
         <li id="section-64">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-64">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-64">&#167;</a>
               </div>
               <p>Create a function bound to a given object (assigning <code>this</code>, and arguments,
 optionally). Delegates to <strong>ECMAScript 5</strong>‘s native <code>Function.bind</code> if
@@ -1446,8 +1446,8 @@ available.</p>
         <li id="section-65">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-65">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-65">&#167;</a>
               </div>
               <p>Partially apply a function by creating a version that has had some of its
 arguments pre-filled, without changing its dynamic <code>this</code> context. _ acts
@@ -1474,8 +1474,8 @@ as a placeholder, allowing any combination of arguments to be pre-filled.</p>
         <li id="section-66">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-66">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-66">&#167;</a>
               </div>
               <p>Bind a number of an object’s methods to that object. Remaining arguments
 are the method names to be bound. Useful for ensuring that all callbacks
@@ -1499,8 +1499,8 @@ defined on an object belong to it.</p>
         <li id="section-67">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-67">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-67">&#167;</a>
               </div>
               <p>Memoize an expensive function by storing its results.</p>
 
@@ -1523,8 +1523,8 @@ defined on an object belong to it.</p>
         <li id="section-68">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-68">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-68">&#167;</a>
               </div>
               <p>Delays a function for the given number of milliseconds, and then calls
 it with the arguments supplied.</p>
@@ -1544,8 +1544,8 @@ it with the arguments supplied.</p>
         <li id="section-69">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-69">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-69">&#167;</a>
               </div>
               <p>Defers a function, scheduling it to run after the current call stack has
 cleared.</p>
@@ -1562,8 +1562,8 @@ cleared.</p>
         <li id="section-70">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-70">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-70">&#167;</a>
               </div>
               <p>Returns a function, that, when invoked, will only be triggered at most once
 during a given window of time. Normally, the throttled function will run
@@ -1609,8 +1609,8 @@ but if you’d like to disable the execution on the leading edge, pass
         <li id="section-71">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-71">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-71">&#167;</a>
               </div>
               <p>Returns a function, that, as long as it continues to be invoked, will not
 be triggered. The function will be called after it stops being called for
@@ -1657,8 +1657,8 @@ leading edge, instead of the trailing.</p>
         <li id="section-72">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-72">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-72">&#167;</a>
               </div>
               <p>Returns the first function passed as an argument to the second,
 allowing you to adjust arguments, run code before and after, and
@@ -1676,8 +1676,8 @@ conditionally execute the original function.</p>
         <li id="section-73">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-73">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-73">&#167;</a>
               </div>
               <p>Returns a negated version of the passed-in predicate.</p>
 
@@ -1695,8 +1695,8 @@ conditionally execute the original function.</p>
         <li id="section-74">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-74">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-74">&#167;</a>
               </div>
               <p>Returns a function that is the composition of a list of functions, each
 consuming the return value of the function that follows.</p>
@@ -1720,8 +1720,8 @@ consuming the return value of the function that follows.</p>
         <li id="section-75">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-75">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-75">&#167;</a>
               </div>
               <p>Returns a function that will only be executed after being called N times.</p>
 
@@ -1741,8 +1741,8 @@ consuming the return value of the function that follows.</p>
         <li id="section-76">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-76">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-76">&#167;</a>
               </div>
               <p>Returns a function that will only be executed before being called N times.</p>
 
@@ -1766,8 +1766,8 @@ consuming the return value of the function that follows.</p>
         <li id="section-77">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-77">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-77">&#167;</a>
               </div>
               <p>Returns a function that will be executed at most one time, no matter how
 often you call it. Useful for lazy initialization.</p>
@@ -1782,8 +1782,8 @@ often you call it. Useful for lazy initialization.</p>
         <li id="section-78">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-78">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-78">&#167;</a>
               </div>
               <h2 id="object-functions">Object Functions</h2>
 
@@ -1795,8 +1795,8 @@ often you call it. Useful for lazy initialization.</p>
         <li id="section-79">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-79">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-79">&#167;</a>
               </div>
               
             </div>
@@ -1807,8 +1807,8 @@ often you call it. Useful for lazy initialization.</p>
         <li id="section-80">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-80">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-80">&#167;</a>
               </div>
               <p>Retrieve the names of an object’s properties.
 Delegates to <strong>ECMAScript 5</strong>‘s native <code>Object.keys</code></p>
@@ -1829,8 +1829,8 @@ Delegates to <strong>ECMAScript 5</strong>‘s native <code>Object.keys</code></
         <li id="section-81">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-81">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-81">&#167;</a>
               </div>
               <p>Retrieve the values of an object’s properties.</p>
 
@@ -1852,8 +1852,8 @@ Delegates to <strong>ECMAScript 5</strong>‘s native <code>Object.keys</code></
         <li id="section-82">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-82">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-82">&#167;</a>
               </div>
               <p>Convert an object into a list of <code>[key, value]</code> pairs.</p>
 
@@ -1875,8 +1875,8 @@ Delegates to <strong>ECMAScript 5</strong>‘s native <code>Object.keys</code></
         <li id="section-83">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-83">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-83">&#167;</a>
               </div>
               <p>Invert the keys and values of an object. The values must be serializable.</p>
 
@@ -1897,8 +1897,8 @@ Delegates to <strong>ECMAScript 5</strong>‘s native <code>Object.keys</code></
         <li id="section-84">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-84">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-84">&#167;</a>
               </div>
               <p>Return a sorted list of the function names available on the object.
 Aliased as <code>methods</code></p>
@@ -1919,8 +1919,8 @@ Aliased as <code>methods</code></p>
         <li id="section-85">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-85">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-85">&#167;</a>
               </div>
               <p>Extend a given object with all the properties in passed-in object(s).</p>
 
@@ -1946,8 +1946,8 @@ Aliased as <code>methods</code></p>
         <li id="section-86">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-86">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-86">&#167;</a>
               </div>
               <p>Return a copy of the object only containing the whitelisted properties.</p>
 
@@ -1979,8 +1979,8 @@ Aliased as <code>methods</code></p>
         <li id="section-87">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-87">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-87">&#167;</a>
               </div>
               <p>Return a copy of the object without the blacklisted properties.</p>
 
@@ -2004,8 +2004,8 @@ Aliased as <code>methods</code></p>
         <li id="section-88">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-88">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-88">&#167;</a>
               </div>
               <p>Fill in a given object with default properties.</p>
 
@@ -2028,8 +2028,8 @@ Aliased as <code>methods</code></p>
         <li id="section-89">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-89">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-89">&#167;</a>
               </div>
               <p>Create a (shallow-cloned) duplicate of an object.</p>
 
@@ -2046,8 +2046,8 @@ Aliased as <code>methods</code></p>
         <li id="section-90">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-90">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-90">&#167;</a>
               </div>
               <p>Invokes interceptor with the obj, and then returns obj.
 The primary purpose of this method is to “tap into” a method chain, in
@@ -2066,8 +2066,8 @@ order to perform operations on intermediate results within the chain.</p>
         <li id="section-91">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-91">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-91">&#167;</a>
               </div>
               <p>Internal recursive comparison function for <code>isEqual</code>.</p>
 
@@ -2081,8 +2081,8 @@ order to perform operations on intermediate results within the chain.</p>
         <li id="section-92">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-92">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-92">&#167;</a>
               </div>
               <p>Identical objects are equal. <code>0 === -0</code>, but they aren’t identical.
 See the <a href="http://wiki.ecmascript.org/doku.php?id=harmony:egal">Harmony <code>egal</code> proposal</a>.</p>
@@ -2097,8 +2097,8 @@ See the <a href="http://wiki.ecmascript.org/doku.php?id=harmony:egal">Harmony <c
         <li id="section-93">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-93">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-93">&#167;</a>
               </div>
               <p>A strict comparison is necessary because <code>null == undefined</code>.</p>
 
@@ -2112,8 +2112,8 @@ See the <a href="http://wiki.ecmascript.org/doku.php?id=harmony:egal">Harmony <c
         <li id="section-94">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-94">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-94">&#167;</a>
               </div>
               <p>Unwrap any wrapped objects.</p>
 
@@ -2128,8 +2128,8 @@ See the <a href="http://wiki.ecmascript.org/doku.php?id=harmony:egal">Harmony <c
         <li id="section-95">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-95">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-95">&#167;</a>
               </div>
               <p>Compare <code>[[Class]]</code> names.</p>
 
@@ -2145,8 +2145,8 @@ See the <a href="http://wiki.ecmascript.org/doku.php?id=harmony:egal">Harmony <c
         <li id="section-96">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-96">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-96">&#167;</a>
               </div>
               <p>Strings, numbers, regular expressions, dates, and booleans are compared by value.</p>
 
@@ -2160,8 +2160,8 @@ See the <a href="http://wiki.ecmascript.org/doku.php?id=harmony:egal">Harmony <c
         <li id="section-97">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-97">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-97">&#167;</a>
               </div>
               <p>RegExps are coerced to strings for comparison (Note: ‘’ + /a/i === ‘/a/i’)</p>
 
@@ -2175,8 +2175,8 @@ See the <a href="http://wiki.ecmascript.org/doku.php?id=harmony:egal">Harmony <c
         <li id="section-98">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-98">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-98">&#167;</a>
               </div>
               <p>Primitives and their corresponding object wrappers are equivalent; thus, <code>&quot;5&quot;</code> is
 equivalent to <code>new String(&quot;5&quot;)</code>.</p>
@@ -2192,8 +2192,8 @@ equivalent to <code>new String(&quot;5&quot;)</code>.</p>
         <li id="section-99">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-99">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-99">&#167;</a>
               </div>
               <p><code>NaN</code>s are equivalent, but non-reflexive.
 Object(NaN) is equivalent to NaN</p>
@@ -2208,8 +2208,8 @@ Object(NaN) is equivalent to NaN</p>
         <li id="section-100">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-100">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-100">&#167;</a>
               </div>
               <p>An <code>egal</code> comparison is performed for other numeric values.</p>
 
@@ -2225,8 +2225,8 @@ Object(NaN) is equivalent to NaN</p>
         <li id="section-101">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-101">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-101">&#167;</a>
               </div>
               <p>Coerce dates and booleans to numeric primitive values. Dates are compared by their
 millisecond representations. Note that invalid dates with millisecond representations
@@ -2244,8 +2244,8 @@ of <code>NaN</code> are not equivalent.</p>
         <li id="section-102">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-102">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-102">&#167;</a>
               </div>
               <p>Assume equality for cyclic structures. The algorithm for detecting cyclic
 structures is adapted from ES 5.1 section 15.12.3, abstract operation <code>JO</code>.</p>
@@ -2261,8 +2261,8 @@ structures is adapted from ES 5.1 section 15.12.3, abstract operation <code>JO</
         <li id="section-103">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-103">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-103">&#167;</a>
               </div>
               <p>Linear search. Performance is inversely proportional to the number of
 unique nested structures.</p>
@@ -2278,8 +2278,8 @@ unique nested structures.</p>
         <li id="section-104">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-104">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-104">&#167;</a>
               </div>
               <p>Objects with different constructors are not equivalent, but <code>Object</code>s
 from different frames are.</p>
@@ -2296,8 +2296,8 @@ from different frames are.</p>
         <li id="section-105">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-105">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-105">&#167;</a>
               </div>
               <p>Handle Object.create(x) cases</p>
 
@@ -2316,8 +2316,8 @@ from different frames are.</p>
         <li id="section-106">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-106">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-106">&#167;</a>
               </div>
               <p>Add the first object to the stack of traversed objects.</p>
 
@@ -2333,8 +2333,8 @@ from different frames are.</p>
         <li id="section-107">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-107">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-107">&#167;</a>
               </div>
               <p>Recursively compare objects and arrays.</p>
 
@@ -2348,8 +2348,8 @@ from different frames are.</p>
         <li id="section-108">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-108">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-108">&#167;</a>
               </div>
               <p>Compare array lengths to determine if a deep comparison is necessary.</p>
 
@@ -2365,8 +2365,8 @@ from different frames are.</p>
         <li id="section-109">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-109">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-109">&#167;</a>
               </div>
               <p>Deep compare the contents, ignoring non-numeric properties.</p>
 
@@ -2384,8 +2384,8 @@ from different frames are.</p>
         <li id="section-110">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-110">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-110">&#167;</a>
               </div>
               <p>Deep compare objects.</p>
 
@@ -2400,8 +2400,8 @@ from different frames are.</p>
         <li id="section-111">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-111">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-111">&#167;</a>
               </div>
               <p>Ensure that both objects contain the same number of properties before comparing deep equality.</p>
 
@@ -2417,8 +2417,8 @@ from different frames are.</p>
         <li id="section-112">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-112">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-112">&#167;</a>
               </div>
               <p>Deep compare each member</p>
 
@@ -2436,8 +2436,8 @@ from different frames are.</p>
         <li id="section-113">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-113">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-113">&#167;</a>
               </div>
               <p>Remove the first object from the stack of traversed objects.</p>
 
@@ -2454,8 +2454,8 @@ from different frames are.</p>
         <li id="section-114">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-114">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-114">&#167;</a>
               </div>
               <p>Perform a deep comparison to check if two objects are equal.</p>
 
@@ -2471,8 +2471,8 @@ from different frames are.</p>
         <li id="section-115">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-115">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-115">&#167;</a>
               </div>
               <p>Is a given array, string, or object empty?
 An “empty” object has no enumerable own-properties.</p>
@@ -2492,8 +2492,8 @@ An “empty” object has no enumerable own-properties.</p>
         <li id="section-116">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-116">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-116">&#167;</a>
               </div>
               <p>Is a given value a DOM element?</p>
 
@@ -2509,8 +2509,8 @@ An “empty” object has no enumerable own-properties.</p>
         <li id="section-117">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-117">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-117">&#167;</a>
               </div>
               <p>Is a given value an array?
 Delegates to ECMA5’s native Array.isArray</p>
@@ -2527,8 +2527,8 @@ Delegates to ECMA5’s native Array.isArray</p>
         <li id="section-118">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-118">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-118">&#167;</a>
               </div>
               <p>Is a given variable an object?</p>
 
@@ -2545,8 +2545,8 @@ Delegates to ECMA5’s native Array.isArray</p>
         <li id="section-119">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-119">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-119">&#167;</a>
               </div>
               <p>Add some isType methods: isArguments, isFunction, isString, isNumber, isDate, isRegExp.</p>
 
@@ -2564,8 +2564,8 @@ Delegates to ECMA5’s native Array.isArray</p>
         <li id="section-120">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-120">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-120">&#167;</a>
               </div>
               <p>Define a fallback version of the method in browsers (ahem, IE), where
 there isn’t any inspectable “Arguments” type.</p>
@@ -2584,8 +2584,8 @@ there isn’t any inspectable “Arguments” type.</p>
         <li id="section-121">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-121">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-121">&#167;</a>
               </div>
               <p>Optimize <code>isFunction</code> if appropriate. Work around an IE 11 bug.</p>
 
@@ -2603,8 +2603,8 @@ there isn’t any inspectable “Arguments” type.</p>
         <li id="section-122">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-122">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-122">&#167;</a>
               </div>
               <p>Is a given object a finite number?</p>
 
@@ -2620,8 +2620,8 @@ there isn’t any inspectable “Arguments” type.</p>
         <li id="section-123">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-123">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-123">&#167;</a>
               </div>
               <p>Is the given value <code>NaN</code>? (NaN is the only number which does not equal itself).</p>
 
@@ -2637,8 +2637,8 @@ there isn’t any inspectable “Arguments” type.</p>
         <li id="section-124">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-124">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-124">&#167;</a>
               </div>
               <p>Is a given value a boolean?</p>
 
@@ -2654,8 +2654,8 @@ there isn’t any inspectable “Arguments” type.</p>
         <li id="section-125">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-125">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-125">&#167;</a>
               </div>
               <p>Is a given value equal to null?</p>
 
@@ -2671,8 +2671,8 @@ there isn’t any inspectable “Arguments” type.</p>
         <li id="section-126">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-126">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-126">&#167;</a>
               </div>
               <p>Is a given variable undefined?</p>
 
@@ -2688,8 +2688,8 @@ there isn’t any inspectable “Arguments” type.</p>
         <li id="section-127">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-127">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-127">&#167;</a>
               </div>
               <p>Shortcut function for checking if an object has a given property directly
 on itself (in other words, not on a prototype).</p>
@@ -2706,8 +2706,8 @@ on itself (in other words, not on a prototype).</p>
         <li id="section-128">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-128">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-128">&#167;</a>
               </div>
               <h2 id="utility-functions">Utility Functions</h2>
 
@@ -2719,8 +2719,8 @@ on itself (in other words, not on a prototype).</p>
         <li id="section-129">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-129">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-129">&#167;</a>
               </div>
               
             </div>
@@ -2731,8 +2731,8 @@ on itself (in other words, not on a prototype).</p>
         <li id="section-130">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-130">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-130">&#167;</a>
               </div>
               <p>Run Underscore.js in <em>noConflict</em> mode, returning the <code>_</code> variable to its
 previous owner. Returns a reference to the Underscore object.</p>
@@ -2750,8 +2750,8 @@ previous owner. Returns a reference to the Underscore object.</p>
         <li id="section-131">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-131">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-131">&#167;</a>
               </div>
               <p>Keep the identity function around for default iteratees.</p>
 
@@ -2781,8 +2781,8 @@ previous owner. Returns a reference to the Underscore object.</p>
         <li id="section-132">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-132">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-132">&#167;</a>
               </div>
               <p>Returns a predicate for checking whether an object has a given set of <code>key:value</code> pairs.</p>
 
@@ -2807,8 +2807,8 @@ previous owner. Returns a reference to the Underscore object.</p>
         <li id="section-133">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-133">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-133">&#167;</a>
               </div>
               <p>Run a function <strong>n</strong> times.</p>
 
@@ -2827,8 +2827,8 @@ previous owner. Returns a reference to the Underscore object.</p>
         <li id="section-134">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-134">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-134">&#167;</a>
               </div>
               <p>Return a random integer between min and max (inclusive).</p>
 
@@ -2848,8 +2848,8 @@ previous owner. Returns a reference to the Underscore object.</p>
         <li id="section-135">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-135">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-135">&#167;</a>
               </div>
               <p>A (possibly faster) way to get the current timestamp as an integer.</p>
 
@@ -2865,8 +2865,8 @@ previous owner. Returns a reference to the Underscore object.</p>
         <li id="section-136">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-136">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-136">&#167;</a>
               </div>
               <p>List of HTML entities for escaping.</p>
 
@@ -2888,8 +2888,8 @@ previous owner. Returns a reference to the Underscore object.</p>
         <li id="section-137">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-137">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-137">&#167;</a>
               </div>
               <p>Functions for escaping and unescaping strings to/from HTML interpolation.</p>
 
@@ -2906,8 +2906,8 @@ previous owner. Returns a reference to the Underscore object.</p>
         <li id="section-138">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-138">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-138">&#167;</a>
               </div>
               <p>Regexes for identifying a key that needs to be escaped</p>
 
@@ -2930,8 +2930,8 @@ previous owner. Returns a reference to the Underscore object.</p>
         <li id="section-139">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-139">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-139">&#167;</a>
               </div>
               <p>If the value of the named <code>property</code> is a function then invoke it with the
 <code>object</code> as context; otherwise, return it.</p>
@@ -2950,8 +2950,8 @@ previous owner. Returns a reference to the Underscore object.</p>
         <li id="section-140">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-140">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-140">&#167;</a>
               </div>
               <p>Generate a unique integer id (unique within the entire client session).
 Useful for temporary DOM ids.</p>
@@ -2970,8 +2970,8 @@ Useful for temporary DOM ids.</p>
         <li id="section-141">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-141">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-141">&#167;</a>
               </div>
               <p>By default, Underscore uses ERB-style template delimiters, change the
 following template settings to use alternative delimiters.</p>
@@ -2990,8 +2990,8 @@ following template settings to use alternative delimiters.</p>
         <li id="section-142">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-142">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-142">&#167;</a>
               </div>
               <p>When customizing <code>templateSettings</code>, if you don’t want to define an
 interpolation, evaluation or escaping regex, we need one that is
@@ -3007,8 +3007,8 @@ guaranteed not to match.</p>
         <li id="section-143">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-143">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-143">&#167;</a>
               </div>
               <p>Certain characters need to be escaped so that they can be put into a
 string literal.</p>
@@ -3036,8 +3036,8 @@ string literal.</p>
         <li id="section-144">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-144">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-144">&#167;</a>
               </div>
               <p>JavaScript micro-templating, similar to John Resig’s implementation.
 Underscore templating handles arbitrary delimiters, preserves whitespace,
@@ -3056,8 +3056,8 @@ NB: <code>oldSettings</code> only exists for backwards compatibility.</p>
         <li id="section-145">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-145">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-145">&#167;</a>
               </div>
               <p>Combine delimiters into one regular expression via alternation.</p>
 
@@ -3075,8 +3075,8 @@ NB: <code>oldSettings</code> only exists for backwards compatibility.</p>
         <li id="section-146">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-146">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-146">&#167;</a>
               </div>
               <p>Compile the template source, escaping string literals appropriately.</p>
 
@@ -3102,8 +3102,8 @@ NB: <code>oldSettings</code> only exists for backwards compatibility.</p>
         <li id="section-147">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-147">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-147">&#167;</a>
               </div>
               <p>Adobe VMs need the match returned to produce the correct offest.</p>
 
@@ -3119,8 +3119,8 @@ NB: <code>oldSettings</code> only exists for backwards compatibility.</p>
         <li id="section-148">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-148">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-148">&#167;</a>
               </div>
               <p>If a variable is not specified, place data values in local scope.</p>
 
@@ -3149,8 +3149,8 @@ NB: <code>oldSettings</code> only exists for backwards compatibility.</p>
         <li id="section-149">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-149">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-149">&#167;</a>
               </div>
               <p>Provide the compiled source as a convenience for precompilation.</p>
 
@@ -3168,8 +3168,8 @@ NB: <code>oldSettings</code> only exists for backwards compatibility.</p>
         <li id="section-150">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-150">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-150">&#167;</a>
               </div>
               <p>Add a “chain” function. Start chaining a wrapped Underscore object.</p>
 
@@ -3187,8 +3187,8 @@ NB: <code>oldSettings</code> only exists for backwards compatibility.</p>
         <li id="section-151">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-151">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-151">&#167;</a>
               </div>
               <h2 id="oop">OOP</h2>
 
@@ -3200,8 +3200,8 @@ NB: <code>oldSettings</code> only exists for backwards compatibility.</p>
         <li id="section-152">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-152">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-152">&#167;</a>
               </div>
               <p>If Underscore is called as a function, it returns a wrapped object that
 can be used OO-style. This wrapper holds altered versions of all the
@@ -3215,8 +3215,8 @@ underscore functions. Wrapped objects may be chained.</p>
         <li id="section-153">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-153">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-153">&#167;</a>
               </div>
               <p>Helper function to continue chaining intermediate results.</p>
 
@@ -3232,8 +3232,8 @@ underscore functions. Wrapped objects may be chained.</p>
         <li id="section-154">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-154">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-154">&#167;</a>
               </div>
               <p>Add your own custom functions to the Underscore object.</p>
 
@@ -3256,8 +3256,8 @@ underscore functions. Wrapped objects may be chained.</p>
         <li id="section-155">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-155">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-155">&#167;</a>
               </div>
               <p>Add all of the Underscore functions to the wrapper object.</p>
 
@@ -3271,8 +3271,8 @@ underscore functions. Wrapped objects may be chained.</p>
         <li id="section-156">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-156">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-156">&#167;</a>
               </div>
               <p>Add all mutator Array functions to the wrapper.</p>
 
@@ -3294,8 +3294,8 @@ underscore functions. Wrapped objects may be chained.</p>
         <li id="section-157">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-157">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-157">&#167;</a>
               </div>
               <p>Add all accessor Array functions to the wrapper.</p>
 
@@ -3314,8 +3314,8 @@ underscore functions. Wrapped objects may be chained.</p>
         <li id="section-158">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-158">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-158">&#167;</a>
               </div>
               <p>Extracts the result from a wrapped and chained object.</p>
 
@@ -3331,8 +3331,8 @@ underscore functions. Wrapped objects may be chained.</p>
         <li id="section-159">
             <div class="annotation">
               
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-159">&#182;</a>
+              <div class="sswrap ">
+                <a class="ss" href="#section-159">&#167;</a>
               </div>
               <p>AMD registration happens at the end for compatibility with AMD loaders
 that may not enforce next-turn semantics on modules. Even though general


### PR DESCRIPTION
This pull request will make the following replacements:

old | new
--- | ---
&#x00b6; | &#x00a7;
`&#182;` | `&#167;`
`.pilcrow` | `.ss`
`.pilwrap` | `.sswrap`
`class="pilcrow"` | `class="ss"`
`class="pilwrap "` | `class="sswrap "`

Note: Should use Unicode hex instead of decimal: `&#182;` should be `&#x00b6;` and `&#167;`should be `&#x00a7;`, but that is another issue.