### PR TITLE
Optimize _.range

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -670,7 +670,7 @@
   // the native Python `range()` function. See
   // [the Python documentation](http://docs.python.org/library/functions.html#range).
   _.range = function(start, stop, step) {
-    if (arguments.length <= 1) {
+    if (stop == null) {
       stop = start || 0;
       start = 0;
     }


### PR DESCRIPTION
Prevents an [arguments deopt](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#31-reassigning-a-defined-parameter-while-also-mentioning-arguments-in-the-body-typical-example).

http://jsperf.com/range-optimization