### PR TITLE
Add proper Object function matches

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -767,6 +767,103 @@
   test('matches', function() {
     var moe = {name: 'Moe Howard', hair: true};
     var curly = {name: 'Curly Howard', hair: false};
+
+    equal(_.matches(moe, {hair: true}), true, 'Returns a boolean');
+    equal(_.matches(curly, {hair: true}), false, 'Returns a boolean');
+
+    equal(_.matches(5, {__x__: undefined}), false, 'can match undefined props on primitives');
+    equal(_.matches({__x__: undefined}, {__x__: undefined}), true, 'can match undefined props');
+
+    equal(_.matches(null, {}), true, 'Empty spec called with null object returns true');
+    equal(_.matches(null, {a: 1}), false, 'Non-empty spec called with null object returns false');
+
+    _.each([null, undefined], function(item) { strictEqual(_.matches(item, null), true, 'null matches null'); });
+    _.each([null, undefined], function(item) { strictEqual(_.matches(item, null), true, 'null matches {}'); });
+    strictEqual(_.matches({b: 1}, {a: undefined}), false, 'handles undefined values (1683)');
+
+    _.each([true, 5, NaN, null, undefined], function(item) {
+      strictEqual(_.matches({a: 1}, item), true, 'treats primitives as empty');
+    });
+
+    function Prototest() {}
+    Prototest.prototype.x = 1;
+    var specObj = new Prototest;
+    equal(_.matches({x: 2}, specObj), true, 'spec is restricted to own properties');
+
+    specObj.y = 5;
+    equal(_.matches({x: 1, y: 5}, specObj), true);
+    equal(_.matches({x: 1, y: 4}, specObj), false);
+
+    ok(_.matches(specObj, {x: 1, y: 5}), 'inherited and own properties are checked on the test object');
+
+    Prototest.x = 5;
+    ok(_.matches({x: 5, y: 1}, Prototest), 'spec can be a function');
+
+    //null edge cases
+    var oCon = {'constructor': Object};
+    deepEqual(_.map([null, undefined, 5, {}], _.partial(_.matches, _, oCon)), [false, false, false, true], 'doesnt fasley match constructor on undefined/null');
+  });
+
+  test('matcher', function() {
+    var moe = {name: 'Moe Howard', hair: true};
+    var curly = {name: 'Curly Howard', hair: false};
+    var stooges = [moe, curly];
+
+    equal(_.matcher({hair: true})(moe), true, 'Returns a boolean');
+    equal(_.matcher({hair: true})(curly), false, 'Returns a boolean');
+
+    equal(_.matcher({__x__: undefined})(5), false, 'can match undefined props on primitives');
+    equal(_.matcher({__x__: undefined})({__x__: undefined}), true, 'can match undefined props');
+
+    equal(_.matcher({})(null), true, 'Empty spec called with null object returns true');
+    equal(_.matcher({a: 1})(null), false, 'Non-empty spec called with null object returns false');
+
+    ok(_.find(stooges, _.matcher({hair: false})) === curly, 'returns a predicate that can be used by finding functions.');
+    ok(_.find(stooges, _.matcher(moe)) === moe, 'can be used to locate an object exists in a collection.');
+    deepEqual(_.where([null, undefined], {a: 1}), [], 'Do not throw on null values.');
+
+    deepEqual(_.where([null, undefined], null), [null, undefined], 'null matches null');
+    deepEqual(_.where([null, undefined], {}), [null, undefined], 'null matches {}');
+    deepEqual(_.where([{b: 1}], {a: undefined}), [], 'handles undefined values (1683)');
+
+    _.each([true, 5, NaN, null, undefined], function(item) {
+      deepEqual(_.where([{a: 1}], item), [{a: 1}], 'treats primitives as empty');
+    });
+
+    function Prototest() {}
+    Prototest.prototype.x = 1;
+    var specObj = new Prototest;
+    var protospec = _.matcher(specObj);
+    equal(protospec({x: 2}), true, 'spec is restricted to own properties');
+
+    specObj.y = 5;
+    protospec = _.matcher(specObj);
+    equal(protospec({x: 1, y: 5}), true);
+    equal(protospec({x: 1, y: 4}), false);
+
+    ok(_.matcher({x: 1, y: 5})(specObj), 'inherited and own properties are checked on the test object');
+
+    Prototest.x = 5;
+    ok(_.matcher(Prototest)({x: 5, y: 1}), 'spec can be a function');
+
+    // #1729
+    var o = {'b': 1};
+    var m = _.matcher(o);
+
+    equal(m({'b': 1}), true);
+    o.b = 2;
+    o.a = 1;
+    equal(m({'b': 1}), true, 'changing spec object doesnt change matches result');
+
+
+    //null edge cases
+    var oCon = _.matcher({'constructor': Object});
+    deepEqual(_.map([null, undefined, 5, {}], oCon), [false, false, false, true], 'doesnt fasley match constructor on undefined/null');
+  });
+
+  test('matches (legacy matcher)', function() {
+    var moe = {name: 'Moe Howard', hair: true};
+    var curly = {name: 'Curly Howard', hair: false};
     var stooges = [moe, curly];
 
     equal(_.matches({hair: true})(moe), true, 'Returns a boolean');

--- a/underscore.js
+++ b/underscore.js
@@ -87,7 +87,7 @@
   var cb = function(value, context, argCount) {
     if (value == null) return _.identity;
     if (_.isFunction(value)) return optimizeCb(value, context, argCount);
-    if (_.isObject(value)) return _.matches(value);
+    if (_.isObject(value)) return _.matcher(value);
     return _.property(value);
   };
   _.iteratee = function(value, context) {
@@ -300,13 +300,13 @@
   // Convenience version of a common use case of `filter`: selecting only objects
   // containing specific `key:value` pairs.
   _.where = function(obj, attrs) {
-    return _.filter(obj, _.matches(attrs));
+    return _.filter(obj, _.matcher(attrs));
   };
 
   // Convenience version of a common use case of `find`: getting the first object
   // containing specific `key:value` pairs.
   _.findWhere = function(obj, attrs) {
-    return _.find(obj, _.matches(attrs));
+    return _.find(obj, _.matcher(attrs));
   };
 
   // Return the maximum element (or element-based computation).
@@ -1091,6 +1091,20 @@
     return obj;
   };
 
+  // Returns whether an object has a given set of `key:value` pairs.
+  _.matches = function(object, attrs) {
+    if (arguments.length < 2) return _.matcher(object);
+    var keys = _.keys(attrs), length = keys.length;
+    if (object == null) return !length;
+    var obj = Object(object);
+    for (var i = 0; i < length; i++) {
+      var key = keys[i];
+      if (attrs[key] !== obj[key] || !(key in obj)) return false;
+    }
+    return true;
+  };
+
+
   // Internal recursive comparison function for `isEqual`.
   var eq = function(a, b, aStack, bStack) {
     // Identical objects are equal. `0 === -0`, but they aren't identical.
@@ -1306,16 +1320,10 @@
   };
 
   // Returns a predicate for checking whether an object has a given set of `key:value` pairs.
-  _.matches = function(attrs) {
-    var pairs = _.pairs(attrs), length = pairs.length;
+  _.matcher = function(attrs) {
+    attrs = _.assign({}, attrs);
     return function(obj) {
-      if (obj == null) return !length;
-      obj = new Object(obj);
-      for (var i = 0; i < length; i++) {
-        var pair = pairs[i], key = pair[0];
-        if (pair[1] !== obj[key] || !(key in obj)) return false;
-      }
-      return true;
+      return _.matches(obj, attrs);
     };
   };
 


### PR DESCRIPTION
This takes `_.matches` and turns it into a proper Object Function (takes the object as the first parameter). This should satisfy the performance problems seen in [jashkenas/backbone#3487](https://github.com/jashkenas/backbone/pull/3487#issuecomment-75001423).

I think it’s pretty apparent we jumbled the arguments originally. See the need to special case [`Backbone.Model#matches`](https://github.com/jashkenas/backbone/blob/master/backbone.js#L390-L393) instead of auto proxying like the other [`_` methods](https://github.com/jashkenas/backbone/blob/master/backbone.js#L669-L680). We even have to special case [`Collection#matches`](https://github.com/jashkenas/backbone/blob/master/backbone.js#L917-L924) so we don’t kill performance doing simple `where`s.

The legacy `_.matches(obj)` predicate matcher has been extracted into `_.matcher`. `_.matches` will return the predicate matcher if only one argument is provided. This legacy support should be removed in v2.0.