### PR TITLE
Modify defer to use native task queue via promise if available

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -768,8 +768,20 @@
   });
 
   // Defers a function, scheduling it to run after the current call stack has
-  // cleared.
-  _.defer = _.partial(_.delay, _, 1);
+  // cleared. Use native promise if available.
+  _.defer = (function() {
+    if (!Promise) {
+      return _.partial(_.delay, _, 1);
+    }
+    var _promise = new Promise(function(resolve) {
+      resolve();
+    });
+    return restArgs(function(func, args) {
+      _promise.then(function() {
+        func.apply(null, args);
+      });
+    });
+  })();
 
   // Returns a function, that, when invoked, will only be triggered at most once
   // during a given window of time. Normally, the throttled function will run

--- a/underscore.js
+++ b/underscore.js
@@ -770,7 +770,7 @@
   // Defers a function, scheduling it to run after the current call stack has
   // cleared. Use native promise if available.
   _.defer = (function() {
-    if (!Promise) {
+    if (typeof Promise !== 'function') {
       return _.partial(_.delay, _, 1);
     }
     var _promise = new Promise(function(resolve) {


### PR DESCRIPTION
Hi there
I wonder if we can use native defer when run on environment that has Promise interface available?
Take advantage from browser optimized task queue.