### PR TITLE
Remove redundant _.first() test

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -13,8 +13,6 @@
     assert.equal(result, 4, 'works on an arguments object.');
     result = _.map([[1, 2, 3], [1, 2, 3]], _.first);
     assert.deepEqual(result, [1, 1], 'works well with _.map');
-    result = (function() { return _.first([1, 2, 3], 2); }());
-    assert.deepEqual(result, [1, 2]);
 
     assert.equal(_.first(null), void 0, 'handles nulls');
     assert.strictEqual(_.first([1, 2, 3], -1).length, 0);


### PR DESCRIPTION
This test was originally added in pull request #500 as a way to affirm that the
`_.take()` alias was working. In pull request #1663 we moved to testing aliases
explicitly, but left this test an additional `_.first()` test.

It is redundant because it is functionally identical to the test on line 10.