### PR TITLE
Reword comment to not use "require"

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -42,7 +42,7 @@
   };
 
   // Export the Underscore object for **Node.js**, with
-  // backwards-compatibility for the old `require()` API. If we're in
+  // backwards-compatibility for their old module API. If we're in
   // the browser, add `_` as a global object.
   if (typeof exports !== 'undefined') {
     if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
Longshot I know...

browserify does a [quick](https://github.com/substack/node-detective/blob/75946ee23cb7abb974a2053235ecb2663b879c07/index.js#L4) regexp match for `\brequire\b` before deciding on whether to build an AST to get the require calls. By rewording this comment so that the word "require" is nowhere in the source, you'd be improving everyones build times. Browserify provides a `noparse` escape hatch but this is an easy win.