### PR TITLE
syntax fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -1131,7 +1131,7 @@ var buttonView = {
 };
 _.bindAll(buttonView, 'onClick', 'onHover');
 // When the button is clicked, this.label will have the correct value.
-jQuery('#underscore_button').bind('click', buttonView.onClick);
+jQuery('#underscore_button').on('click', buttonView.onClick);
 </pre>
 
       <p id="partial">


### PR DESCRIPTION
change example syntax fom `bind` to `on`, since they are functionally equivalent, and the use of `bind` was causing fellow readers some confusion when used as part of the example for the `_.bindAll` function

