### PR TITLE
Added a _.reverse array method with a variable argument.

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -41,6 +41,17 @@
     deepEqual(result, [2, 3, 4], 'works on arguments object');
   });
 
+  test('reverse', function() {
+    var numbers = [0, 1, 2, 3 ,4];
+    deepEqual(_.reverse(numbers), [4, 3, 2, 1, 0], 'working reverse()');
+    deepEqual(_.reverse(numbers, -1), [0, 1, 2, 3 ,4], 'working reverse(-1)');
+    deepEqual(_.reverse(numbers, 0), [0, 1, 2, 3 ,4], 'working reverse(0)');
+    deepEqual(_.reverse(numbers, 1), [0, 1, 2, 3 ,4], 'working reverse(1)');
+    deepEqual(_.reverse(numbers, 3), [2, 1, 0, 3 ,4], 'working reverse(3)');
+    deepEqual(_.reverse(numbers, 5), [4, 3, 2, 1, 0], 'working reverse(5)');
+    deepEqual(_.reverse(numbers, 6), [4, 3, 2, 1, 0], 'working reverse(6)');
+  });
+
   test('tail', function() {
     strictEqual(_.rest, _.tail, 'alias for rest');
   });

--- a/underscore.js
+++ b/underscore.js
@@ -489,13 +489,13 @@
   _.reverse = _.flip = function(array, n, guard) {
 	  if (array == null) return void 0;
 	  var revarray = [];
-	  if (n == null || guard) {
-		  while ( (i = array.shift()) != undefined ) { revarray.unshift(i); };
+	  if (n == null || n >= array.length || guard) {
+      _.times(array.length, function(i) { revarray.unshift(array[i])});
 		  return revarray;
 	  }
 	  else {
-		  _.times(n, function() { revarray.unshift(array.shift()) } );
-		  return revarray.concat(array);
+		  _.times(Math.max(0, n), function(i) { revarray.unshift(array[i]) } );
+		  return revarray.concat(array.slice(Math.max(0, n)));
 	  }
   };
 

--- a/underscore.js
+++ b/underscore.js
@@ -488,9 +488,7 @@
   // Passing an **n** will return a copy of array with the first N entries reversed.
   _.reverse = _.flip = function(array, n, guard) {
 	  if (array == null) return void 0;
-	  var copy = array.slice();
 	  if (n == null || n >= array.length || guard) return array.slice().reverse();
-		  // _.times(Math.max(0, n), function(i) { revarray.unshift(array[i]) } );
 		return array.slice(0, Math.max(0, n)).reverse().concat(array.slice(Math.max(0,n)));
   };
 

--- a/underscore.js
+++ b/underscore.js
@@ -483,6 +483,21 @@
   _.rest = _.tail = _.drop = function(array, n, guard) {
     return slice.call(array, n == null || guard ? 1 : n);
   };
+  
+  // Returns a copy of the reversed array. Aliased as `flip`.
+  // Passing an **n** will return a copy of array with the first N entries reversed.
+  _.reverse = _.flip = function(array, n, guard) {
+	  if (array == null) return void 0;
+	  var revarray = [];
+	  if (n == null || guard) {
+		  while ( (i = array.shift()) != undefined ) { revarray.unshift(i); };
+		  return revarray;
+	  }
+	  else {
+		  _.times(n, function() { revarray.unshift(array.shift()) } );
+		  return revarray.concat(array);
+	  }
+  };
 
   // Trim out all falsy values from an array.
   _.compact = function(array) {

--- a/underscore.js
+++ b/underscore.js
@@ -488,15 +488,10 @@
   // Passing an **n** will return a copy of array with the first N entries reversed.
   _.reverse = _.flip = function(array, n, guard) {
 	  if (array == null) return void 0;
-	  var revarray = [];
-	  if (n == null || n >= array.length || guard) {
-      _.times(array.length, function(i) { revarray.unshift(array[i])});
-		  return revarray;
-	  }
-	  else {
-		  _.times(Math.max(0, n), function(i) { revarray.unshift(array[i]) } );
-		  return revarray.concat(array.slice(Math.max(0, n)));
-	  }
+	  var copy = array.slice();
+	  if (n == null || n >= array.length || guard) return array.slice().reverse();
+		  // _.times(Math.max(0, n), function(i) { revarray.unshift(array[i]) } );
+		return array.slice(0, Math.max(0, n)).reverse().concat(array.slice(Math.max(0,n)));
   };
 
   // Trim out all falsy values from an array.


### PR DESCRIPTION
Added a `_.reverse` (aliased `_.flip`) array method to *underscore.js*; and the unit tests to *test/array.js*.
Returns a copy of the reversed array. Aliased as `flip`.
Passing an **n** will return a copy of array with the first N entries reversed.
Example usage:
```
_.reverse([0, 1, 2, 3, 4])
=> [4, 3, 2, 1, 0]
_.reverse([0, 1, 2, 3, 4], 3)
=> [2, 1, 0, 3, 4]
```
