### PR TITLE
Clean up comments on cb() and _.iteratee()

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -85,9 +85,9 @@
     };
   };
 
-  // A mostly-internal function to generate callbacks that can be applied
-  // to each element in a collection, returning the desired result — either
-  // `identity`, an arbitrary callback, a property matcher, or a property accessor.
+  // An internal function to generate callbacks that can be applied to each
+  // element in a collection, returning the desired result — either `identity`,
+  // an arbitrary callback, a property matcher, or a property accessor.
   var cb = function(value, context, argCount) {
     if (value == null) return _.identity;
     if (_.isFunction(value)) return optimizeCb(value, context, argCount);
@@ -95,6 +95,7 @@
     return _.property(value);
   };
 
+  // An external wrapper for the internal callback generator
   _.iteratee = function(value, context) {
     return cb(value, context, Infinity);
   };


### PR DESCRIPTION
In commit 44a47fb, `_.iteratee()` was converted into the fully internal function `cb()`. However, the comment was not not updated to reflect its new internal status.