### PR TITLE
adds coverage reporting and badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 *.log
 *.idea
 *.swp
+nyc_output
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,4 @@ env:
   - secure: bDZSBQfqr21hCayjcZ20IxrV6+XGhxQPFIfwWqEKLrF93Gu8LLVjZRxXE/mE8I8N4Z5WtDNb4ZHrm/TTzmcPa5MuHgIxEdknQCncobH8oimwc83SHwEPk6okeNKl39VlCjvvnmoe/V/KpnknuYn3Rqghtl/Uv9KLpCwskwjTtcw=
   - secure: SRECgXuwcZTcD3GVxTS2bYNgRyye4vq6BLrV2PH9FyNenowsKQR2EwlC/dppc1Q8NWMgv79J/R96q9JOFh+mEH9L5dlBb2yhnGH8amVeM/ChAJHT/F8YktKM453uVpz5fR00QcCQDDUOx6Pvx374ID0OKNpWKAkQBWA9mPTsLnE=
   matrix: BROWSER=false
+after_success: npm run coveralls

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
                                                                                    \/___/
 
 [![Build Status](https://travis-ci.org/jashkenas/underscore.png)](https://travis-ci.org/jashkenas/underscore)
-[![Coverage Status](https://coveralls.io/repos/jashkenas/underscore/badge.svg?branch=)](https://coveralls.io/r/bcoe/underscore?branch=)
+[![Coverage Status](https://coveralls.io/repos/jashkenas/underscore/badge.svg?branch=)](https://coveralls.io/r/jashkenas/underscore?branch=)
 
 Underscore.js is a utility-belt library for JavaScript that provides
 support for the usual functional suspects (each, map, reduce, filter...)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
                                                                                   \ \____/
                                                                                    \/___/
 
+[![Build Status](https://travis-ci.org/jashkenas/underscore.png)](https://travis-ci.org/jashkenas/underscore)
+[![Coverage Status](https://coveralls.io/repos/jashkenas/underscore/badge.svg?branch=)](https://coveralls.io/r/bcoe/underscore?branch=)
+
 Underscore.js is a utility-belt library for JavaScript that provides
 support for the usual functional suspects (each, map, reduce, filter...)
 without extending any core JavaScript objects.

--- a/package.json
+++ b/package.json
@@ -17,16 +17,20 @@
   "main": "underscore.js",
   "version": "1.8.3",
   "devDependencies": {
+    "coveralls": "^2.11.2",
     "docco": "*",
     "eslint": "0.6.x",
     "karma": "~0.12.31",
     "karma-qunit": "~0.1.4",
+    "nyc": "^2.1.3",
     "qunit-cli": "~0.2.0",
     "uglify-js": "2.4.x"
   },
   "scripts": {
     "test": "npm run test-node && npm run lint",
     "lint": "eslint underscore.js test/*.js",
+    "coverage": "nyc npm run test-node && nyc report",
+    "coveralls": "nyc npm run test-node && nyc report --reporter=text-lcov | coveralls",
     "test-node": "qunit-cli test/*.js",
     "test-browser": "npm i karma-phantomjs-launcher && ./node_modules/karma/bin/karma start",
     "build": "uglifyjs underscore.js -c \"evaluate=false\" --comments \"/    .*/\" -m --source-map underscore-min.map -o underscore-min.js",


### PR DESCRIPTION
This pull adds coverage and build status badges. Coverage is facilitated by [nyc](https://www.npmjs.com/package/nyc) and the hosted coverage service coveralls.io.

* run `npm run coverage` to get a human readable coverage report.
* run `npm run coverage -- --reporter=lcov` to get an HTML report over coverage in the /coverage folder.
* run `npm run coveralls` to report coverage to the [coveralls.io](https://coveralls.io/).
  * you'll need to setup your repo on coveralls.io and grap the `COVERALLS_REPO_TOKEN`.
  * on travis-ci.org, you'll need to set an environment variable with the value of `COVERALLS_REPO_TOKEN `