### PR TITLE
fix _.isEmpty for empty NodeList object in WebKit

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -566,7 +566,9 @@
     ok(_.isEmpty(), 'undefined is empty');
     ok(_.isEmpty(''), 'the empty string is empty');
     ok(!_.isEmpty('moe'), 'but other strings are not');
-
+    if (testElement) {
+      ok(_.isEmpty(testElement.childNodes), 'NodeList is empty');
+    }
     var obj = {one : 1};
     delete obj.one;
     ok(_.isEmpty(obj), 'deleting all the keys from an object empties it');

--- a/underscore.js
+++ b/underscore.js
@@ -1188,7 +1188,7 @@
   // An "empty" object has no enumerable own-properties.
   _.isEmpty = function(obj) {
     if (obj == null) return true;
-    if (isArrayLike(obj) && (_.isArray(obj) || _.isString(obj) || _.isArguments(obj))) return obj.length === 0;
+    if (isArrayLike(obj) && (_.isArray(obj) || _.isString(obj) || _.isArguments(obj) || _.has(obj, 'length'))) return obj.length === 0;
     return _.keys(obj).length === 0;
   };
 


### PR DESCRIPTION
After noticing that `_.isEmpty` fails in WebKit (Chrome/Safari) due to `Object.keys(emptyNodeList)` returning `length` as a key I added a failing test and implemented a fix which checks if the object has `length` implemented as a final check before trying `keys` as I'm assuming that if length is available it should be used regardless of the type of object it is.

Please consider it.

Thanks.