### PR TITLE
Add Composite Predicate Functions

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -515,6 +515,32 @@
     equal(_.negate(isOdd)(3), false, 'should return the complement of the given function');
   });
 
+  test('allPass', function() {
+    var isOdd = function(n){ return n & 1; };
+    var gt10 = function(n) { return n > 10; };
+    var gt20 = function(n) { return n > 20; };
+    var isOddGt10AndGt20 = _.allPass(isOdd, gt10, gt20);
+    equal(isOddGt10AndGt20(21), true, 'true if all predicates pass');
+    equal(isOddGt10AndGt20(22), false, 'false if any predicate fails');
+    equal(isOddGt10AndGt20(20), false, 'false if any predicate fails');
+    equal(isOddGt10AndGt20(19), false, 'false if any predicate fails');
+    equal(isOddGt10AndGt20(10), false, 'false if any predicate fails');
+    equal(isOddGt10AndGt20(9), false, 'false if any predicate fails');
+  });
+
+  test('allPass', function() {
+    var isOdd = function(n){ return n & 1; };
+    var gt10 = function(n) { return n > 10; };
+    var gt20 = function(n) { return n > 20; };
+    var isOddGt10OrGt20 = _.anyPass(isOdd, gt10, gt20);
+    equal(isOddGt10OrGt20(22), true, 'true if any predicates pass');
+    equal(isOddGt10OrGt20(21), true, 'true if any predicates pass');
+    equal(isOddGt10OrGt20(20), true, 'true if any predicates pass');
+    equal(isOddGt10OrGt20(19), true, 'true if any predicates pass');
+    equal(isOddGt10OrGt20(9), true, 'true if any predicates fail');
+    equal(isOddGt10OrGt20(10), false, 'false if all predicates fail');
+  });
+
   test('compose', function() {
     var greet = function(name){ return 'hi: ' + name; };
     var exclaim = function(sentence){ return sentence + '!'; };

--- a/test/functions.js
+++ b/test/functions.js
@@ -526,6 +526,8 @@
     equal(isOddGt10AndGt20(19), false, 'false if any predicate fails');
     equal(isOddGt10AndGt20(10), false, 'false if any predicate fails');
     equal(isOddGt10AndGt20(9), false, 'false if any predicate fails');
+
+    ok(_.allPass({name: 'moe'}, {age: 50})({name: 'moe', age: 50}), 'supports shorthand syntax');
   });
 
   test('allPass', function() {
@@ -539,6 +541,8 @@
     equal(isOddGt10OrGt20(19), true, 'true if any predicates pass');
     equal(isOddGt10OrGt20(9), true, 'true if any predicates fail');
     equal(isOddGt10OrGt20(10), false, 'false if all predicates fail');
+
+    ok(_.anyPass({name: 'moe'}, {age: 50})({name: 'moe', age: 20}), 'supports shorthand syntax');
   });
 
   test('compose', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -865,13 +865,13 @@
 
   // Creates a composite predicate function
   function createCompositePredicates(method) {
-      return function() {
-          var predicates = _.map(arguments, cb);
-          return function() {
-              var context = this, args = arguments;
+      return restArgs(function(predicates) {
+          predicates = _.map(predicates, cb);
+          return restArgs(function(args) {
+              var context = this;
               return method(predicates, function(predicate) { return predicate.apply(context, args); });
-          };
-      };
+          });
+      });
   }
 
   // Returns a composite predicate function, similar to binary logic operators.

--- a/underscore.js
+++ b/underscore.js
@@ -863,6 +863,21 @@
     };
   };
 
+  // Creates a composite predicate function
+  function createCompositePredicates(method) {
+      return function() {
+          var predicates = slice.call(arguments);
+          return function() {
+              var context = this, args = arguments;
+              return method(predicates, function(predicate) { return predicate.apply(context, args); });
+          };
+      };
+  }
+
+  // Returns a composite predicate function, similar to binary logic operators.
+  _.allPass = createCompositePredicates(_.every);
+  _.anyPass = createCompositePredicates(_.some);
+
   // Returns a function that is the composition of a list of functions, each
   // consuming the return value of the function that follows.
   _.compose = function() {

--- a/underscore.js
+++ b/underscore.js
@@ -866,7 +866,7 @@
   // Creates a composite predicate function
   function createCompositePredicates(method) {
       return function() {
-          var predicates = slice.call(arguments);
+          var predicates = _.map(arguments, cb);
           return function() {
               var context = this, args = arguments;
               return method(predicates, function(predicate) { return predicate.apply(context, args); });


### PR DESCRIPTION
Cross posting from lodash/lodash#1072. We already have `_.negate` for negating predicate functions, how about adding something similar to `and` and `or` logic for composing predicate functions. This would allow pretty nifty filtering like:

``` javascript
_.filter(array, _.allPass(_.isObject, _.negate(_.isArray))); // #2123
```
