### PR TITLE
Guard _.contains fromIndex

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -427,12 +427,14 @@
     strictEqual(_.includes, _.contains, 'alias for includes');
 
     var numbers = [1, 2, 3, 1, 2, 3, 1, 2, 3];
-    strictEqual(_.includes(numbers, 1, 1), true);
-    strictEqual(_.includes(numbers, 1, -1), false);
-    strictEqual(_.includes(numbers, 1, -2), false);
-    strictEqual(_.includes(numbers, 1, -3), true);
-    strictEqual(_.includes(numbers, 1, 6), true);
-    strictEqual(_.includes(numbers, 1, 7), false);
+    strictEqual(_.includes(numbers, 1, 1), true, 'contains takes a fromIndex');
+    strictEqual(_.includes(numbers, 1, -1), false, 'contains takes a fromIndex');
+    strictEqual(_.includes(numbers, 1, -2), false, 'contains takes a fromIndex');
+    strictEqual(_.includes(numbers, 1, -3), true, 'contains takes a fromIndex');
+    strictEqual(_.includes(numbers, 1, 6), true, 'contains takes a fromIndex');
+    strictEqual(_.includes(numbers, 1, 7), false, 'contains takes a fromIndex');
+
+    ok(_.every([1, 2, 3], _.partial(_.contains, numbers)), 'fromIndex is guarded');
   });
 
   test('includes with NaN', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -252,11 +252,12 @@
     return false;
   };
 
-  // Determine if the array or object contains a given value (using `===`).
+  // Determine if the array or object contains a given item (using `===`).
   // Aliased as `includes` and `include`.
-  _.contains = _.includes = _.include = function(obj, target, fromIndex) {
+  _.contains = _.includes = _.include = function(obj, item, fromIndex, guard) {
     if (!isArrayLike(obj)) obj = _.values(obj);
-    return _.indexOf(obj, target, typeof fromIndex == 'number' && fromIndex) >= 0;
+    if (typeof fromIndex != 'number' || guard) fromIndex = 0;
+    return _.indexOf(obj, item, fromIndex) >= 0;
   };
 
   // Invoke a method (with arguments) on every item in a collection.


### PR DESCRIPTION
Ok, maybe one more PR... Noticed this one from #2100.

Guards `_.contains`’s `fromIndex`, so that it may be easily used with `_.partial`.

```javascript
var array = [1, 2, 3, 4, 5];
var subArray = [1, 2];

// Before
_.every(subArray, function(i) { return _.contains(array, i); });
// After
_.every(subArray, _.partial(_.contains, array));
```

Re: #2046, #1962