### PR TITLE
Dubious Improvement: Combine _.every and _.some logic

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -245,31 +245,28 @@
     return _.filter(obj, _.negate(cb(predicate)), context);
   };
 
+  // Generator function to create the some and every functions. `breakValue` is
+  // the boolean predicate response that should cause an early return.
+  var createSomeOrEvery = function(breakValue) {
+    return function(obj, predicate, context) {
+      predicate = cb(predicate, context);
+      var keys = !isArrayLike(obj) && _.keys(obj),
+          length = (keys || obj).length;
+      for (var index = 0; index < length; index++) {
+        var key = keys ? keys[index] : index;
+        if (!!predicate(obj[key], key, obj) === breakValue) return breakValue;
+      }
+      return !breakValue;
+    };
+  };
+
   // Determine whether all of the elements match a truth test.
   // Aliased as `all`.
-  _.every = _.all = function(obj, predicate, context) {
-    predicate = cb(predicate, context);
-    var keys = !isArrayLike(obj) && _.keys(obj),
-        length = (keys || obj).length;
-    for (var index = 0; index < length; index++) {
-      var currentKey = keys ? keys[index] : index;
-      if (!predicate(obj[currentKey], currentKey, obj)) return false;
-    }
-    return true;
-  };
+  _.every = _.all = createSomeOrEvery(false);
 
   // Determine if at least one element in the object matches a truth test.
   // Aliased as `any`.
-  _.some = _.any = function(obj, predicate, context) {
-    predicate = cb(predicate, context);
-    var keys = !isArrayLike(obj) && _.keys(obj),
-        length = (keys || obj).length;
-    for (var index = 0; index < length; index++) {
-      var currentKey = keys ? keys[index] : index;
-      if (predicate(obj[currentKey], currentKey, obj)) return true;
-    }
-    return false;
-  };
+  _.some = _.any = createSomeOrEvery(true);
 
   // Determine if the array or object contains a given item (using `===`).
   // Aliased as `includes` and `include`.


### PR DESCRIPTION
These two functions were nearly identical. Inspired by #2060, I thought I would
try to combine the two to save some bytes. Ironically, repetitive code gzips
very well, so this refactor actually ends up _adding_ 3 bytes to the
minified-gzipped size. Oh well.

Never the less, I figured I'd open the PR, since it does reduce repetition in
the source code, and maybe it will serve as a guide for somebody else who looks
into combing these.

Pros:

* Less code in underscore.js
* DRYer code (https://en.wikipedia.org/wiki/Don't_repeat_yourself)

Cons:

* Larger gzipped file size
* Possibly a _tiny_ bit slower (I'm no perf expert)
* Code is harder to understand

Feel free to close this PR if, as I suspect, these trade-offs are not worthwhile.