### PR TITLE
debounce doc: which invocation's args are used

### DIFF
--- a/index.html
+++ b/index.html
@@ -1234,6 +1234,12 @@ $(window).scroll(throttled);
       </p>
 
       <p>
+        At the end of the <b>wait</b> interval, the function will be called
+        with the arguments that were passed <i>most recently</i> to the
+        debounced function.
+      </p>
+
+      <p>
         Pass <tt>true</tt> for the <b>immediate</b> argument to cause
         <b>debounce</b> to trigger the function on the leading instead of the
         trailing edge of the <b>wait</b> interval. Useful in circumstances like


### PR DESCRIPTION
I couldn't figure out from reading the docs whether `const f = _.debounce(x => { console.log(x); }, 1000); f(1); f(2);` would print `1` or `2`.

Discovered experimentally that the answer is `2`. This PR drops a hint about that behavior into the documentation.