### PR TITLE
described correct behavior of _.result in docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1930,8 +1930,8 @@ _.unescape('Curly, Larry &amp;amp; Moe');
         <br />
         If the value of the named <b>property</b> is a function then invoke it
         with the <b>object</b> as context; otherwise, return it. If a default value
-        is provided and the property doesn't exist than the default will be returned.
-        If <tt>defaultValue</tt> is a function its result will be returned.
+        is provided and the property doesn't exist or is undefined than the default
+        will be returned. If <tt>defaultValue</tt> is a function its result will be returned.
       </p>
       <pre>
 var object = {cheese: 'crumpets', stuff: function(){ return 'nonsense'; }};


### PR DESCRIPTION
`_.result({foo: undefined}, 'foo', 'bar') //bar`

The behavior described in the _.result docs specifies that the defaultValue (if provided) will be returned if an objects property does not exists. Though the implementation will also return the default value when the property exists but has the value `undefined`. Changed docs to reflect this.
