### PR TITLE
Clean up assertions for _.uniq()

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -143,33 +143,23 @@
   test('uniq', function(assert) {
     var list = [1, 2, 1, 3, 1, 4];
     assert.deepEqual(_.uniq(list), [1, 2, 3, 4], 'can find the unique values of an unsorted array');
-
     list = [1, 1, 1, 2, 2, 3];
     assert.deepEqual(_.uniq(list, true), [1, 2, 3], 'can find the unique values of a sorted array faster');
 
-    list = [{name: 'moe'}, {name: 'curly'}, {name: 'larry'}, {name: 'curly'}];
-    var iterator = function(value) { return value.name; };
-    assert.deepEqual(_.map(_.uniq(list, false, iterator), iterator), ['moe', 'curly', 'larry'], 'can find the unique values of an array using a custom iterator');
+    list = [{name: 'Moe'}, {name: 'Curly'}, {name: 'Larry'}, {name: 'Curly'}];
+    var expected = [{name: 'Moe'}, {name: 'Curly'}, {name: 'Larry'}];
+    var iterator = function(stooge) { return stooge.name; };
+    assert.deepEqual(_.uniq(list, false, iterator), expected, 'uses the result of `iterator` for uniqueness comparisons (unsorted case)');
+    assert.deepEqual(_.uniq(list, iterator), expected, '`sorted` argument defaults to false when omitted');
+    assert.deepEqual(_.uniq(list, 'name'), expected, 'when `iterator` is a string, uses that key for comparisons (unsorted case)');
 
-    assert.deepEqual(_.map(_.uniq(list, iterator), iterator), ['moe', 'curly', 'larry'], 'can find the unique values of an array using a custom iterator without specifying whether array is sorted');
+    list = [{score: 8}, {score: 10}, {score: 10}];
+    expected = [{score: 8}, {score: 10}];
+    iterator = function(item) { return item.score; };
+    assert.deepEqual(_.uniq(list, true, iterator), expected, 'uses the result of `iterator` for uniqueness comparisons (sorted case)');
+    assert.deepEqual(_.uniq(list, true, 'score'), expected, 'when `iterator` is a string, uses that key for comparisons (sorted case)');
 
-    iterator = function(value) { return value + 1; };
-    list = [1, 2, 2, 3, 4, 4];
-    assert.deepEqual(_.uniq(list, true, iterator), [1, 2, 3, 4], 'iterator works with sorted array');
-
-    var kittens = [
-      {kitten: 'Celery', cuteness: 8},
-      {kitten: 'Juniper', cuteness: 10},
-      {kitten: 'Spottis', cuteness: 10}
-    ];
-
-    var expected = [
-      {kitten: 'Celery', cuteness: 8},
-      {kitten: 'Juniper', cuteness: 10}
-    ];
-
-    assert.deepEqual(_.uniq(kittens, true, 'cuteness'), expected, 'string iterator works with sorted array');
-
+    assert.deepEqual(_.uniq([{0: 1}, {0: 1}, {0: 1}, {0: 2}], 0), [{0: 1}, {0: 2}], 'can use falsey pluck like iterator');
 
     var result = (function(){ return _.uniq(arguments); }(1, 2, 1, 3, 1, 4));
     assert.deepEqual(result, [1, 2, 3, 4], 'works on an arguments object');
@@ -177,19 +167,17 @@
     var a = {}, b = {}, c = {};
     assert.deepEqual(_.uniq([a, b, a, b, c]), [a, b, c], 'works on values that can be tested for equivalency but not ordered');
 
-    assert.deepEqual(_.uniq(null), []);
+    assert.deepEqual(_.uniq(null), [], 'returns an empty array when `array` is not iterable');
 
     var context = {};
     list = [3];
     _.uniq(list, function(value, index, array) {
-      assert.strictEqual(this, context);
-      assert.strictEqual(value, 3);
-      assert.strictEqual(index, 0);
-      assert.strictEqual(array, list);
+      assert.strictEqual(this, context, 'executes its iterator in the given context');
+      assert.strictEqual(value, 3, 'passes its iterator the value');
+      assert.strictEqual(index, 0, 'passes its iterator the index');
+      assert.strictEqual(array, list, 'passes its iterator the entire array');
     }, context);
 
-    assert.deepEqual(_.uniq([{a: 1, b: 1}, {a: 1, b: 2}, {a: 1, b: 3}, {a: 2, b: 1}], 'a'), [{a: 1, b: 1}, {a: 2, b: 1}], 'can use pluck like iterator');
-    assert.deepEqual(_.uniq([{0: 1, b: 1}, {0: 1, b: 2}, {0: 1, b: 3}, {0: 2, b: 1}], 0), [{0: 1, b: 1}, {0: 2, b: 1}], 'can use falsey pluck like iterator');
   });
 
   test('unique', function(assert) {


### PR DESCRIPTION
* Improve assertion grouping
* Improve assertion messages
* Remove unused properties from test objects
* Reuse existing sorted "score" list for sorted tests
* Remove clever/confusing usage of _.map for asserting list equality
* Simplify test data to be more terse and readable (yes I feel guilty for
  removing the cute kittens)