### PR TITLE
Add _.restParam

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -588,28 +588,28 @@
 
   });
 
-  test('restParam', 10, function() {
-    _.restParam(function(a, args) {
+  test('restArgs', 10, function() {
+    _.restArgs(function(a, args) {
         strictEqual(a, 1);
         deepEqual(args, [2, 3], 'collects rest arguments into an array');
     })(1, 2, 3);
 
-    _.restParam(function(a, args) {
+    _.restArgs(function(a, args) {
         strictEqual(a, undefined);
         deepEqual(args, [], 'passes empty array if there are not enough arguments');
     })();
 
-    _.restParam(function(a, b, c, args) {
+    _.restArgs(function(a, b, c, args) {
         strictEqual(arguments.length, 4);
         deepEqual(args, [4, 5], 'works on functions with many named parameters');
     })(1, 2, 3, 4, 5);
 
     var obj = {};
-    _.restParam(function() {
+    _.restArgs(function() {
         strictEqual(this, obj, 'invokes function with this context');
     }).call(obj);
 
-    _.restParam(function(array, iteratee, context) {
+    _.restArgs(function(array, iteratee, context) {
         deepEqual(array, [1, 2, 3, 4], 'startIndex can be used manually specify index of rest parameter');
         strictEqual(iteratee, undefined);
         strictEqual(context, undefined);

--- a/test/functions.js
+++ b/test/functions.js
@@ -588,4 +588,32 @@
 
   });
 
+  test('restParam', 10, function() {
+    _.restParam(function(a, args) {
+        strictEqual(a, 1);
+        deepEqual(args, [2, 3], 'collects rest arguments into an array');
+    })(1, 2, 3);
+
+    _.restParam(function(a, args) {
+        strictEqual(a, undefined);
+        deepEqual(args, [], 'passes empty array if there are not enough arguments');
+    })();
+
+    _.restParam(function(a, b, c, args) {
+        strictEqual(arguments.length, 4);
+        deepEqual(args, [4, 5], 'works on functions with many named parameters');
+    })(1, 2, 3, 4, 5);
+
+    var obj = {};
+    _.restParam(function() {
+        strictEqual(this, obj, 'invokes function with this context');
+    }).call(obj);
+
+    _.restParam(function(array, iteratee, context) {
+        deepEqual(array, [1, 2, 3, 4], 'startIndex can be used manually specify index of rest parameter');
+        strictEqual(iteratee, undefined);
+        strictEqual(context, undefined);
+    }, 0)(1, 2, 3, 4);
+  });
+
 }());

--- a/underscore.js
+++ b/underscore.js
@@ -98,7 +98,7 @@
   var restParam = function(func, startIndex) {
     startIndex = startIndex == null ? func.length - 1 : +startIndex;
     return function() {
-      var length = arguments.length > startIndex ? arguments.length - startIndex : 0;
+      var length = Math.max(arguments.length - startIndex, 0);
       var rest = Array(length);
       for (var index = 0; index < length; index++) {
         rest[index] = arguments[index + startIndex];

--- a/underscore.js
+++ b/underscore.js
@@ -95,7 +95,7 @@
 
   // Similar to ES6's rest params (http://ariya.ofilabs.com/2013/03/es6-and-rest-parameter.html)
   // This accumulates the arguments passed into an array, after a given index.
-  _.restParam = function(func, startIndex) {
+  var restParam = function(func, startIndex) {
     startIndex = startIndex == null ? func.length - 1 : +startIndex;
     return function() {
       var length = arguments.length > startIndex ? arguments.length - startIndex : 0;
@@ -112,7 +112,7 @@
       for (index = 0; index < startIndex; index++) {
         args[index] = arguments[index];
       }
-      args[index] = rest;
+      args[startIndex] = rest;
       return func.apply(this, args);
     };
   };
@@ -274,7 +274,7 @@
   };
 
   // Invoke a method (with arguments) on every item in a collection.
-  _.invoke = _.restParam(function(obj, method, args) {
+  _.invoke = restParam(function(obj, method, args) {
     var isFunc = _.isFunction(method);
     return _.map(obj, function(value) {
       var func = isFunc ? method : value[method];
@@ -511,7 +511,7 @@
   };
 
   // Return a version of the array that does not contain the specified value(s).
-  _.without = _.restParam(function(array, otherArrays) {
+  _.without = restParam(function(array, otherArrays) {
     return _.difference(array, otherArrays);
   });
 
@@ -711,7 +711,7 @@
     if (nativeBind && func.bind === nativeBind) return nativeBind.apply(func, slice.call(arguments, 1));
     if (!_.isFunction(func)) throw new TypeError('Bind must be called on a function');
     var args = slice.call(arguments, 2);
-    var bound = _.restParam(function(callArgs) {
+    var bound = restParam(function(callArgs) {
       return executeBound(func, bound, context, this, args.concat(callArgs));
     });
     return bound;
@@ -721,7 +721,7 @@
   // arguments pre-filled, without changing its dynamic `this` context. _ acts
   // as a placeholder by default, allowing any combination of arguments to be
   // pre-filled. Set `_.partial.placeholder` for a custom placeholder argument.
-  _.partial = _.restParam(function(func, boundArgs) {
+  _.partial = restParam(function(func, boundArgs) {
     var placeholder = _.partial.placeholder;
     var bound = function() {
       var position = 0, length = boundArgs.length;
@@ -740,7 +740,7 @@
   // Bind a number of an object's methods to that object. Remaining arguments
   // are the method names to be bound. Useful for ensuring that all callbacks
   // defined on an object belong to it.
-  _.bindAll = _.restParam(function(obj, keys) {
+  _.bindAll = restParam(function(obj, keys) {
     if (keys.length < 1) throw new Error('bindAll must be passed function names');
     return _.each(keys, function(key) {
       obj[key] = _.bind(obj[key], obj);
@@ -761,7 +761,7 @@
 
   // Delays a function for the given number of milliseconds, and then calls
   // it with the arguments supplied.
-  _.delay = _.restParam(function(func, wait, args) {
+  _.delay = restParam(function(func, wait, args) {
     return setTimeout(function(){
       return func.apply(null, args);
     }, wait);
@@ -895,6 +895,8 @@
   // Returns a function that will be executed at most one time, no matter how
   // often you call it. Useful for lazy initialization.
   _.once = _.partial(_.before, 2);
+
+  _.restParam = restParam;
 
   // Object Functions
   // ----------------
@@ -1506,7 +1508,7 @@
   _.mixin = function(obj) {
     _.each(_.functions(obj), function(name) {
       var func = _[name] = obj[name];
-      _.prototype[name] = _.restParam(function(args) {
+      _.prototype[name] = restParam(function(args) {
         args.unshift(this._wrapped);
         return result(this, func.apply(_, args));
       });

--- a/underscore.js
+++ b/underscore.js
@@ -93,9 +93,9 @@
     return cb(value, context, Infinity);
   };
 
-  // Similar to ES6's rest params (http://ariya.ofilabs.com/2013/03/es6-and-rest-parameter.html)
+  // Similar to ES6's rest param (http://ariya.ofilabs.com/2013/03/es6-and-rest-parameter.html)
   // This accumulates the arguments passed into an array, after a given index.
-  var restParam = function(func, startIndex) {
+  var restArgs = function(func, startIndex) {
     startIndex = startIndex == null ? func.length - 1 : +startIndex;
     return function() {
       var length = Math.max(arguments.length - startIndex, 0);
@@ -274,7 +274,7 @@
   };
 
   // Invoke a method (with arguments) on every item in a collection.
-  _.invoke = restParam(function(obj, method, args) {
+  _.invoke = restArgs(function(obj, method, args) {
     var isFunc = _.isFunction(method);
     return _.map(obj, function(value) {
       var func = isFunc ? method : value[method];
@@ -511,7 +511,7 @@
   };
 
   // Return a version of the array that does not contain the specified value(s).
-  _.without = restParam(function(array, otherArrays) {
+  _.without = restArgs(function(array, otherArrays) {
     return _.difference(array, otherArrays);
   });
 
@@ -711,7 +711,7 @@
     if (nativeBind && func.bind === nativeBind) return nativeBind.apply(func, slice.call(arguments, 1));
     if (!_.isFunction(func)) throw new TypeError('Bind must be called on a function');
     var args = slice.call(arguments, 2);
-    var bound = restParam(function(callArgs) {
+    var bound = restArgs(function(callArgs) {
       return executeBound(func, bound, context, this, args.concat(callArgs));
     });
     return bound;
@@ -721,7 +721,7 @@
   // arguments pre-filled, without changing its dynamic `this` context. _ acts
   // as a placeholder by default, allowing any combination of arguments to be
   // pre-filled. Set `_.partial.placeholder` for a custom placeholder argument.
-  _.partial = restParam(function(func, boundArgs) {
+  _.partial = restArgs(function(func, boundArgs) {
     var placeholder = _.partial.placeholder;
     var bound = function() {
       var position = 0, length = boundArgs.length;
@@ -740,7 +740,7 @@
   // Bind a number of an object's methods to that object. Remaining arguments
   // are the method names to be bound. Useful for ensuring that all callbacks
   // defined on an object belong to it.
-  _.bindAll = restParam(function(obj, keys) {
+  _.bindAll = restArgs(function(obj, keys) {
     if (keys.length < 1) throw new Error('bindAll must be passed function names');
     return _.each(keys, function(key) {
       obj[key] = _.bind(obj[key], obj);
@@ -761,7 +761,7 @@
 
   // Delays a function for the given number of milliseconds, and then calls
   // it with the arguments supplied.
-  _.delay = restParam(function(func, wait, args) {
+  _.delay = restArgs(function(func, wait, args) {
     return setTimeout(function(){
       return func.apply(null, args);
     }, wait);
@@ -896,7 +896,7 @@
   // often you call it. Useful for lazy initialization.
   _.once = _.partial(_.before, 2);
 
-  _.restParam = restParam;
+  _.restArgs = restArgs;
 
   // Object Functions
   // ----------------
@@ -1508,7 +1508,7 @@
   _.mixin = function(obj) {
     _.each(_.functions(obj), function(name) {
       var func = _[name] = obj[name];
-      _.prototype[name] = restParam(function(args) {
+      _.prototype[name] = restArgs(function(args) {
         args.unshift(this._wrapped);
         return result(this, func.apply(_, args));
       });

--- a/underscore.js
+++ b/underscore.js
@@ -97,20 +97,25 @@
   // Similar to ES6's rest params (http://ariya.ofilabs.com/2013/03/es6-and-rest-parameter.html)
   // This accumulates the arguments passed into an array, after a given index.
   _.restParams = function(func, startIndex) {
-    startIndex = startIndex != null ? +startIndex : 1;
+    startIndex = startIndex == null ? func.length - 1 : +startIndex;
     return function() {
-      var len = arguments.length;
-      var args = Array(len > startIndex ? len - startIndex : 0);
-      for (var index = startIndex; index < len; index++) {
-        args[index - startIndex] = arguments[index];
+      var length = arguments.length > startIndex ? arguments.length - startIndex : 0;
+      var rest = Array(length);
+      for (var index = 0; index < length; index++) {
+        rest[index] = arguments[index + startIndex];
       }
       switch (startIndex) {
-        case 0: return func.call(this, args);
-        case 1: return func.call(this, arguments[0], args);
-        case 2: return func.call(this, arguments[0], arguments[1], args);
-        case 3: return func.call(this, arguments[0], arguments[1], arguments[2], args);
+        case 0: return func.call(this, rest);
+        case 1: return func.call(this, arguments[0], rest);
+        case 2: return func.call(this, arguments[0], arguments[1], rest);
+        case 3: return func.call(this, arguments[0], arguments[1], arguments[2], rest);
       }
-      return func.apply(this, _.take(arguments, startIndex).concat([args]));
+      var args = Array(startIndex + 1);
+      for (index = 0; index < startIndex; index++) {
+        args[index] = arguments[index];
+      }
+      args[index] = rest;
+      return func.apply(this, args);
     };
   };
 
@@ -277,7 +282,7 @@
       var func = isFunc ? method : value[method];
       return func == null ? func : func.apply(value, args);
     });
-  }, 2);
+  });
 
   // Convenience version of a common use case of `map`: fetching a property.
   _.pluck = function(obj, key) {
@@ -710,7 +715,7 @@
     var args = slice.call(arguments, 2);
     var bound = _.restParams(function(callArgs) {
       return executeBound(func, bound, context, this, args.concat(callArgs));
-    }, 0);
+    });
     return bound;
   };
 
@@ -762,7 +767,7 @@
     return setTimeout(function(){
       return func.apply(null, args);
     }, wait);
-  }, 2);
+  });
 
   // Defers a function, scheduling it to run after the current call stack has
   // cleared.

--- a/underscore.js
+++ b/underscore.js
@@ -19,7 +19,6 @@
 
   // Create quick reference variables for speed access to core prototypes.
   var
-    push             = ArrayProto.push,
     slice            = ArrayProto.slice,
     toString         = ObjProto.toString,
     hasOwnProperty   = ObjProto.hasOwnProperty;
@@ -96,7 +95,7 @@
 
   // Similar to ES6's rest params (http://ariya.ofilabs.com/2013/03/es6-and-rest-parameter.html)
   // This accumulates the arguments passed into an array, after a given index.
-  _.restParams = function(func, startIndex) {
+  _.restParam = function(func, startIndex) {
     startIndex = startIndex == null ? func.length - 1 : +startIndex;
     return function() {
       var length = arguments.length > startIndex ? arguments.length - startIndex : 0;
@@ -108,7 +107,6 @@
         case 0: return func.call(this, rest);
         case 1: return func.call(this, arguments[0], rest);
         case 2: return func.call(this, arguments[0], arguments[1], rest);
-        case 3: return func.call(this, arguments[0], arguments[1], arguments[2], rest);
       }
       var args = Array(startIndex + 1);
       for (index = 0; index < startIndex; index++) {
@@ -276,7 +274,7 @@
   };
 
   // Invoke a method (with arguments) on every item in a collection.
-  _.invoke = _.restParams(function(obj, method, args) {
+  _.invoke = _.restParam(function(obj, method, args) {
     var isFunc = _.isFunction(method);
     return _.map(obj, function(value) {
       var func = isFunc ? method : value[method];
@@ -513,7 +511,7 @@
   };
 
   // Return a version of the array that does not contain the specified value(s).
-  _.without = _.restParams(function(array, otherArrays) {
+  _.without = _.restParam(function(array, otherArrays) {
     return _.difference(array, otherArrays);
   });
 
@@ -713,7 +711,7 @@
     if (nativeBind && func.bind === nativeBind) return nativeBind.apply(func, slice.call(arguments, 1));
     if (!_.isFunction(func)) throw new TypeError('Bind must be called on a function');
     var args = slice.call(arguments, 2);
-    var bound = _.restParams(function(callArgs) {
+    var bound = _.restParam(function(callArgs) {
       return executeBound(func, bound, context, this, args.concat(callArgs));
     });
     return bound;
@@ -723,7 +721,7 @@
   // arguments pre-filled, without changing its dynamic `this` context. _ acts
   // as a placeholder by default, allowing any combination of arguments to be
   // pre-filled. Set `_.partial.placeholder` for a custom placeholder argument.
-  _.partial = _.restParams(function(func, boundArgs) {
+  _.partial = _.restParam(function(func, boundArgs) {
     var placeholder = _.partial.placeholder;
     var bound = function() {
       var position = 0, length = boundArgs.length;
@@ -742,7 +740,7 @@
   // Bind a number of an object's methods to that object. Remaining arguments
   // are the method names to be bound. Useful for ensuring that all callbacks
   // defined on an object belong to it.
-  _.bindAll = _.restParams(function(obj, keys) {
+  _.bindAll = _.restParam(function(obj, keys) {
     if (keys.length < 1) throw new Error('bindAll must be passed function names');
     return _.each(keys, function(key) {
       obj[key] = _.bind(obj[key], obj);
@@ -763,7 +761,7 @@
 
   // Delays a function for the given number of milliseconds, and then calls
   // it with the arguments supplied.
-  _.delay = _.restParams(function(func, wait, args) {
+  _.delay = _.restParam(function(func, wait, args) {
     return setTimeout(function(){
       return func.apply(null, args);
     }, wait);
@@ -1508,11 +1506,10 @@
   _.mixin = function(obj) {
     _.each(_.functions(obj), function(name) {
       var func = _[name] = obj[name];
-      _.prototype[name] = function() {
-        var args = [this._wrapped];
-        push.apply(args, arguments);
+      _.prototype[name] = _.restParam(function(args) {
+        args.unshift(this._wrapped);
         return result(this, func.apply(_, args));
-      };
+      });
     });
   };
 


### PR DESCRIPTION
`_.restParam` is the equivalent of ES6's rest parameter. It's particularly useful as an alternative to `slice.call(arguments, index)` (numerous examples in this PR), and it's a reusable, very fast version of inline for-loop slicing, eg. https://github.com/jashkenas/backbone/pull/3489.

```javascript
var test = function(a, b, ...args) {
   console.log(arguments);
}

test(1, 2, 3, 4, 5); // => [1, 2, [3, 4, 5]]

var test = _.restParam(function(a, b, args) {
   console.log(arguments);
});

test(1, 2, 3, 4, 5); // => [1, 2, [3, 4, 5]]
```