### PR TITLE
Avoid an arguments deopt

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -168,6 +168,11 @@
     deepEqual(_.pick(data, function(val, key) {
       return this[key] === 3 && this === instance;
     }, instance), {c: 3}, 'function is given context');
+
+    ok(!_.has(_.pick({}, 'foo'), 'foo'), 'does not set own property if property not in object');
+    _.pick(data, function(value, key, obj) {
+      equal(obj, data, 'passes same object as third parameter of iteratee');
+    });
   });
 
   test('omit', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -987,12 +987,12 @@
   };
 
   // Return a copy of the object only containing the whitelisted properties.
-  _.pick = function(obj, iteratee, context) {
-    var result = {}, keys;
+  _.pick = function(object, oiteratee, context) {
+    var result = {}, obj = object, iteratee, keys;
     if (obj == null) return result;
-    if (_.isFunction(iteratee)) {
+    if (_.isFunction(oiteratee)) {
       keys = _.allKeys(obj);
-      iteratee = optimizeCb(iteratee, context);
+      iteratee = optimizeCb(oiteratee, context);
     } else {
       keys = flatten(arguments, false, false, 1);
       iteratee = function(value, key, obj) { return key in obj; };


### PR DESCRIPTION
[Arguments Deopt](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#31-reassigning-a-defined-parameter-while-also-mentioning-arguments-in-the-body-typical-example), [jsperf](http://jsperf.com/underscore-1639/6)

Small refinement on last night's https://github.com/jashkenas/underscore/pull/2065.
