### PR TITLE
fixed isArrayLike returning true for 0

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -789,6 +789,7 @@
     equal(_.size(new String('hello')), 5, 'can compute the size of string object');
 
     equal(_.size(null), 0, 'handles nulls');
+    equal(_.size(0), 0, 'handles numbers');
   });
 
   test('partition', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -127,7 +127,7 @@
   // Related: http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tolength
   var MAX_ARRAY_INDEX = Math.pow(2, 53) - 1;
   var isArrayLike = function(collection) {
-    var length = collection && collection.length;
+    var length = collection != null && collection.length;
     return typeof length == 'number' && length >= 0 && length <= MAX_ARRAY_INDEX;
   };
 


### PR DESCRIPTION
before: 

```
_.size(0) //undefined
_.size(1) //0
```

after:

```
_.size(0) //0
_.size(1) //0
```

There are probably other methods that are broken for the value `0` but `_.size` is how I discovered the bug.