### PR TITLE
Optimize _.isEqual for primatives

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1115,6 +1115,15 @@
     if (a === b) return a !== 0 || 1 / a === 1 / b;
     // A strict comparison is necessary because `null == undefined`.
     if (a == null || b == null) return a === b;
+    // `NaN`s are equivalent, but non-reflexive.
+    if (a !== a) return b !== b;
+    // Exhaust primitive checks
+    var type = typeof a;
+    if (type !== 'function' && type !== 'object' && typeof b !== 'object') return false;
+    return deepEq(a, b, aStack, bStack);
+  };
+
+  var deepEq = function(a, b, aStack, bStack) {
     // Unwrap any wrapped objects.
     if (a instanceof _) a = a._wrapped;
     if (b instanceof _) b = b._wrapped;


### PR DESCRIPTION
#2180 got micro-opty, but we can still speed up `_.isEqual` with acceptable changes.

I'm stealing a page from lodash and splitting `eq()` and `deepEq()`. Yes, I [waffled](https://github.com/jashkenas/underscore/pull/2180#issuecomment-102730045) about creating another function, but we're able to not duplicate checks and get a [30x speed boost](http://jsperf.com/underscore-isequal/9) with primitives.