### PR TITLE
added iterate OBJ parameter to keep the consistency

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1104,7 +1104,7 @@
       if (keys.length > 1) context = keys[1];
     } else {
       keys = _.map(flatten(keys, false, false), String);
-      iteratee = function(value, key) {
+      iteratee = function(value, key, obj) {
         return !_.contains(keys, key);
       };
     }


### PR DESCRIPTION
pick iteratee function is called with `iteratee(value, key, obj)` but omit iteratee is defined with `iteratee(value, key)` 