### PR TITLE
Remove nativeBind usage

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -17,7 +17,7 @@
   var previousUnderscore = root._;
 
   // Save bytes in the minified (but not gzipped) version:
-  var ArrayProto = Array.prototype, ObjProto = Object.prototype, FuncProto = Function.prototype;
+  var ArrayProto = Array.prototype, ObjProto = Object.prototype;
 
   // Create quick reference variables for speed access to core prototypes.
   var
@@ -31,7 +31,6 @@
   var
     nativeIsArray = Array.isArray,
     nativeKeys = Object.keys,
-    nativeBind = FuncProto.bind,
     nativeCreate = Object.create;
 
   // Naked function reference for surrogate-prototype-swapping.
@@ -711,15 +710,13 @@
   // Create a function bound to a given object (assigning `this`, and arguments,
   // optionally). Delegates to **ECMAScript 5**'s native `Function.bind` if
   // available.
-  _.bind = function(func, context) {
-    if (nativeBind && func.bind === nativeBind) return nativeBind.apply(func, slice.call(arguments, 1));
+  _.bind = restArgs(function(func, context, args) {
     if (!_.isFunction(func)) throw new TypeError('Bind must be called on a function');
-    var args = slice.call(arguments, 2);
     var bound = restArgs(function(callArgs) {
       return executeBound(func, bound, context, this, args.concat(callArgs));
     });
     return bound;
-  };
+  });
 
   // Partially apply a function by creating a version that has had some of its
   // arguments pre-filled, without changing its dynamic `this` context. _ acts


### PR DESCRIPTION
We cover almost all of nativeBind's cases:
- Binding function to context
- Binding function to context with args
- Binding constructor with args

The only downside is supported environments will no longer get the correct `length` property of the bound method. Usually, you subtract the number of bound args from `func`'s length. But, now Underscore is consistent between all environments.

http://jsperf.com/native-bind-vs-underscore/2

Re: #2197
