### PR TITLE
Add a navigational link to the sidebar for _.isError

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,6 +307,7 @@
       <li>- <a href="#isBoolean">isBoolean</a></li>
       <li>- <a href="#isDate">isDate</a></li>
       <li>- <a href="#isRegExp">isRegExp</a></li>
+      <li>- <a href="#isError">isError</a></li>
       <li>- <a href="#isNaN">isNaN</a></li>
       <li>- <a href="#isNull">isNull</a></li>
       <li>- <a href="#isUndefined">isUndefined</a></li>


### PR DESCRIPTION
`_.isError` is documented but not in the sidebar.

// checked for other 1.8.x new features as well