### PR TITLE
optional parameter for predicate on _.unique

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -187,39 +187,25 @@
 
     assert.deepEqual(_.uniq([{a: 1, b: 1}, {a: 1, b: 2}, {a: 1, b: 3}, {a: 2, b: 1}], 'a'), [{a: 1, b: 1}, {a: 2, b: 1}], 'can use pluck like iterator');
     assert.deepEqual(_.uniq([{0: 1, b: 1}, {0: 1, b: 2}, {0: 1, b: 3}, {0: 2, b: 1}], 0), [{0: 1, b: 1}, {0: 2, b: 1}], 'can use falsey pluck like iterator');
+
+    var col = [{a: 1, b: 2}, {a: 1, b: 2}, {a: 1, b: 2, c: 3}],
+      customMatcher = function(item1, item2) {
+        return _.isEqual(item1.keys, item2.keys);
+      };
+
+    assert.deepEqual(_.uniq(col, false, null, null, _.isEqual), [{a: 1, b: 2}, {a: 1, b: 2, c: 3}], 'can use a predicate matcher');
+    assert.deepEqual(_.uniq(col, false, null, null, customMatcher), [{a: 1, b: 2}], 'can use a custom matcher function');
+    assert.deepEqual(_.uniq(col, true, null, null, _.isEqual), [{a: 1, b: 2}, {a: 1, b: 2, c: 3}], 'ignores sort parameter if predicate function');
+    assert.deepEqual(_.uniq(col, null, null, null, _.isEqual), [{a: 1, b: 2}, {a: 1, b: 2, c: 3}], 'works with null passed for all params but predicate');
+
+    _.uniq(col, false, null, context, function(item1, item2) {
+      assert.strictEqual(this, context, 'passes the context to the predicate');
+      return _.isEqual(item1, item2);
+    });
   });
 
   test('unique', function(assert) {
     assert.strictEqual(_.unique, _.uniq, 'is an alias for uniq');
-  });
-
-  test('uniqueWithAlias', function (assert) {
-    assert.strictEqual(_.uniqueWith, _.uniqWith, 'is an alias for uniqWith');
-  });
-
-  test('uniqWith', function(assert) {
-    var list = [1, 2, 1, 3, 1, 4],
-      kittens = [
-        {kitten: 'Celery', cuteness: 8},
-        {kitten: 'Juniper', cuteness: 10},
-        {kitten: 'Juniper', cuteness: 10},
-        {kitten: 'Spottis', cuteness: 10},
-        {kitten: 'Stripes', cuteness: 11}
-      ],
-      uniqeKittens = [
-        {kitten: 'Celery', cuteness: 8},
-        {kitten: 'Juniper', cuteness: 10},
-        {kitten: 'Spottis', cuteness: 10},
-        {kitten: 'Stripes', cuteness: 11}
-      ],
-      byCuteness = function (a, b) {
-        return a.cuteness === b.cuteness;
-      }
-
-    assert.deepEqual(_.uniqWith(list), [1, 2, 3, 4], 'can find the unique values from a non object array');
-    assert.deepEqual(_.uniqWith(kittens, _.isEqual), uniqeKittens, 'finds unique objects using _.isEqual');
-    assert.deepEqual(_.uniqWith(kittens), uniqeKittens, 'defaults to _.isEqual if nothing passed');
-    assert.deepEqual(_.pluck(_.uniqWith(kittens, byCuteness), 'cuteness'), [8, 10, 11], 'returns all, if comparator only looks at name');
   });
 
   test('intersection', function(assert) {

--- a/test/arrays.js
+++ b/test/arrays.js
@@ -193,6 +193,35 @@
     assert.strictEqual(_.unique, _.uniq, 'is an alias for uniq');
   });
 
+  test('uniqueWithAlias', function (assert) {
+    assert.strictEqual(_.uniqueWith, _.uniqWith, 'is an alias for uniqWith');
+  });
+
+  test('uniqWith', function(assert) {
+    var list = [1, 2, 1, 3, 1, 4],
+      kittens = [
+        {kitten: 'Celery', cuteness: 8},
+        {kitten: 'Juniper', cuteness: 10},
+        {kitten: 'Juniper', cuteness: 10},
+        {kitten: 'Spottis', cuteness: 10},
+        {kitten: 'Stripes', cuteness: 11}
+      ],
+      uniqeKittens = [
+        {kitten: 'Celery', cuteness: 8},
+        {kitten: 'Juniper', cuteness: 10},
+        {kitten: 'Spottis', cuteness: 10},
+        {kitten: 'Stripes', cuteness: 11}
+      ],
+      byCuteness = function (a, b) {
+        return a.cuteness === b.cuteness;
+      }
+
+    assert.deepEqual(_.uniqWith(list), [1, 2, 3, 4], 'can find the unique values from a non object array');
+    assert.deepEqual(_.uniqWith(kittens, _.isEqual), uniqeKittens, 'finds unique objects using _.isEqual');
+    assert.deepEqual(_.uniqWith(kittens), uniqeKittens, 'defaults to _.isEqual if nothing passed');
+    assert.deepEqual(_.pluck(_.uniqWith(kittens, byCuteness), 'cuteness'), [8, 10, 11], 'returns all, if comparator only looks at name');
+  });
+
   test('intersection', function(assert) {
     var stooges = ['moe', 'curly', 'larry'], leaders = ['moe', 'groucho'];
     assert.deepEqual(_.intersection(stooges, leaders), ['moe'], 'can take the set intersection of two arrays');

--- a/test/collections.js
+++ b/test/collections.js
@@ -430,6 +430,31 @@
     assert.ok(_.every([1, 2, 3], _.partial(_.includes, numbers)), 'fromIndex is guarded');
   });
 
+  test('includeWithAlias', function(assert) {
+    assert.strictEqual(_.includeWith, _.includesWith, 'is an alias for containsWith');
+    assert.strictEqual(_.includeWith, _.containsWith, 'is an alias for includeWith');
+  });
+
+  test('includeWith', function(assert) {
+
+    var list = [1, 2, 1, 3, 1, 4];
+    var kittens = [
+      {kitten: 'Celery', cuteness: 8},
+      {kitten: 'Juniper', cuteness: 10},
+      {kitten: 'Spottis', cuteness: 10}
+    ];
+
+    var checkCute = function(a, b) {
+      return a.cuteness == 8;
+    }
+
+    assert.strictEqual(_.includeWith(list, 4), true, 'should find the item in the list');
+    assert.strictEqual(_.includeWith(kittens, {cuteness: 8}, checkCute), true, 'should use the method passed for comparison');
+    assert.strictEqual(_.includeWith(kittens, {kitten: 'Juniper', cuteness: 8}, _.isEqual), false, 'should not find as cuteness does not match');
+    assert.strictEqual(_.includeWith(kittens, {kitten: 'Juniper', cuteness: 10}, _.isEqual), true, 'should find the obj as cuteness matches');
+    assert.strictEqual(_.includeWith(kittens, {kitten: 'Juniper', cuteness: 10}), true, 'should use _.isEqual by default');
+  });
+
   test('include', function(assert) {
     assert.strictEqual(_.include, _.includes, 'is an alias for includes');
   });

--- a/test/collections.js
+++ b/test/collections.js
@@ -430,31 +430,6 @@
     assert.ok(_.every([1, 2, 3], _.partial(_.includes, numbers)), 'fromIndex is guarded');
   });
 
-  test('includeWithAlias', function(assert) {
-    assert.strictEqual(_.includeWith, _.includesWith, 'is an alias for containsWith');
-    assert.strictEqual(_.includeWith, _.containsWith, 'is an alias for includeWith');
-  });
-
-  test('includeWith', function(assert) {
-
-    var list = [1, 2, 1, 3, 1, 4];
-    var kittens = [
-      {kitten: 'Celery', cuteness: 8},
-      {kitten: 'Juniper', cuteness: 10},
-      {kitten: 'Spottis', cuteness: 10}
-    ];
-
-    var checkCute = function(a, b) {
-      return a.cuteness == 8;
-    }
-
-    assert.strictEqual(_.includeWith(list, 4), true, 'should find the item in the list');
-    assert.strictEqual(_.includeWith(kittens, {cuteness: 8}, checkCute), true, 'should use the method passed for comparison');
-    assert.strictEqual(_.includeWith(kittens, {kitten: 'Juniper', cuteness: 8}, _.isEqual), false, 'should not find as cuteness does not match');
-    assert.strictEqual(_.includeWith(kittens, {kitten: 'Juniper', cuteness: 10}, _.isEqual), true, 'should find the obj as cuteness matches');
-    assert.strictEqual(_.includeWith(kittens, {kitten: 'Juniper', cuteness: 10}), true, 'should use _.isEqual by default');
-  });
-
   test('include', function(assert) {
     assert.strictEqual(_.include, _.includes, 'is an alias for includes');
   });

--- a/underscore.js
+++ b/underscore.js
@@ -278,6 +278,15 @@
     return _.indexOf(obj, item, fromIndex) >= 0;
   };
 
+  _.containsWith = _.includesWith = _.includeWith = function(array, item, predicate) {
+    predicate = _.isFunction(predicate) ? predicate : _.isEqual;
+    for (var i = 0, length = getLength(array); i < length; i++) {
+      if (predicate(array[i], item))
+        return true;
+    }
+    return false;
+  };
+
   // Invoke a method (with arguments) on every item in a collection.
   _.invoke = restArgs(function(obj, method, args) {
     var isFunc = _.isFunction(method);
@@ -556,6 +565,20 @@
       } else if (!_.contains(result, value)) {
         result.push(value);
       }
+    }
+    return result;
+  };
+
+  // Produce a duplicate-free version of the array using the passed function for comparison rather than ===
+  // comparator defaults to _.isEqual for comparison if omitted
+  _.uniqueWith = _.uniqWith = function(array, predicate) {
+    var result = [], item;
+    predicate = _.isFunction(predicate) ? predicate : _.isEqual;
+
+    for (var i = 0, length = getLength(array); i < length; i++) {
+      item = array[i];
+      if (!_.containsWith(result, item, predicate))
+        result.push(item);
     }
     return result;
   };

--- a/underscore.js
+++ b/underscore.js
@@ -538,13 +538,13 @@
       context = iteratee;
       iteratee = isSorted;
       isSorted = false;
-      predicate = _.isNull(predicate) ? context : predicate;
+      predicate = _.isNull(predicate) && _.isFunction(context) ? context : predicate;
     }
     // cannot use sort with predicate matcher
     if (_.isFunction(predicate)) {
       isSorted = false;
       iteratee = null;
-      predicate = _.bind(predicate, context);
+      predicate = optimizeCb(predicate, context);
     }
 
     if (iteratee != null) iteratee = cb(iteratee, context);


### PR DESCRIPTION
this allows for using custom matcher function for comparison
defaults to `_.isEqual` for comparison #2311 

added a `_.uniqueWith` function as discussed, also added `_.includeWith` as a method to detect if an Array or Collection has an item passing a method. This will be useful if we implement the other methods discussed in the thread as well.
