### PR TITLE
Use karma concurrency for initiating parallel sauce tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,7 @@ before_script:
 script:
   - npm test
   - "[ $BROWSER == false ] || npm run test-browser"
-  # Karma sauce is limited to running about 5-7 browsers (or it will tiemout) at a time so we just run vendor by vendor here
-  - "[ $BROWSER == false ] || karma start karma.conf-sauce.js --browsers FIREFOX_V4,FIREFOX_V11,FIREFOX_V20,FIREFOX_V30,FIREFOX_V35"
-  - "[ $BROWSER == false ] || karma start karma.conf-sauce.js --browsers CHROME_V28,CHROME_V35,CHROME_V40,ANDROID_V4.0,ANDROID_V4.3"
-  - "[ $BROWSER == false ] || karma start karma.conf-sauce.js --browsers INTERNET_EXPLORER_V9,INTERNET_EXPLORER_V10,INTERNET_EXPLORER_V11,MICROSOFTEDGE_V20.10240"
-  - "[ $BROWSER == false ] || karma start karma.conf-sauce.js --browsers SAFARI_V5,SAFARI_V6,SAFARI_V7"
-  - "[ $BROWSER == false ] || karma start karma.conf-sauce.js --browsers OPERA_V11,OPERA_V12"
+  - "[ $BROWSER == false ] || karma start karma.conf-sauce.js"
 notifications:
   email: false
 env:

--- a/karma.conf-sauce.js
+++ b/karma.conf-sauce.js
@@ -4,32 +4,34 @@ var _ = require('./');
 var sauceBrowsers = _.reduce([
   ['firefox', '35'],
   ['firefox', '30'],
-  ['firefox', '20'],
+  ['firefox', '21'],
   ['firefox', '11'],
   ['firefox', '4'],
 
   ['chrome', '40'],
-  ['chrome', '35'],
-  ['chrome', '28'],
+  ['chrome', '39'],
+  ['chrome', '31'],
+  ['chrome', '26'],
 
-  ['microsoftedge', '20.10240', 'Windows 10'],
+  ['microsoftedge', '20', 'Windows 10'],
   ['internet explorer', '11', 'Windows 10'],
   ['internet explorer', '10', 'Windows 8'],
   ['internet explorer', '9', 'Windows 7'],
-  // Currently do not work with Karma.
-  // ['internet explorer', '8', 'Windows 7'],
-  // ['internet explorer', '7', 'Windows XP'],
+  ['internet explorer', '8'],
+  ['internet explorer', '7', 'Windows XP'],
   // ['internet explorer', '6', 'Windows XP'],
 
   ['opera', '12'],
   ['opera', '11'],
 
-  ['android', '4.3'],
+  ['android', '5'],
+  ['android', '4.4'],
+  ['android', '4.3'], 
   ['android', '4.0'],
 
-  ['safari', '8'],
-  ['safari', '6'],
+  ['safari', '8.0', 'OS X 10.10'],
   ['safari', '7'],
+  ['safari', '6'],
   ['safari', '5']
 ], function(memo, platform) {
   var label = (platform[0] + '_v' + platform[1]).replace(' ', '_').toUpperCase();
@@ -59,6 +61,10 @@ module.exports = function(config) {
       'underscore.js',
       'test/*.js'
     ],
+
+    // Number of sauce tests to start in parallel
+    concurrency: 2,
+
     // test results reporter to use
     reporters: ['dots', 'saucelabs'],
     port: 9876,

--- a/karma.conf-sauce.js
+++ b/karma.conf-sauce.js
@@ -13,20 +13,21 @@ var sauceBrowsers = _.reduce([
   ['chrome', '31'],
   ['chrome', '26'],
 
-  ['microsoftedge', '20', 'Windows 10'],
+  ['microsoftedge', '20.10240', 'Windows 10'],
   ['internet explorer', '11', 'Windows 10'],
   ['internet explorer', '10', 'Windows 8'],
   ['internet explorer', '9', 'Windows 7'],
   ['internet explorer', '8'],
-  ['internet explorer', '7', 'Windows XP'],
-  // ['internet explorer', '6', 'Windows XP'],
+  // Currently karma-sauce has issues with sockets and these browsers
+  // ['internet explorer', '7'],
+  // ['internet explorer', '6'],
 
   ['opera', '12'],
   ['opera', '11'],
 
   ['android', '5'],
   ['android', '4.4'],
-  ['android', '4.3'], 
+  ['android', '4.3'],
   ['android', '4.0'],
 
   ['safari', '8.0', 'OS X 10.10'],
@@ -34,7 +35,12 @@ var sauceBrowsers = _.reduce([
   ['safari', '6'],
   ['safari', '5']
 ], function(memo, platform) {
-  var label = (platform[0] + '_v' + platform[1]).replace(' ', '_').toUpperCase();
+  // internet explorer -> ie
+  var label = platform[0].split(' ');
+  if (label.length > 1) {
+    label = _.invoke(label, 'charAt', 0)
+  }
+  label = (label.join("") + '_v' + platform[1]).replace(' ', '_').toUpperCase();
   memo[label] = _.pick({
     'base': 'SauceLabs',
     'browserName': platform[0],
@@ -63,7 +69,7 @@ module.exports = function(config) {
     ],
 
     // Number of sauce tests to start in parallel
-    concurrency: 2,
+    concurrency: 9,
 
     // test results reporter to use
     reporters: ['dots', 'saucelabs'],
@@ -76,14 +82,11 @@ module.exports = function(config) {
       tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER
     },
 
-    // TODO(vojta): remove once SauceLabs supports websockets.
-    // This speeds up the capturing a bit, as browsers don't even try to use websocket.
-    transports: ['xhr-polling'],
     captureTimeout: 120000,
-    customLaunchers: sauceBrowsers
+    customLaunchers: sauceBrowsers,
 
     // Browsers to launch, commented out to prevent karma from starting
     // too many concurrent browsers and timing sauce out.
-    // browsers: _.keys(sauceBrowsers)
+    browsers: _.keys(sauceBrowsers)
   });
 };

--- a/karma.conf-sauce.js
+++ b/karma.conf-sauce.js
@@ -17,8 +17,8 @@ var sauceBrowsers = _.reduce([
   ['internet explorer', '11', 'Windows 10'],
   ['internet explorer', '10', 'Windows 8'],
   ['internet explorer', '9', 'Windows 7'],
-  ['internet explorer', '8'],
-  // Currently karma-sauce has issues with sockets and these browsers
+  // Currently disabled due to karma-sauce issues
+  // ['internet explorer', '8'],
   // ['internet explorer', '7'],
   // ['internet explorer', '6'],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "coveralls": "^2.11.2",
     "docco": "*",
     "eslint": "0.21.x",
-    "karma": "~0.12.31",
+    "karma": "^0.13.13",
     "karma-qunit": "~0.1.4",
     "nyc": "^2.1.3",
     "qunit-cli": "~0.2.0",


### PR DESCRIPTION
As of 0.13.12 karma supports a concurrency field to limit browsers started in parallel. See https://github.com/karma-runner/karma/pull/1646

Don't merge til green lights

Have to still tinker with the concurrency limit. I think we should be able to set 4