### PR TITLE
Fix array typo in home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -975,7 +975,7 @@ _.zip(['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]);
         and so on. Use with <tt>apply</tt> to pass in an array of arrays.
       </p>
       <pre>
-_.unzip(["moe", 30, true], ["larry", 40, false], ["curly", 50, false]);
+_.unzip([["moe", 30, true], ["larry", 40, false], ["curly", 50, false]]);
 =&gt; [['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]]
 </pre>
 


### PR DESCRIPTION
_.unzip accepts a single array of arrays.

As smartmuki found in github issue #2159. 