### PR TITLE
Speeding up _.uniq method by using hash table lookups for primitive data...

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -176,6 +176,11 @@
 
     deepEqual(_.uniq(null), []);
 
+    deepEqual(_.uniq([1, '1', true, 'true']), [1, '1', true, 'true'], 'it does not conflate primitive data types');
+
+    var iterfn = function(n){ return n; };
+    deepEqual(_.uniq([1, '1', true, 'true'], iterfn), [1, '1', true, 'true'], 'it does not conflate primitive data types when using iteratee');
+
     var context = {};
     list = [3];
     _.uniq(list, function(value, index, array) {

--- a/underscore.js
+++ b/underscore.js
@@ -520,19 +520,41 @@
     if (iteratee != null) iteratee = cb(iteratee, context);
     var result = [];
     var seen = [];
+    var seenPrimitive = {};
     for (var i = 0, length = array.length; i < length; i++) {
       var value = array[i],
           computed = iteratee ? iteratee(value, i, array) : value;
+
+      var vType = typeof computed,
+          vKey = vType[0] + computed,
+          isPrimitive = _.contains(['number', 'string', 'boolean', 'undefined'], vType);
+
       if (isSorted) {
         if (!i || seen !== computed) result.push(value);
         seen = computed;
       } else if (iteratee) {
-        if (!_.contains(seen, computed)) {
+
+        if (isPrimitive){
+          if (seenPrimitive[vKey] === undefined){
+            seenPrimitive[vKey] = true;
+            result.push(value);
+          }
+        } else if (!_.contains(seen, computed)){
           seen.push(computed);
           result.push(value);
         }
-      } else if (!_.contains(result, value)) {
-        result.push(value);
+
+      } else {
+
+        if (isPrimitive){
+          if (seenPrimitive[vKey] === undefined){
+            seenPrimitive[vKey] = true;
+            result.push(value);
+          }
+        } else if (!_.contains(result, value)){
+          result.push(value);
+        }
+
       }
     }
     return result;
@@ -1134,7 +1156,7 @@
     }
     // Assume equality for cyclic structures. The algorithm for detecting cyclic
     // structures is adapted from ES 5.1 section 15.12.3, abstract operation `JO`.
-    
+
     // Initializing stack of traversed objects.
     // It's done here since we only need them for objects and arrays comparison.
     aStack = aStack || [];
@@ -1298,7 +1320,7 @@
     };
   };
 
-  // Returns a predicate for checking whether an object has a given set of 
+  // Returns a predicate for checking whether an object has a given set of
   // `key:value` pairs.
   _.matcher = _.matches = function(attrs) {
     attrs = _.extendOwn({}, attrs);
@@ -1525,7 +1547,7 @@
   // Provide unwrapping proxy for some methods used in engine operations
   // such as arithmetic and JSON stringification.
   _.prototype.valueOf = _.prototype.toJSON = _.prototype.value;
-  
+
   _.prototype.toString = function() {
     return '' + this._wrapped;
   };

--- a/underscore.js
+++ b/underscore.js
@@ -529,11 +529,10 @@
         if (!i || seen !== computed) result.push(value);
         seen = computed;
       } else {
-        var vType = typeof computed,
-          isPrimitive = _.contains(['number', 'string', 'boolean', 'undefined'], vType);
+        var isPrimitive = !_.isObject(computed);
 
         if (isPrimitive) {
-          var vKey = vType == 'string' ? 's' + computed : computed;
+          var vKey = (typeof computed === 'string') ? 's' + computed : computed;
           if (seenPrimitive[vKey] === undefined){
             seenPrimitive[vKey] = true;
             result.push(value);

--- a/underscore.js
+++ b/underscore.js
@@ -529,10 +529,11 @@
         if (!i || seen !== computed) result.push(value);
         seen = computed;
       } else {
-        var isPrimitive = !_.isObject(computed);
+        var vType = typeof computed,
+            isPrimitive = _.contains(['number', 'string', 'boolean', 'undefined'], vType) || _.isNull(computed);
 
         if (isPrimitive) {
-          var vKey = (typeof computed === 'string') ? 's' + computed : computed;
+          var vKey = (vType === 'string') ? 's' + computed : computed;
           if (seenPrimitive[vKey] === undefined){
             seenPrimitive[vKey] = true;
             result.push(value);

--- a/underscore.js
+++ b/underscore.js
@@ -526,8 +526,9 @@
           computed = iteratee ? iteratee(value, i, array) : value;
 
       var vType = typeof computed,
-          vKey = vType[0] + computed,
           isPrimitive = _.contains(['number', 'string', 'boolean', 'undefined'], vType);
+
+      if (isPrimitive) var vKey = vType[0] + computed;
 
       if (isSorted) {
         if (!i || seen !== computed) result.push(value);

--- a/underscore.js
+++ b/underscore.js
@@ -539,9 +539,11 @@
             result.push(value);
           }
 
-        } else if (iteratee && !_.contains(seen, computed)) {
-          seen.push(computed);
-          result.push(value);
+        } else if (iteratee) {
+          if (!_.contains(seen, computed)) {
+            seen.push(computed);
+            result.push(value);
+          }
 
         } else if (!_.contains(result, value)) {
           result.push(value);

--- a/underscore.js
+++ b/underscore.js
@@ -525,34 +525,25 @@
       var value = array[i],
           computed = iteratee ? iteratee(value, i, array) : value;
 
-      var vType = typeof computed,
-          isPrimitive = _.contains(['number', 'string', 'boolean', 'undefined'], vType);
-
-      if (isPrimitive) var vKey = vType[0] + computed;
-
       if (isSorted) {
         if (!i || seen !== computed) result.push(value);
         seen = computed;
-      } else if (iteratee) {
+      } else {
+        var vType = typeof computed,
+          isPrimitive = _.contains(['number', 'string', 'boolean', 'undefined'], vType);
 
-        if (isPrimitive){
+        if (isPrimitive) {
+          var vKey = vType[0] + computed;
           if (seenPrimitive[vKey] === undefined){
             seenPrimitive[vKey] = true;
             result.push(value);
           }
-        } else if (!_.contains(seen, computed)){
+
+        } else if (iteratee && !_.contains(seen, computed)) {
           seen.push(computed);
           result.push(value);
-        }
 
-      } else {
-
-        if (isPrimitive){
-          if (seenPrimitive[vKey] === undefined){
-            seenPrimitive[vKey] = true;
-            result.push(value);
-          }
-        } else if (!_.contains(result, value)){
+        } else if (!_.contains(result, value)) {
           result.push(value);
         }
 

--- a/underscore.js
+++ b/underscore.js
@@ -533,7 +533,7 @@
           isPrimitive = _.contains(['number', 'string', 'boolean', 'undefined'], vType);
 
         if (isPrimitive) {
-          var vKey = vType[0] + computed;
+          var vKey = vType == 'string' ? 's' + computed : computed;
           if (seenPrimitive[vKey] === undefined){
             seenPrimitive[vKey] = true;
             result.push(value);


### PR DESCRIPTION
... types.

It is now works 200 times faster on my macbook air on an unsorted array with primitive data types.

I used these tests with 1000000 elements to measure perfomance:

function testSpeed(n){
    var tarr = [];

```
for(var i = 0; i<=n; i++){
    tarr.push(Math.floor(Math.random()*10000));
}

var startTime = Date.now();
_.uniq(tarr);

console.log("Ended by:", Date.now()-startTime);
```

}

function testSpeedIter(n){
    var tarr = [];

```
for(var i = 0; i<=n; i++){
    tarr.push(Math.floor(Math.random()*10000));
}

var iter = function(v, i, array){
    return v+"some";
}

var startTime = Date.now();

_.uniq(tarr, iter);

console.log("Ended by:", Date.now()-startTime);
```

}
