### PR TITLE
Alias allKeys to keysIn

### DIFF
--- a/index.html
+++ b/index.html
@@ -1346,6 +1346,7 @@ _.keys({one: 1, two: 2, three: 3});
 
       <p id="allKeys">
         <b class="header">allKeys</b><code>_.allKeys(object)</code>
+        <span class="alias">Alias: <b>keysIn</b></span>
         <br />
         Retrieve <i>all</i> the names of <b>object</b>'s own and inherited properties.
       </p>

--- a/test/objects.js
+++ b/test/objects.js
@@ -36,7 +36,7 @@
   });
 
   test('allKeys', function() {
-    deepEqual(_.allKeys({one : 1, two : 2}), ['one', 'two'], 'can extract the allKeys from an object');
+    deepEqual(_.allKeys({one : 1, two : 2}), ['one', 'two'], 'can extract the keys from an object');
     // the test above is not safe because it relies on for-in enumeration order
     var a = []; a[1] = 0;
     deepEqual(_.allKeys(a), ['1'], 'is not fooled by sparse arrays; see issue #95');
@@ -48,7 +48,7 @@
       deepEqual(_.allKeys(val), []);
     });
 
-    // allKeys that may be missed if the implementation isn't careful
+    // Keys that may be missed if the implementation isn't careful
     var trouble = {
       constructor: Object,
       valueOf: _.noop,

--- a/underscore.js
+++ b/underscore.js
@@ -929,7 +929,7 @@
   };
 
   // Retrieve all the property names of an object.
-  _.allKeys = function(obj) {
+  _.allKeys = _.keysIn = function(obj) {
     if (!_.isObject(obj)) return [];
     var keys = [];
     for (var key in obj) keys.push(key);


### PR DESCRIPTION
I’m only mad because it wasn’t discussed. And, I think `_.keysIn` is a better name, in part because of your [own argument](https://github.com/jashkenas/underscore/commit/4f771e0a04e8b071b4857e8e8da13fcb79c5c0d5#commitcomment-9833268).

Re: https://github.com/jashkenas/underscore/issues/2061, 4f771e0
