### PR TITLE
Fix typo in comment

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1479,7 +1479,7 @@
         source += "';\n" + evaluate + "\n__p+='";
       }
 
-      // Adobe VMs need the match returned to produce the correct offest.
+      // Adobe VMs need the match returned to produce the correct offset.
       return match;
     });
     source += "';\n";


### PR DESCRIPTION
Noticed a small typo while checking something in the source. s/offest/offset