### PR TITLE
Simplify - reduces nested array complexity to depth 1

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -79,6 +79,10 @@
     equal(result, 3, 'works on an arguments object');
   });
 
+  test('simplify', function() {
+    deepEqual(_.simplify([[1, 2, 3], [2, 3, 4], [[[3, 4, 5], [6, 7, 8]]]]), [[1, 2, 3], [2, 3, 4], [3, 4, 5], [6, 7, 8]], 'should simplify array as expected');
+  });
+
   test('flatten', function() {
     deepEqual(_.flatten(null), [], 'Flattens supports null');
     deepEqual(_.flatten(void 0), [], 'Flattens supports undefined');

--- a/underscore.js
+++ b/underscore.js
@@ -225,6 +225,22 @@
     if (key !== void 0 && key !== -1) return obj[key];
   };
 
+
+  _.simplify = function(paramArr) {
+    var changed;
+    var arr = _.clone(paramArr);
+    var simplified;
+    do {
+      simplified = [];
+      changed = false;
+      _.each(arr, function(item) {
+        simplified.push.apply(simplified, (changed = _.isArray(item) && _.every(item, _.isArray)) ? item : [item]);
+      });
+      arr = simplified;
+    } while (changed)
+    return simplified;
+  };
+
   // Return all the elements that pass a truth test.
   // Aliased as `select`.
   _.filter = _.select = function(obj, predicate, context) {


### PR DESCRIPTION
_.simplify([[1, 2, 3], [2, 3, 4], [[[3, 4, 5], [6, 7, 8]]]])

=> [[1, 2, 3], [2, 3, 4], [3, 4, 5], [6, 7, 8]]