### PR TITLE
_.omit maps keys to String, _.pick should as well

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1056,7 +1056,7 @@
       keys = _.allKeys(obj);
     } else {
       iteratee = keyInObj;
-      keys = flatten(keys, false, false);
+      keys = _.map(flatten(keys, false, false), String);
       obj = Object(obj);
     }
     for (var i = 0, length = keys.length; i < length; i++) {


### PR DESCRIPTION
Making `_.pick` convert keys to `String` as well, to match the behavior of `_.omit`.