### PR TITLE
isEqual performance optimization

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1113,7 +1113,7 @@
     // Identical objects are equal. `0 === -0`, but they aren't identical.
     // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
     if (a === b) return a !== 0 || 1 / a === 1 / b;
-    if( typeof a != 'object' && typeof b != 'object' ) return a != a ? b != b : a === b;
+    if( typeof a != 'object' && typeof b != 'object' ) return a != a && b != b;
 
     if (a == null || b == null) return a === b;
 

--- a/underscore.js
+++ b/underscore.js
@@ -1114,8 +1114,7 @@
     // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
     if (a === b) return a !== 0 || 1 / a === 1 / b;
     if( typeof a != 'object' && typeof b != 'object' ) return a != a && b != b;
-
-    if (a == null || b == null) return a === b;
+    if (a == null || b == null) return false;
 
     // Unwrap any wrapped objects.
     if (a instanceof _) a = a._wrapped;
@@ -1205,7 +1204,9 @@
 
   // Perform a deep comparison to check if two objects are equal.
   _.isEqual = function(a, b) {
-      return eq( a, b );
+      if (a === b) return a !== 0 || 1 / a === 1 / b;
+      if( typeof a != 'object' && typeof b != 'object' ) return a != a && b != b;
+      return a != null && b != null && eq( a, b );
   };
 
   // Is a given array, string, or object empty?

--- a/underscore.js
+++ b/underscore.js
@@ -1210,7 +1210,9 @@
 
   // Perform a deep comparison to check if two objects are equal.
   _.isEqual = function(a, b) {
-      return eq( a, b );
+      if (a === b) return a !== 0 || 1 / a === 1 / b;
+      if( typeof a != 'object' && typeof b != 'object' ) return a != a && b != b;
+      return a != null && b != null && deepEq( a, b );
   };
 
   // Is a given array, string, or object empty?

--- a/underscore.js
+++ b/underscore.js
@@ -1110,15 +1110,10 @@
 
   // Internal recursive comparison function for `isEqual`.
   var deepEq, eq = function(a, b, aStack, bStack) {
-      // Identical objects are equal. `0 === -0`, but they aren't identical.
-      // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
       if (a === b) return a !== 0 || 1 / a === 1 / b;
-
-      // if objects are of primitive types, they are not equal unless both of them are NaNs.
-      if (typeof a != 'object' && typeof b != 'object') return a != a && b != b;
-
-      // if any of a or b is null, objects are not equal.
-      return a != null && b != null && deepEq(a, b, aStack, bStack);
+      var typeA = typeof a;
+      return typeA != 'function' && typeA != 'object' && typeof b != 'object' ?
+        a != a && b != b : a != null && b != null && deepEq(a, b, aStack, bStack);
   };
 
   deepEq = function(a, b, aStack, bStack) {
@@ -1211,8 +1206,9 @@
   // Perform a deep comparison to check if two objects are equal.
   _.isEqual = function(a, b) {
       if (a === b) return a !== 0 || 1 / a === 1 / b;
-      if (typeof a != 'object' && typeof b != 'object') return a != a && b != b;
-      return a != null && b != null && deepEq(a, b);
+      var typeA = typeof a;
+      return typeA != 'function' && typeA != 'object' && typeof b != 'object' ?
+        a != a && b != b : a != null && b != null &&  deepEq(a, b);
   };
 
   // Is a given array, string, or object empty?

--- a/underscore.js
+++ b/underscore.js
@@ -1201,9 +1201,7 @@
       // Identical objects are equal. `0 === -0`, but they aren't identical.
       // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
       if (a === b) return a !== 0 || 1 / a === 1 / b;
-      var typeA = typeof a;
-      if( typeA != typeof b ) return false;
-      if( typeA == 'object' ) return a && b ? eq( a, b ) : a === b;
+      if( ( typeof a == 'object' || typeof b == 'object' ) && a != null && b != null ) return eq( a, b );
       return a != a ? b != b : a === b;
   };
 

--- a/underscore.js
+++ b/underscore.js
@@ -1113,9 +1113,9 @@
     // Identical objects are equal. `0 === -0`, but they aren't identical.
     // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
     if (a === b) return a !== 0 || 1 / a === 1 / b;
-    if (a == null || b == null) return a === b;
-
     if( typeof a != 'object' && typeof b != 'object' ) return a != a ? b != b : a === b;
+
+    if (a == null || b == null) return a === b;
 
     // Unwrap any wrapped objects.
     if (a instanceof _) a = a._wrapped;

--- a/underscore.js
+++ b/underscore.js
@@ -1110,6 +1110,13 @@
 
   // Internal recursive comparison function for `isEqual`.
   var eq = function(a, b, aStack, bStack) {
+    // Identical objects are equal. `0 === -0`, but they aren't identical.
+    // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
+    if (a === b) return a !== 0 || 1 / a === 1 / b;
+    if (a == null || b == null) return a === b;
+
+    if( typeof a != 'object' && typeof b != 'object' ) return a != a ? b != b : a === b;
+
     // Unwrap any wrapped objects.
     if (a instanceof _) a = a._wrapped;
     if (b instanceof _) b = b._wrapped;
@@ -1198,12 +1205,7 @@
 
   // Perform a deep comparison to check if two objects are equal.
   _.isEqual = function(a, b) {
-      // Identical objects are equal. `0 === -0`, but they aren't identical.
-      // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
-      if (a === b) return a !== 0 || 1 / a === 1 / b;
-      if (a == null || b == null) return a === b;
-      if( typeof a == 'object' || typeof b == 'object' ) return eq( a, b );
-      return a != a ? b != b : a === b;
+      return eq( a, b );
   };
 
   // Is a given array, string, or object empty?

--- a/underscore.js
+++ b/underscore.js
@@ -1109,19 +1109,19 @@
 
 
   // Internal recursive comparison function for `isEqual`.
-  var eq = function(a, b, aStack, bStack) {
+  var deepEq, eq = function(a, b, aStack, bStack) {
       // Identical objects are equal. `0 === -0`, but they aren't identical.
       // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
       if (a === b) return a !== 0 || 1 / a === 1 / b;
 
       // if objects are of primitive types, they are not equal unless both of them are NaNs.
-      if( typeof a != 'object' && typeof b != 'object' ) return a != a && b != b;
+      if (typeof a != 'object' && typeof b != 'object') return a != a && b != b;
 
       // if any of a or b is null, objects are not equal.
-      return a != null && b != null && deepEq( a, b, aStack, bStack );
-  }
+      return a != null && b != null && deepEq(a, b, aStack, bStack);
+  };
 
-  var deepEq = function(a, b, aStack, bStack) {
+  deepEq = function(a, b, aStack, bStack) {
     // Unwrap any wrapped objects.
     if (a instanceof _) a = a._wrapped;
     if (b instanceof _) b = b._wrapped;
@@ -1211,8 +1211,8 @@
   // Perform a deep comparison to check if two objects are equal.
   _.isEqual = function(a, b) {
       if (a === b) return a !== 0 || 1 / a === 1 / b;
-      if( typeof a != 'object' && typeof b != 'object' ) return a != a && b != b;
-      return a != null && b != null && deepEq( a, b );
+      if (typeof a != 'object' && typeof b != 'object') return a != a && b != b;
+      return a != null && b != null && deepEq(a, b);
   };
 
   // Is a given array, string, or object empty?

--- a/underscore.js
+++ b/underscore.js
@@ -1203,7 +1203,10 @@
 
   // Perform a deep comparison to check if two objects are equal.
   _.isEqual = function(a, b) {
-    return eq(a, b);
+      var typeA = typeof a;
+      if( typeA != typeof b ) return false;
+      if( typeA == 'object' ) return a && b ? eq( a, b ) : a === b;
+      return a === 0 || a != a ? eq(a, b) : a === b;
   };
 
   // Is a given array, string, or object empty?

--- a/underscore.js
+++ b/underscore.js
@@ -1110,11 +1110,6 @@
 
   // Internal recursive comparison function for `isEqual`.
   var eq = function(a, b, aStack, bStack) {
-    // Identical objects are equal. `0 === -0`, but they aren't identical.
-    // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
-    if (a === b) return a !== 0 || 1 / a === 1 / b;
-    // A strict comparison is necessary because `null == undefined`.
-    if (a == null || b == null) return a === b;
     // Unwrap any wrapped objects.
     if (a instanceof _) a = a._wrapped;
     if (b instanceof _) b = b._wrapped;
@@ -1203,6 +1198,9 @@
 
   // Perform a deep comparison to check if two objects are equal.
   _.isEqual = function(a, b) {
+      // Identical objects are equal. `0 === -0`, but they aren't identical.
+      // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
+      if (a === b) return a !== 0 || 1 / a === 1 / b;
       var typeA = typeof a;
       if( typeA != typeof b ) return false;
       if( typeA == 'object' ) return a && b ? eq( a, b ) : a === b;

--- a/underscore.js
+++ b/underscore.js
@@ -1204,7 +1204,7 @@
       var typeA = typeof a;
       if( typeA != typeof b ) return false;
       if( typeA == 'object' ) return a && b ? eq( a, b ) : a === b;
-      return a === 0 || a != a ? eq(a, b) : a === b;
+      return a != a ? b != b : a === b;
   };
 
   // Is a given array, string, or object empty?

--- a/underscore.js
+++ b/underscore.js
@@ -1110,12 +1110,18 @@
 
   // Internal recursive comparison function for `isEqual`.
   var eq = function(a, b, aStack, bStack) {
-    // Identical objects are equal. `0 === -0`, but they aren't identical.
-    // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
-    if (a === b) return a !== 0 || 1 / a === 1 / b;
-    if( typeof a != 'object' && typeof b != 'object' ) return a != a && b != b;
-    if (a == null || b == null) return false;
+      // Identical objects are equal. `0 === -0`, but they aren't identical.
+      // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
+      if (a === b) return a !== 0 || 1 / a === 1 / b;
 
+      // if objects are of primitive types, they are not equal unless both of them are NaNs.
+      if( typeof a != 'object' && typeof b != 'object' ) return a != a && b != b;
+
+      // if any of a or b is null, objects are not equal.
+      return a != null && b != null && deepEq( a, b, aStack, bStack );
+  }
+
+  var deepEq = function(a, b, aStack, bStack) {
     // Unwrap any wrapped objects.
     if (a instanceof _) a = a._wrapped;
     if (b instanceof _) b = b._wrapped;
@@ -1204,9 +1210,7 @@
 
   // Perform a deep comparison to check if two objects are equal.
   _.isEqual = function(a, b) {
-      if (a === b) return a !== 0 || 1 / a === 1 / b;
-      if( typeof a != 'object' && typeof b != 'object' ) return a != a && b != b;
-      return a != null && b != null && eq( a, b );
+      return eq( a, b );
   };
 
   // Is a given array, string, or object empty?

--- a/underscore.js
+++ b/underscore.js
@@ -1201,7 +1201,8 @@
       // Identical objects are equal. `0 === -0`, but they aren't identical.
       // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
       if (a === b) return a !== 0 || 1 / a === 1 / b;
-      if( ( typeof a == 'object' || typeof b == 'object' ) && a != null && b != null ) return eq( a, b );
+      if (a == null || b == null) return a === b;
+      if( typeof a == 'object' || typeof b == 'object' ) return eq( a, b );
       return a != a ? b != b : a === b;
   };
 


### PR DESCRIPTION
Optimized isEqual for speed on primitive types. Now it's multiple times faster than lodash in all browsers.

Performance of isEqual is critical for Backbone.Model.set performance.

http://jsperf.com/underscore-isequal/5

Integer comparison:
Chrome: 70x faster 
Firefox: 50x faster
Safari: 140x faster