### PR TITLE
Don't let eslint ignore global _ in tests

### DIFF
--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -3,7 +3,6 @@
     "browser": true
   },
   "globals": {
-    "_": false,
     "test": false,
     "ok": false,
     "is": false,


### PR DESCRIPTION
As of pull request #2033 (commit 2646f2eaaa3a1b6511051b5e0c461bcaf238e778) we
explicitly define `_` in our test files, so we no longer need this exception.