### PR TITLE
Add input validation for _.partial

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -739,6 +739,9 @@
   // as a placeholder by default, allowing any combination of arguments to be
   // pre-filled. Set `_.partial.placeholder` for a custom placeholder argument.
   _.partial = restArgs(function(func, boundArgs) {
+    if (typeof func !== 'function') {
+      throw new Error('partial must be passed a function');
+    }
     var placeholder = _.partial.placeholder;
     var bound = function() {
       var position = 0, length = boundArgs.length;


### PR DESCRIPTION
At first you may think this is not needed, since the error might surface from inside, when the function is empty, but it makes problem when combines with promises (timers/delayed functions).
Without it, I got an exception such as:

```
undefined is not a function
    at executeBound (node_modules\underscore\underscore.js:701:67)
    at bound (node_modules\underscore\underscore.js:733:14)
    at tryCatcher (node_modules\bluebird\js\main\util.js:24:31)
    at Promise._settlePromiseFromHandler (node_modules\bluebird\js\main\promise.js:454:31)
    at Promise._settlePromiseAt (node_modules\bluebird\js\main\promise.js:530:18)
    at Promise._settlePromises (node_modules\bluebird\js\main\promise.js:646:14)
    at Async._drainQueue (node_modules\bluebird\js\main\async.js:182:16)
    at Async._drainQueues (node_modules\bluebird\js\main\async.js:192:10)
    at Immediate.Async.drainQueues [as _onImmediate] (node_modules\bluebird\js\main\async.js:15:14)
    at processImmediate [as _immediateCallback] (timers.js:367:17) - TypeError: undefined is not a function
```

As you can see, this doesn't tell me anything on where my code is actually wrong;
When we throw the error from the _.partial() function instead, I can see the correct stacktrace, where I actually gave a non-function variable to _.partial().
