### PR TITLE
Alias restArgs as restParam

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -620,4 +620,8 @@
     }, 0)(1, 2, 3, 4);
   });
 
+  test('restParam', function() {
+    strictEqual(_.restParam, _.restArgs, 'Should be aliased');
+  });
+
 }());

--- a/underscore.js
+++ b/underscore.js
@@ -902,7 +902,7 @@
   // often you call it. Useful for lazy initialization.
   _.once = _.partial(_.before, 2);
 
-  _.restArgs = restArgs;
+  _.restParam = _.restArgs = restArgs;
 
   // Object Functions
   // ----------------


### PR DESCRIPTION
Closes #2209 

Related issue (where name was discussed) #2140 

In the name of lodash/underdash compatibility I think we should probably drop `restArgs` in favour of  `restParam` which is closer to what is described in the JavaScript spec (`rest` parameter). The counter argument is we call them args elsewhere in the library.

Otherwise an alias should be sufficient.