### PR TITLE
Fix _.indexOf with NaN and isSorted

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -316,9 +316,10 @@
     equal(_.indexOf(numbers, num, true), 1, '40 is in the list');
     equal(_.indexOf(numbers, 6, true), -1, '6 isnt in the list');
     equal(_.indexOf([1, 2, 5, 4, 6, 7], 5, true), -1, 'sorted indexOf doesn\'t uses binary search');
-    ok(_.every(['1', [], {}, null], function() {
-      return _.indexOf(numbers, num, {}) === 1;
+    ok(_.every(['1', [], {}, null], function(isSorted) {
+      return _.indexOf(numbers, num, isSorted) === 1;
     }), 'non-nums as fromIndex make indexOf assume sorted');
+    equal(_.indexOf([1, 2, NaN], NaN, true), 2, 'isSorted with NaN returns correct result');
 
     numbers = [1, 2, 3, 1, 2, 3, 1, 2, 3];
     index = _.indexOf(numbers, 2, 5);

--- a/underscore.js
+++ b/underscore.js
@@ -608,16 +608,18 @@
   // If the array is large and already in sort order, pass `true`
   // for **isSorted** to use binary search.
   _.indexOf = function(array, item, isSorted) {
-    var i = 0, length = array && array.length;
-    if (typeof isSorted == 'number') {
+    var i = 0, length = array ? array.length : 0;
+    var startIndex = typeof isSorted == 'number';
+    if (startIndex) {
       i = isSorted < 0 ? Math.max(0, length + isSorted) : isSorted;
-    } else if (isSorted && length) {
-      i = _.sortedIndex(array, item);
-      return array[i] === item ? i : -1;
     }
     if (item !== item) {
       var index = _.findIndex(slice.call(array, i), _.isNaN);
       return index >= 0 ? index + i : -1;
+    }
+    if (isSorted && length && !startIndex) {
+        i = _.sortedIndex(array, item);
+        return array[i] === item ? i : -1;
     }
     for (; i < length; i++) if (array[i] === item) return i;
     return -1;


### PR DESCRIPTION
Slight breaking change from 1.8.0. Prioritizes finding `NaN` over using a sorted search.

This may not be a good change, since using `isSorted` is only defined to find matches if the array is actually sorted. Before this change, `[1, 5, 2, NaN]` wouldn't find `NaN` (if it were `===`), but afterwards it would.