### PR TITLE
Iterate functions as objects

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -148,18 +148,17 @@
   test('Iterate function as object', function() {
     //github issue #1992: collection methods should not iterate functions as arrays but as objects
 
-    var collection_methods = ['each','map','reduce','reduceRight','find','filter','where','findWhere','reject','every','some','contains','pluck','max','min','sortBy','groupBy','indexBy','countBy','shuffle','sample','toArray','size','partition'];
-    collection_methods.map(iterate_function_as_object);
+    var collectionMethods = ['each', 'map', 'reduce', 'reduceRight', 'find', 'filter', 'where', 'findWhere', 'reject', 'every', 'some', 'contains', 'pluck', 'max', 'min', 'sortBy', 'groupBy', 'indexBy', 'countBy', 'shuffle', 'sample', 'toArray', 'size', 'partition'];
+    _.each(collectionMethods, iterateFunctionAsObject);
 
-    function iterate_function_as_object(method) {
-
-      var fn = function(a, b, c) {};
+    function iterateFunctionAsObject(method) {
+      var fn = function(a, b, c) {a = b = c;};
       fn.foo = 'bar';
-      _[method](fn, function(value,key) {
-        strictEqual(key+value, 'foobar', '_.' + method + ' iterates function as object');
+
+      _[method](fn, function(value, key) {
+        strictEqual(key + value, 'foobar', '_.' + method + ' iterates function as object');
       });
     }
-
   });
 
   test('map', function() {

--- a/test/collections.js
+++ b/test/collections.js
@@ -145,6 +145,23 @@
     });
   });
 
+  test('Iterate function as object', function() {
+    //github issue #1992: collection methods should not iterate functions as arrays but as objects
+
+    var collection_methods = ['each','map','reduce','reduceRight','find','filter','where','findWhere','reject','every','some','contains','pluck','max','min','sortBy','groupBy','indexBy','countBy','shuffle','sample','toArray','size','partition'];
+    collection_methods.map(iterate_function_as_object);
+
+    function iterate_function_as_object(method) {
+
+      var fn = function(a, b, c) {};
+      fn.foo = 'bar';
+      _[method](fn, function(value,key) {
+        strictEqual(key+value, 'foobar', '_.' + method + ' iterates function as object');
+      });
+    }
+
+  });
+
   test('map', function() {
     var doubled = _.map([1, 2, 3], function(num){ return num * 2; });
     deepEqual(doubled, [2, 4, 6], 'doubled numbers');

--- a/underscore.js
+++ b/underscore.js
@@ -143,7 +143,7 @@
   var MAX_ARRAY_INDEX = Math.pow(2, 53) - 1;
   var getLength = property('length');
   var isArrayLike = function(collection) {
-    if ( typeof collection === 'function' && collection.constructor !== root.NodeList ) return false;
+    if ( typeof collection === 'function' && Object.prototype.toString.call(collection) !== '[object NodeList]' ) return false;
     var length = getLength(collection);
     return typeof length == 'number' && length >= 0 && length <= MAX_ARRAY_INDEX;
   };

--- a/underscore.js
+++ b/underscore.js
@@ -143,6 +143,7 @@
   var MAX_ARRAY_INDEX = Math.pow(2, 53) - 1;
   var getLength = property('length');
   var isArrayLike = function(collection) {
+    if (typeof collection === 'function') return false;
     var length = getLength(collection);
     return typeof length == 'number' && length >= 0 && length <= MAX_ARRAY_INDEX;
   };

--- a/underscore.js
+++ b/underscore.js
@@ -143,7 +143,7 @@
   var MAX_ARRAY_INDEX = Math.pow(2, 53) - 1;
   var getLength = property('length');
   var isArrayLike = function(collection) {
-    if (typeof collection === 'function') return false;
+    if ( typeof collection === 'function' && !(collection instanceof window.NodeList) ) return false;
     var length = getLength(collection);
     return typeof length == 'number' && length >= 0 && length <= MAX_ARRAY_INDEX;
   };

--- a/underscore.js
+++ b/underscore.js
@@ -143,7 +143,7 @@
   var MAX_ARRAY_INDEX = Math.pow(2, 53) - 1;
   var getLength = property('length');
   var isArrayLike = function(collection) {
-    if ( typeof collection === 'function' && !(collection instanceof window.NodeList) ) return false;
+    if ( typeof collection === 'function' && collection.constructor !== root.NodeList ) return false;
     var length = getLength(collection);
     return typeof length == 'number' && length >= 0 && length <= MAX_ARRAY_INDEX;
   };

--- a/underscore.js
+++ b/underscore.js
@@ -143,7 +143,8 @@
   var MAX_ARRAY_INDEX = Math.pow(2, 53) - 1;
   var getLength = property('length');
   var isArrayLike = function(collection) {
-    if ( typeof collection === 'function' && Object.prototype.toString.call(collection) !== '[object NodeList]' ) return false;
+    if ( typeof collection === 'function' && toString.call(collection) === '[object Function]' ) return false;
+
     var length = getLength(collection);
     return typeof length == 'number' && length >= 0 && length <= MAX_ARRAY_INDEX;
   };


### PR DESCRIPTION
fixes #1992: Collections should not iterate functions as array-likes

Paired with @jridgewell, @alewiscondev.
