### PR TITLE
Clean up testing of aliases

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -18,11 +18,11 @@
   });
 
   test('head', function(assert) {
-    assert.strictEqual(_.first, _.head, 'alias for first');
+    assert.strictEqual(_.head, _.first, 'is an alias for first');
   });
 
   test('take', function(assert) {
-    assert.strictEqual(_.first, _.take, 'alias for first');
+    assert.strictEqual(_.take, _.first, 'is an alias for first');
   });
 
   test('rest', function(assert) {
@@ -39,11 +39,11 @@
   });
 
   test('tail', function(assert) {
-    assert.strictEqual(_.rest, _.tail, 'alias for rest');
+    assert.strictEqual(_.tail, _.rest, 'is an alias for rest');
   });
 
   test('drop', function(assert) {
-    assert.strictEqual(_.rest, _.drop, 'alias for rest');
+    assert.strictEqual(_.drop, _.rest, 'is an alias for rest');
   });
 
   test('initial', function(assert) {
@@ -192,7 +192,7 @@
   });
 
   test('unique', function(assert) {
-    assert.strictEqual(_.uniq, _.unique, 'alias for uniq');
+    assert.strictEqual(_.unique, _.uniq, 'is an alias for uniq');
   });
 
   test('intersection', function(assert) {

--- a/test/collections.js
+++ b/test/collections.js
@@ -14,7 +14,7 @@
 
     answers = [];
     _.each([1, 2, 3], function(num){ answers.push(num); });
-    assert.deepEqual(answers, [1, 2, 3], 'aliased as "forEach"');
+    assert.deepEqual(answers, [1, 2, 3], 'can iterate a simple array');
 
     answers = [];
     var obj = {one: 1, two: 2, three: 3};
@@ -46,7 +46,7 @@
   });
 
   test('forEach', function(assert) {
-    assert.strictEqual(_.each, _.forEach, 'alias for each');
+    assert.strictEqual(_.forEach, _.each, 'is an alias for each');
   });
 
   test('lookupIterator with contexts', function(assert) {
@@ -172,7 +172,7 @@
   });
 
   test('collect', function(assert) {
-    assert.strictEqual(_.map, _.collect, 'alias for map');
+    assert.strictEqual(_.collect, _.map, 'is an alias for map');
   });
 
   test('reduce', function(assert) {
@@ -182,9 +182,6 @@
     var context = {multiplier: 3};
     sum = _.reduce([1, 2, 3], function(memo, num){ return memo + num * this.multiplier; }, 0, context);
     assert.equal(sum, 18, 'can reduce with a context object');
-
-    sum = _.inject([1, 2, 3], function(memo, num){ return memo + num; }, 0);
-    assert.equal(sum, 6, 'aliased as "inject"');
 
     sum = _([1, 2, 3]).reduce(function(memo, num){ return memo + num; }, 0);
     assert.equal(sum, 6, 'OO-style reduce');
@@ -202,7 +199,11 @@
   });
 
   test('foldl', function(assert) {
-    assert.strictEqual(_.reduce, _.foldl, 'alias for reduce');
+    assert.strictEqual(_.foldl, _.reduce, 'is an alias for reduce');
+  });
+
+  test('inject', function(assert) {
+    assert.strictEqual(_.inject, _.reduce, 'is an alias for reduce');
   });
 
   test('reduceRight', function(assert) {
@@ -256,7 +257,7 @@
   });
 
   test('foldr', function(assert) {
-    assert.strictEqual(_.reduceRight, _.foldr, 'alias for reduceRight');
+    assert.strictEqual(_.foldr, _.reduceRight, 'is an alias for reduceRight');
   });
 
   test('find', function(assert) {
@@ -298,7 +299,7 @@
   });
 
   test('detect', function(assert) {
-    assert.strictEqual(_.detect, _.find, 'alias for detect');
+    assert.strictEqual(_.detect, _.find, 'is an alias for find');
   });
 
   test('filter', function(assert) {
@@ -323,7 +324,7 @@
   });
 
   test('select', function(assert) {
-    assert.strictEqual(_.filter, _.select, 'alias for filter');
+    assert.strictEqual(_.select, _.filter, 'is an alias for filter');
   });
 
   test('reject', function(assert) {
@@ -373,7 +374,7 @@
   });
 
   test('all', function(assert) {
-    assert.strictEqual(_.all, _.every, 'alias for all');
+    assert.strictEqual(_.all, _.every, 'is an alias for every');
   });
 
   test('some', function(assert) {
@@ -403,7 +404,7 @@
   });
 
   test('any', function(assert) {
-    assert.strictEqual(_.any, _.some, 'alias for any');
+    assert.strictEqual(_.any, _.some, 'is an alias for some');
   });
 
   test('includes', function(assert) {
@@ -417,24 +418,25 @@
 
     assert.ok(_.includes({moe: 1, larry: 3, curly: 9}, 3) === true, '_.includes on objects checks their values');
     assert.ok(_([1, 2, 3]).includes(2), 'OO-style includes');
+
+    var numbers = [1, 2, 3, 1, 2, 3, 1, 2, 3];
+    assert.strictEqual(_.includes(numbers, 1, 1), true, 'takes a fromIndex');
+    assert.strictEqual(_.includes(numbers, 1, -1), false, 'takes a fromIndex');
+    assert.strictEqual(_.includes(numbers, 1, -2), false, 'takes a fromIndex');
+    assert.strictEqual(_.includes(numbers, 1, -3), true, 'takes a fromIndex');
+    assert.strictEqual(_.includes(numbers, 1, 6), true, 'takes a fromIndex');
+    assert.strictEqual(_.includes(numbers, 1, 7), false, 'takes a fromIndex');
+
+    assert.ok(_.every([1, 2, 3], _.partial(_.includes, numbers)), 'fromIndex is guarded');
   });
 
   test('include', function(assert) {
-    assert.strictEqual(_.includes, _.include, 'alias for includes');
+    assert.strictEqual(_.include, _.includes, 'is an alias for includes');
   });
 
   test('contains', function(assert) {
-    assert.strictEqual(_.includes, _.contains, 'alias for includes');
+    assert.strictEqual(_.contains, _.includes, 'is an alias for includes');
 
-    var numbers = [1, 2, 3, 1, 2, 3, 1, 2, 3];
-    assert.strictEqual(_.includes(numbers, 1, 1), true, 'contains takes a fromIndex');
-    assert.strictEqual(_.includes(numbers, 1, -1), false, 'contains takes a fromIndex');
-    assert.strictEqual(_.includes(numbers, 1, -2), false, 'contains takes a fromIndex');
-    assert.strictEqual(_.includes(numbers, 1, -3), true, 'contains takes a fromIndex');
-    assert.strictEqual(_.includes(numbers, 1, 6), true, 'contains takes a fromIndex');
-    assert.strictEqual(_.includes(numbers, 1, 7), false, 'contains takes a fromIndex');
-
-    assert.ok(_.every([1, 2, 3], _.partial(_.contains, numbers)), 'fromIndex is guarded');
   });
 
   test('includes with NaN', function(assert) {

--- a/test/objects.js
+++ b/test/objects.js
@@ -102,7 +102,7 @@
   });
 
   test('methods', function(assert) {
-    assert.strictEqual(_.functions, _.methods, 'alias for functions');
+    assert.strictEqual(_.methods, _.functions, 'is an alias for functions');
   });
 
   test('extend', function(assert) {
@@ -138,32 +138,36 @@
 
   test('extendOwn', function(assert) {
     var result;
-    assert.equal(_.extendOwn({}, {a: 'b'}).a, 'b', 'can assign an object with the attributes of another');
+    assert.equal(_.extendOwn({}, {a: 'b'}).a, 'b', 'can extend an object with the attributes of another');
     assert.equal(_.extendOwn({a: 'x'}, {a: 'b'}).a, 'b', 'properties in source override destination');
     assert.equal(_.extendOwn({x: 'x'}, {a: 'b'}).x, 'x', "properties not in source don't get overriden");
     result = _.extendOwn({x: 'x'}, {a: 'a'}, {b: 'b'});
-    assert.deepEqual(result, {x: 'x', a: 'a', b: 'b'}, 'can assign from multiple source objects');
-    result = _.assign({x: 'x'}, {a: 'a', x: 2}, {a: 'b'});
-    assert.deepEqual(result, {x: 2, a: 'b'}, 'assigning from multiple source objects last property trumps');
-    assert.deepEqual(_.extendOwn({}, {a: void 0, b: null}), {a: void 0, b: null}, 'assign copies undefined values');
+    assert.deepEqual(result, {x: 'x', a: 'a', b: 'b'}, 'can extend from multiple source objects');
+    result = _.extendOwn({x: 'x'}, {a: 'a', x: 2}, {a: 'b'});
+    assert.deepEqual(result, {x: 2, a: 'b'}, 'extending from multiple source objects last property trumps');
+    assert.deepEqual(_.extendOwn({}, {a: void 0, b: null}), {a: void 0, b: null}, 'copies undefined values');
 
     var F = function() {};
     F.prototype = {a: 'b'};
     var subObj = new F();
     subObj.c = 'd';
-    assert.deepEqual(_.extendOwn({}, subObj), {c: 'd'}, 'assign copies own properties from source');
+    assert.deepEqual(_.extendOwn({}, subObj), {c: 'd'}, 'copies own properties from source');
 
     result = {};
-    assert.deepEqual(_.assign(result, null, void 0, {a: 1}), {a: 1}, 'should not error on `null` or `undefined` sources');
+    assert.deepEqual(_.extendOwn(result, null, void 0, {a: 1}), {a: 1}, 'should not error on `null` or `undefined` sources');
 
     _.each(['a', 5, null, false], function(val) {
-      assert.strictEqual(_.assign(val, {a: 1}), val, 'assigning non-objects results in returning the non-object value');
+      assert.strictEqual(_.extendOwn(val, {a: 1}), val, 'extending non-objects results in returning the non-object value');
     });
 
-    assert.strictEqual(_.extendOwn(void 0, {a: 1}), void 0, 'assigning undefined results in undefined');
+    assert.strictEqual(_.extendOwn(void 0, {a: 1}), void 0, 'extending undefined results in undefined');
 
     result = _.extendOwn({a: 1, 0: 2, 1: '5', length: 6}, {0: 1, 1: 2, length: 2});
-    assert.deepEqual(result, {a: 1, 0: 1, 1: 2, length: 2}, 'assign should treat array-like objects like normal objects');
+    assert.deepEqual(result, {a: 1, 0: 1, 1: 2, length: 2}, 'should treat array-like objects like normal objects');
+  });
+
+  test('assign', function(assert) {
+    assert.strictEqual(_.assign, _.extendOwn, 'is an alias for extendOwn');
   });
 
   test('pick', function(assert) {
@@ -877,6 +881,10 @@
     //null edge cases
     var oCon = _.matcher({constructor: Object});
     assert.deepEqual(_.map([null, void 0, 5, {}], oCon), [false, false, false, true], 'doesnt falsey match constructor on undefined/null');
+  });
+
+  test('matches', function(assert) {
+    assert.strictEqual(_.matches, _.matcher, 'is an alias for matcher');
   });
 
   test('findKey', function(assert) {


### PR DESCRIPTION
* Ensure all tests are run against the canonical function name
* Ensure all aliases mentioned in the documentation are tested
* Remove redundant tests which were originally meant to test aliases
* Make alias assertion descriptions consistent readable sentences
* Use `(actual, expected)` argument order in alias assertions