### PR TITLE
Clean up assertions for _.first()

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -6,16 +6,15 @@
   test('first', function(assert) {
     assert.equal(_.first([1, 2, 3]), 1, 'can pull out the first element of an array');
     assert.equal(_([1, 2, 3]).first(), 1, 'can perform OO-style "first()"');
-    assert.deepEqual(_.first([1, 2, 3], 0), [], 'can pass an index to first');
-    assert.deepEqual(_.first([1, 2, 3], 2), [1, 2], 'can pass an index to first');
-    assert.deepEqual(_.first([1, 2, 3], 5), [1, 2, 3], 'can pass an index to first');
+    assert.deepEqual(_.first([1, 2, 3], 0), [], 'can fetch the first 0 elements');
+    assert.deepEqual(_.first([1, 2, 3], 2), [1, 2], 'can fetch the first n elements');
+    assert.deepEqual(_.first([1, 2, 3], 5), [1, 2, 3], 'returns the whole array if n > length');
     var result = (function(){ return _.first(arguments); }(4, 3, 2, 1));
-    assert.equal(result, 4, 'works on an arguments object.');
+    assert.equal(result, 4, 'works on an arguments object');
     result = _.map([[1, 2, 3], [1, 2, 3]], _.first);
     assert.deepEqual(result, [1, 1], 'works well with _.map');
-
-    assert.equal(_.first(null), void 0, 'handles nulls');
-    assert.strictEqual(_.first([1, 2, 3], -1).length, 0);
+    assert.equal(_.first(null), void 0, 'returns undefined when called on null');
+    assert.deepEqual(_.first([1, 2, 3], -1), [], 'returns an empty array when asked for -n elements');
   });
 
   test('head', function(assert) {


### PR DESCRIPTION
Makes the assertion descriptions more consistent.

In the case of the `-n` test, I opted to rewrite it to be more explicit.
Asserting that it actually returns an empty array is ever so slightly more
meaningful than testing that its return value has a length of 0.