### PR TITLE
Prevent iOS from improperly JIT-ing isArrayLike

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -125,9 +125,10 @@
   // Helper for collection methods to determine whether a collection
   // should be iterated as an array or as an object
   // Related: http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tolength
-  var MAX_ARRAY_INDEX = Math.pow(2, 53) - 1;
+  // Avoids a very nasty iOS 8 JIT bug on ARM-64. #2094
+  var MAX_ARRAY_INDEX = Math.pow(2, 53) - 1, LENGTH = 'length';
   var isArrayLike = function(collection) {
-    var length = collection != null && collection.length;
+    var length = collection != null && collection[LENGTH];
     return typeof length == 'number' && length >= 0 && length <= MAX_ARRAY_INDEX;
   };
 


### PR DESCRIPTION
Fixes #2081. Special cases with `_.isArray`, since it’s so damn fast and engines [really dislike](http://jsperf.com/ios-jit-isarraylike/5) doing `'length' in array`.

[jsperf](https://jsperf.com/ios-jit-isarraylike/2), and with [longer collections](http://jsperf.com/ios-jit-isarraylike/3).