### PR TITLE
Remove redundant empty string handing in _.toArray()

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -441,7 +441,7 @@
     if (_.isArray(obj)) return slice.call(obj);
     if (_.isString(obj)) {
       // Keep surrogate pair characters together
-      return obj ? obj.match(reStrSymbol) : [];
+      return obj.match(reStrSymbol);
     }
     if (isArrayLike(obj)) return _.map(obj, _.identity);
     return _.values(obj);


### PR DESCRIPTION
As part of the review for pull request #2298, @jdalton requested that we add
this check to handle the empty string case. However, I'm guessing he didn't
realize that the first line of the function, `if (!obj) return [];`, already
handles that case.

As part of that pull request, @JonAbrams wisely added a test for the empty
string case, so as long as tests are passing this change should be safe.

See: https://github.com/jashkenas/underscore/pull/2298#discussion_r39480698