### PR TITLE
_.defaults() does not initialize for undefined/null

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -262,8 +262,8 @@
 
     equal(options.a, 1, 'should not error on `null` or `undefined` sources');
 
-    strictEqual(_.defaults(null, {a: 1}), null, 'result is null if destination is null');
-    strictEqual(_.defaults(void 0, {a: 1}), void 0, 'result is undefined if destination is undefined');
+    deepEqual(_.defaults(null, {a: 1}), {a: 1}, 'defaults skips nulls');
+    deepEqual(_.defaults(void 0, {a: 1}), {a: 1}, 'defaults skips undefined');
   });
 
   test('clone', function() {

--- a/underscore.js
+++ b/underscore.js
@@ -1008,9 +1008,10 @@
   };
 
   // An internal function for creating assigner functions.
-  var createAssigner = function(keysFunc, undefinedOnly) {
+  var createAssigner = function(keysFunc, defaults) {
     return function(obj) {
       var length = arguments.length;
+      if (defaults) obj = Object(obj);
       if (length < 2 || obj == null) return obj;
       for (var index = 1; index < length; index++) {
         var source = arguments[index],
@@ -1018,7 +1019,7 @@
             l = keys.length;
         for (var i = 0; i < l; i++) {
           var key = keys[i];
-          if (!undefinedOnly || obj[key] === void 0) obj[key] = source[key];
+          if (!defaults || obj[key] === void 0) obj[key] = source[key];
         }
       }
       return obj;


### PR DESCRIPTION
Fixes issue https://github.com/jashkenas/underscore/issues/2115. Defaults null and undefined objects correctly.

Paired with @jridgewell and @djrconcepts!