### PR TITLE
Fix bug when iterating object literal with 'length' key

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -30,6 +30,12 @@
     _.each(obj, function(){ count++; });
     assert.equal(count, 3, 'the fun should be called only 3 times');
 
+    obj = {'length': 1};
+    _.each(obj, function(value, key) {
+      assert.equal(value, 1, 'objects with the key `length` are iterated correctly');
+      assert.equal(key, 'length', 'objects with the key `length` are iterated correctly');
+    });
+
     var answer = null;
     _.each([1, 2, 3], function(num, index, arr){ if (_.include(arr, num)) answer = true; });
     assert.ok(answer, 'can reference the original collection from inside the iterator');

--- a/underscore.js
+++ b/underscore.js
@@ -159,7 +159,7 @@
   _.each = _.forEach = function(obj, iteratee, context) {
     iteratee = optimizeCb(iteratee, context);
     var i, length;
-    if (isArrayLike(obj)) {
+    if (isArrayLike(obj) && _.indexOf(_.keys(obj), 'length') < 0) {
       for (i = 0, length = obj.length; i < length; i++) {
         iteratee(obj[i], i, obj);
       }


### PR DESCRIPTION
This fixes an issue when using `_.each` to iterate over an object that contains the key "length"

Before:

```JavaScript
_.each({"length": 3}, function(value, key){
  console.log(key, value)
})

// => 0 undefined
// => 1 undefined
// => 2 undefined
```

After: 

```JavaScript
_.each({"length": 3}, function(value, key){
  console.log(key, value)
})

// => "length" 3
```

I'd appreciate feedback from anyone who knows a more elegant way to determine if an object contains the key `length` and not the property length since JavaScript doesn't differentiate between property access and accessing an object key.