### PR TITLE
Add functions _.containsAll and _.containsAny

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,6 +208,8 @@
       <li>- <a href="#every">every</a></li>
       <li>- <a href="#some">some</a></li>
       <li>- <a href="#contains">contains</a></li>
+      <li>- <a href="#containsAll">containsAll</a></li>
+      <li>- <a href="#containsAny">containsAny</a></li>
       <li>- <a href="#invoke">invoke</a></li>
       <li>- <a href="#pluck">pluck</a></li>
       <li>- <a href="#max">max</a></li>
@@ -628,6 +630,28 @@ _.some([null, 0, 'yes', false]);
       </p>
       <pre>
 _.contains([1, 2, 3], 3);
+=&gt; true
+</pre>
+
+      <p id="containsAll">
+        <b class="header">containsAll</b><code>_.containsAll(list, sublist)</code>
+        <span class="alias">Alias: <b>includesAll</b></span>
+        <br />
+        Returns <i>true</i> if every value in the <b>sublist</b> is present in the <b>list</b>.
+      </p>
+      <pre>
+_.containsAll([1, 2, 3], [1, 3]);
+=&gt; true
+</pre>
+
+      <p id="containsAny">
+        <b class="header">containsAny</b><code>_.containsAny(list, sublist)</code>
+        <span class="alias">Alias: <b>includesAny</b></span>
+        <br />
+        Returns <i>true</i> if at least one value in the <b>sublist</b> is present in the <b>list</b>.
+      </p>
+      <pre>
+_.containsAll([1, 2, 3], [1, 4]);
 =&gt; true
 </pre>
 

--- a/test/collections.js
+++ b/test/collections.js
@@ -448,6 +448,28 @@
     });
   });
 
+  test('includesAll', function() {
+    var collection = [1, 2, 3];
+
+    strictEqual(_.includesAll(collection, [1, 2]), true);
+    strictEqual(_.includesAll(collection, [1, 4]), false);
+  });
+
+  test('containsAll', function() {
+    strictEqual(_.containsAll, _.includesAll, 'alias for includesAll');
+  });
+
+  test('includesAny', function() {
+    var collection = [1, 2, 3];
+
+    strictEqual(_.includesAny(collection, [1, 2]), true);
+    strictEqual(_.includesAny(collection, [1, 4]), true);
+    strictEqual(_.includesAny(collection, [4, 5]), false);
+  });
+
+  test('containsAny', function() {
+    strictEqual(_.containsAny, _.includesAny, 'alias for includesAny');
+  });
 
   test('invoke', 5, function() {
     var list = [[5, 1, 7], [3, 2, 1]];

--- a/underscore.js
+++ b/underscore.js
@@ -262,12 +262,12 @@
 
   // Determine if an array contains all elements of a target sub-array
   _.containsAll = _.includesAll = function(obj, target) {
-    return _.intersection(obj, target).length == target.length;
+    return _.every(target, _.partial(_.contains, obj));
   };
 
   // Determine if an array contains any elements of a target sub-array
   _.containsAny = _.includesAny = function(obj, target) {
-    return _.intersection(obj, target).length > 0;
+    return _.any(target, _.partial(_.contains, obj));
   };
 
   // Invoke a method (with arguments) on every item in a collection.

--- a/underscore.js
+++ b/underscore.js
@@ -259,6 +259,16 @@
     return _.indexOf(obj, target, typeof fromIndex == 'number' && fromIndex) >= 0;
   };
 
+  // Determine if an array contains all elements of a target sub-array
+  _.containsAll = _.includesAll = function(obj, target) {
+    return _.intersection(obj, target).length == target.length;
+  };
+
+  // Determine if an array contains any elements of a target sub-array
+  _.containsAny = _.includesAny = function(obj, target) {
+    return _.intersection(obj, target).length > 0;
+  };
+
   // Invoke a method (with arguments) on every item in a collection.
   _.invoke = function(obj, method) {
     var args = slice.call(arguments, 2);


### PR DESCRIPTION
`contains` does not currently work with arrays (https://github.com/jashkenas/underscore/issues/1615) and the current workarounds for this aren't very readable.

This PR adds two methods for testing whether a collection includes all or any values from another collection.

```javascript
_.containsAll([1, 2, 3], [1, 3]); //=> true
_.containsAll([1, 2, 3], [1, 4]); //=> false

_.containsAny([1, 2, 3], [1, 4]); //=> true
_.containsAny([1, 2, 3], [4, 5]); //=> false
```