### PR TITLE
 Migrated tests to QUnit 2.0 syntax

### DIFF
--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -14,7 +14,6 @@
     "throws": false,
     "asyncTest": false,
     "start": false,
-    "expect": false,
     "QUnit": false
   },
   "rules": {

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -3,7 +3,6 @@
     "browser": true
   },
   "globals": {
-    "test": false,
     "ok": false,
     "is": false,
     "equal": false,

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -3,8 +3,6 @@
     "browser": true
   },
   "globals": {
-    "asyncTest": false,
-    "start": false,
     "QUnit": false
   },
   "rules": {

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -3,15 +3,6 @@
     "browser": true
   },
   "globals": {
-    "ok": false,
-    "is": false,
-    "equal": false,
-    "deepEqual": false,
-    "strictEqual": false,
-    "notStrictEqual": false,
-    "notEqual": false,
-    "notDeepEqual": false,
-    "throws": false,
     "asyncTest": false,
     "start": false,
     "QUnit": false

--- a/test/arrays.js
+++ b/test/arrays.js
@@ -3,7 +3,7 @@
 
   QUnit.module('Arrays');
 
-  test('first', function(assert) {
+  QUnit.test('first', function(assert) {
     assert.equal(_.first([1, 2, 3]), 1, 'can pull out the first element of an array');
     assert.equal(_([1, 2, 3]).first(), 1, 'can perform OO-style "first()"');
     assert.deepEqual(_.first([1, 2, 3], 0), [], 'returns an empty array when n <= 0 (0 case)');
@@ -17,15 +17,15 @@
     assert.equal(_.first(null), void 0, 'returns undefined when called on null');
   });
 
-  test('head', function(assert) {
+  QUnit.test('head', function(assert) {
     assert.strictEqual(_.head, _.first, 'is an alias for first');
   });
 
-  test('take', function(assert) {
+  QUnit.test('take', function(assert) {
     assert.strictEqual(_.take, _.first, 'is an alias for first');
   });
 
-  test('rest', function(assert) {
+  QUnit.test('rest', function(assert) {
     var numbers = [1, 2, 3, 4];
     assert.deepEqual(_.rest(numbers), [2, 3, 4], 'fetches all but the first element');
     assert.deepEqual(_.rest(numbers, 0), [1, 2, 3, 4], 'returns the whole array when index is 0');
@@ -36,15 +36,15 @@
     assert.deepEqual(_.flatten(result), [2, 3, 2, 3], 'works well with _.map');
   });
 
-  test('tail', function(assert) {
+  QUnit.test('tail', function(assert) {
     assert.strictEqual(_.tail, _.rest, 'is an alias for rest');
   });
 
-  test('drop', function(assert) {
+  QUnit.test('drop', function(assert) {
     assert.strictEqual(_.drop, _.rest, 'is an alias for rest');
   });
 
-  test('initial', function(assert) {
+  QUnit.test('initial', function(assert) {
     assert.deepEqual(_.initial([1, 2, 3, 4, 5]), [1, 2, 3, 4], 'returns all but the last element');
     assert.deepEqual(_.initial([1, 2, 3, 4], 2), [1, 2], 'returns all but the last n elements');
     assert.deepEqual(_.initial([1, 2, 3, 4], 6), [], 'returns an empty array when n > length');
@@ -54,7 +54,7 @@
     assert.deepEqual(_.flatten(result), [1, 2, 1, 2], 'works well with _.map');
   });
 
-  test('last', function(assert) {
+  QUnit.test('last', function(assert) {
     assert.equal(_.last([1, 2, 3]), 3, 'can pull out the last element of an array');
     assert.equal(_([1, 2, 3]).last(), 3, 'can perform OO-style "last()"');
     assert.deepEqual(_.last([1, 2, 3], 0), [], 'returns an empty array when n <= 0 (0 case)');
@@ -68,7 +68,7 @@
     assert.equal(_.last(null), void 0, 'returns undefined when called on null');
   });
 
-  test('compact', function(assert) {
+  QUnit.test('compact', function(assert) {
     assert.deepEqual(_.compact([1, false, null, 0, '', void 0, NaN, 2]), [1, 2], 'removes all falsy values');
     var result = (function(){ return _.compact(arguments); }(0, 1, false, 2, false, 3));
     assert.deepEqual(result, [1, 2, 3], 'works on an arguments object');
@@ -76,7 +76,7 @@
     assert.deepEqual(result, [[1], [3]], 'works well with _.map');
   });
 
-  test('flatten', function(assert) {
+  QUnit.test('flatten', function(assert) {
     assert.deepEqual(_.flatten(null), [], 'supports null');
     assert.deepEqual(_.flatten(void 0), [], 'supports undefined');
 
@@ -102,7 +102,7 @@
     assert.deepEqual(_.flatten(x, true), x[0], 'can handle very deep arrays in shallow mode');
   });
 
-  test('without', function(assert) {
+  QUnit.test('without', function(assert) {
     var list = [1, 2, 1, 0, 3, 1, 4];
     assert.deepEqual(_.without(list, 0, 1), [2, 3, 4], 'removes all instances of the given values');
     var result = (function(){ return _.without(arguments, 0, 1); }(1, 2, 1, 0, 3, 1, 4));
@@ -113,7 +113,7 @@
     assert.deepEqual(_.without(list, list[0]), [{two: 2}], 'compares objects by reference (reference case)');
   });
 
-  test('sortedIndex', function(assert) {
+  QUnit.test('sortedIndex', function(assert) {
     var numbers = [10, 20, 30, 40, 50];
     var indexFor35 = _.sortedIndex(numbers, 35);
     assert.equal(indexFor35, 3, 'finds the index at which a value should be inserted to retain order');
@@ -140,7 +140,7 @@
     assert.equal(_.sortedIndex(largeArray, 2147483648), 2147483648, 'works with large indexes');
   });
 
-  test('uniq', function(assert) {
+  QUnit.test('uniq', function(assert) {
     var list = [1, 2, 1, 3, 1, 4];
     assert.deepEqual(_.uniq(list), [1, 2, 3, 4], 'can find the unique values of an unsorted array');
 
@@ -192,11 +192,11 @@
     assert.deepEqual(_.uniq([{0: 1, b: 1}, {0: 1, b: 2}, {0: 1, b: 3}, {0: 2, b: 1}], 0), [{0: 1, b: 1}, {0: 2, b: 1}], 'can use falsey pluck like iterator');
   });
 
-  test('unique', function(assert) {
+  QUnit.test('unique', function(assert) {
     assert.strictEqual(_.unique, _.uniq, 'is an alias for uniq');
   });
 
-  test('intersection', function(assert) {
+  QUnit.test('intersection', function(assert) {
     var stooges = ['moe', 'curly', 'larry'], leaders = ['moe', 'groucho'];
     assert.deepEqual(_.intersection(stooges, leaders), ['moe'], 'can take the set intersection of two arrays');
     assert.deepEqual(_(stooges).intersection(leaders), ['moe'], 'can perform an OO-style intersection');
@@ -214,7 +214,7 @@
     assert.equal(result.length, 0, 'returns an empty array when passed null as argument beyond the first');
   });
 
-  test('union', function(assert) {
+  QUnit.test('union', function(assert) {
     var result = _.union([1, 2, 3], [2, 30, 1], [1, 40]);
     assert.deepEqual(result, [1, 2, 3, 30, 40], 'takes the union of a list of arrays');
 
@@ -230,7 +230,7 @@
     assert.deepEqual(result, [1, 2, 3], 'restrict the union to arrays only');
   });
 
-  test('difference', function(assert) {
+  QUnit.test('difference', function(assert) {
     var result = _.difference([1, 2, 3], [2, 30, 40]);
     assert.deepEqual(result, [1, 3], 'takes the difference of two arrays');
 
@@ -241,7 +241,7 @@
     assert.deepEqual(result, [1, 2, 3], 'restrict the difference to arrays only');
   });
 
-  test('zip', function(assert) {
+  QUnit.test('zip', function(assert) {
     var names = ['moe', 'larry', 'curly'], ages = [30, 40, 50], leaders = [true];
     assert.deepEqual(_.zip(names, ages, leaders), [
       ['moe', 30, true],
@@ -264,7 +264,7 @@
     assert.deepEqual(_.zip(), [], '_.zip() returns []');
   });
 
-  test('unzip', function(assert) {
+  QUnit.test('unzip', function(assert) {
     assert.deepEqual(_.unzip(null), [], 'handles null');
 
     assert.deepEqual(_.unzip([['a', 'b'], [1, 2]]), [['a', 1], ['b', 2]]);
@@ -277,7 +277,7 @@
     assert.deepEqual(_.unzip(zipped), [['moe', 30, void 0], ['larry', 40, void 0], ['curly', 50, 'extra data']], 'Uses length of largest array');
   });
 
-  test('object', function(assert) {
+  QUnit.test('object', function(assert) {
     var result = _.object(['moe', 'larry', 'curly'], [30, 40, 50]);
     var shouldBe = {moe: 30, larry: 40, curly: 50};
     assert.deepEqual(result, shouldBe, 'two arrays zipped together into an object');
@@ -292,7 +292,7 @@
     assert.deepEqual(_.object(null), {}, 'handles nulls');
   });
 
-  test('indexOf', function(assert) {
+  QUnit.test('indexOf', function(assert) {
     var numbers = [1, 2, 3];
     assert.equal(_.indexOf(numbers, 2), 1, 'can compute indexOf');
     var result = (function(){ return _.indexOf(arguments, 2); }(1, 2, 3));
@@ -343,7 +343,7 @@
     assert.equal(index, -1, 'empty array with truthy `isSorted` returns -1');
   });
 
-  test('indexOf with NaN', function(assert) {
+  QUnit.test('indexOf with NaN', function(assert) {
     assert.strictEqual(_.indexOf([1, 2, NaN, NaN], NaN), 2, 'Expected [1, 2, NaN] to contain NaN');
     assert.strictEqual(_.indexOf([1, 2, Infinity], NaN), -1, 'Expected [1, 2, NaN] to contain NaN');
 
@@ -355,14 +355,14 @@
     }(1, 2, NaN, NaN));
   });
 
-  test('indexOf with +- 0', function(assert) {
+  QUnit.test('indexOf with +- 0', function(assert) {
     _.each([-0, +0], function(val) {
       assert.strictEqual(_.indexOf([1, 2, val, val], val), 2);
       assert.strictEqual(_.indexOf([1, 2, val, val], -val), 2);
     });
   });
 
-  test('lastIndexOf', function(assert) {
+  QUnit.test('lastIndexOf', function(assert) {
     var numbers = [1, 0, 1];
     var falsey = [void 0, '', 0, false, NaN, null, void 0];
     assert.equal(_.lastIndexOf(numbers, 1), 2);
@@ -420,7 +420,7 @@
     }), [0, -1, -1]);
   });
 
-  test('lastIndexOf with NaN', function(assert) {
+  QUnit.test('lastIndexOf with NaN', function(assert) {
     assert.strictEqual(_.lastIndexOf([1, 2, NaN, NaN], NaN), 3, 'Expected [1, 2, NaN] to contain NaN');
     assert.strictEqual(_.lastIndexOf([1, 2, Infinity], NaN), -1, 'Expected [1, 2, NaN] to contain NaN');
 
@@ -432,7 +432,7 @@
     }(1, 2, NaN, NaN));
   });
 
-  test('lastIndexOf with +- 0', function(assert) {
+  QUnit.test('lastIndexOf with +- 0', function(assert) {
     _.each([-0, +0], function(val) {
       assert.strictEqual(_.lastIndexOf([1, 2, val, val], val), 3);
       assert.strictEqual(_.lastIndexOf([1, 2, val, val], -val), 3);
@@ -440,7 +440,7 @@
     });
   });
 
-  test('findIndex', function(assert) {
+  QUnit.test('findIndex', function(assert) {
     var objects = [
       {a: 0, b: 0},
       {a: 1, b: 1},
@@ -483,7 +483,7 @@
     assert.strictEqual(_.findIndex(array, function(x) { return x === 55; }), -1, 'doesn\'t match array-likes keys');
   });
 
-  test('findLastIndex', function(assert) {
+  QUnit.test('findLastIndex', function(assert) {
     var objects = [
       {a: 0, b: 0},
       {a: 1, b: 1},
@@ -526,7 +526,7 @@
     assert.strictEqual(_.findLastIndex(array, function(x) { return x === 55; }), -1, 'doesn\'t match array-likes keys');
   });
 
-  test('range', function(assert) {
+  QUnit.test('range', function(assert) {
     assert.deepEqual(_.range(0), [], 'range with 0 as a first argument generates an empty array');
     assert.deepEqual(_.range(4), [0, 1, 2, 3], 'range with a single positive argument generates an array of elements 0,1,2,...,n-1');
     assert.deepEqual(_.range(5, 8), [5, 6, 7], 'range with two arguments a &amp; b, a&lt;b generates an array of elements a,a+1,a+2,...,b-2,b-1');
@@ -539,7 +539,7 @@
     assert.deepEqual(_.range(-3), [0, -1, -2], 'negative range generates descending array');
   });
 
-  test('chunk', function(assert) {
+  QUnit.test('chunk', function(assert) {
     assert.deepEqual(_.chunk([], 2), [], 'chunk for empty array returns an empty array');
 
     assert.deepEqual(_.chunk([1, 2, 3], 0), [], 'chunk into parts of 0 elements returns empty array');

--- a/test/chaining.js
+++ b/test/chaining.js
@@ -3,7 +3,7 @@
 
   QUnit.module('Chaining');
 
-  test('map/flatten/reduce', function(assert) {
+  QUnit.test('map/flatten/reduce', function(assert) {
     var lyrics = [
       'I\'m a lumberjack and I\'m okay',
       'I sleep all night and I work all day',
@@ -23,7 +23,7 @@
     assert.equal(counts.e, 10, 'counted all the letters in the song');
   });
 
-  test('select/reject/sortBy', function(assert) {
+  QUnit.test('select/reject/sortBy', function(assert) {
     var numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     numbers = _(numbers).chain().select(function(n) {
       return n % 2 === 0;
@@ -35,7 +35,7 @@
     assert.deepEqual(numbers, [10, 6, 2], 'filtered and reversed the numbers');
   });
 
-  test('select/reject/sortBy in functional style', function(assert) {
+  QUnit.test('select/reject/sortBy in functional style', function(assert) {
     var numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     numbers = _.chain(numbers).select(function(n) {
       return n % 2 === 0;
@@ -47,7 +47,7 @@
     assert.deepEqual(numbers, [10, 6, 2], 'filtered and reversed the numbers');
   });
 
-  test('reverse/concat/unshift/pop/map', function(assert) {
+  QUnit.test('reverse/concat/unshift/pop/map', function(assert) {
     var numbers = [1, 2, 3, 4, 5];
     numbers = _(numbers).chain()
       .reverse()
@@ -59,7 +59,7 @@
     assert.deepEqual(numbers, [34, 10, 8, 6, 4, 2, 10, 10], 'can chain together array functions.');
   });
 
-  test('splice', function(assert) {
+  QUnit.test('splice', function(assert) {
     var instance = _([1, 2, 3, 4, 5]).chain();
     assert.deepEqual(instance.splice(1, 3).value(), [1, 5]);
     assert.deepEqual(instance.splice(1, 0).value(), [1, 5]);
@@ -67,27 +67,27 @@
     assert.deepEqual(instance.splice(0, 1).value(), [], '#397 Can create empty array');
   });
 
-  test('shift', function(assert) {
+  QUnit.test('shift', function(assert) {
     var instance = _([1, 2, 3]).chain();
     assert.deepEqual(instance.shift().value(), [2, 3]);
     assert.deepEqual(instance.shift().value(), [3]);
     assert.deepEqual(instance.shift().value(), [], '#397 Can create empty array');
   });
 
-  test('pop', function(assert) {
+  QUnit.test('pop', function(assert) {
     var instance = _([1, 2, 3]).chain();
     assert.deepEqual(instance.pop().value(), [1, 2]);
     assert.deepEqual(instance.pop().value(), [1]);
     assert.deepEqual(instance.pop().value(), [], '#397 Can create empty array');
   });
 
-  test('chaining works in small stages', function(assert) {
+  QUnit.test('chaining works in small stages', function(assert) {
     var o = _([1, 2, 3, 4]).chain();
     assert.deepEqual(o.filter(function(i) { return i < 3; }).value(), [1, 2]);
     assert.deepEqual(o.filter(function(i) { return i > 2; }).value(), [3, 4]);
   });
 
-  test('#1562: Engine proxies for chained functions', function(assert) {
+  QUnit.test('#1562: Engine proxies for chained functions', function(assert) {
     var wrapped = _(512);
     assert.strictEqual(wrapped.toJSON(), 512);
     assert.strictEqual(wrapped.valueOf(), 512);

--- a/test/collections.js
+++ b/test/collections.js
@@ -453,7 +453,8 @@
   });
 
 
-  QUnit.test('invoke', 5, function(assert) {
+  QUnit.test('invoke', function(assert) {
+    assert.expect(5);
     var list = [[5, 1, 7], [3, 2, 1]];
     var result = _.invoke(list, 'sort');
     assert.deepEqual(result[0], [1, 5, 7], 'first array sorted');

--- a/test/collections.js
+++ b/test/collections.js
@@ -3,7 +3,7 @@
 
   QUnit.module('Collections');
 
-  test('each', function(assert) {
+  QUnit.test('each', function(assert) {
     _.each([1, 2, 3], function(num, i) {
       assert.equal(num, i + 1, 'each iterators provide value and iteration count');
     });
@@ -45,11 +45,11 @@
     assert.strictEqual(_.each(null, function(){}), null);
   });
 
-  test('forEach', function(assert) {
+  QUnit.test('forEach', function(assert) {
     assert.strictEqual(_.forEach, _.each, 'is an alias for each');
   });
 
-  test('lookupIterator with contexts', function(assert) {
+  QUnit.test('lookupIterator with contexts', function(assert) {
     _.each([true, false, 'yes', '', 0, 1, {}], function(context) {
       _.each([1], function() {
         assert.equal(this, context);
@@ -57,7 +57,7 @@
     });
   });
 
-  test('Iterating objects with sketchy length properties', function(assert) {
+  QUnit.test('Iterating objects with sketchy length properties', function(assert) {
     var functions = [
         'each', 'map', 'filter', 'find',
         'some', 'every', 'max', 'min',
@@ -101,7 +101,7 @@
     });
   });
 
-  test('Resistant to collection length and properties changing while iterating', function(assert) {
+  QUnit.test('Resistant to collection length and properties changing while iterating', function(assert) {
 
     var collection = [
       'each', 'map', 'filter', 'find',
@@ -145,7 +145,7 @@
     });
   });
 
-  test('map', function(assert) {
+  QUnit.test('map', function(assert) {
     var doubled = _.map([1, 2, 3], function(num){ return num * 2; });
     assert.deepEqual(doubled, [2, 4, 6], 'doubled numbers');
 
@@ -171,11 +171,11 @@
     assert.deepEqual(_.map(people, 'name'), ['moe', 'curly'], 'predicate string map to object properties');
   });
 
-  test('collect', function(assert) {
+  QUnit.test('collect', function(assert) {
     assert.strictEqual(_.collect, _.map, 'is an alias for map');
   });
 
-  test('reduce', function(assert) {
+  QUnit.test('reduce', function(assert) {
     var sum = _.reduce([1, 2, 3], function(memo, num){ return memo + num; }, 0);
     assert.equal(sum, 6, 'can sum up an array');
 
@@ -198,15 +198,15 @@
     assert.equal(_.reduce([], _.noop), void 0, 'returns undefined when collection is empty and no initial value');
   });
 
-  test('foldl', function(assert) {
+  QUnit.test('foldl', function(assert) {
     assert.strictEqual(_.foldl, _.reduce, 'is an alias for reduce');
   });
 
-  test('inject', function(assert) {
+  QUnit.test('inject', function(assert) {
     assert.strictEqual(_.inject, _.reduce, 'is an alias for reduce');
   });
 
-  test('reduceRight', function(assert) {
+  QUnit.test('reduceRight', function(assert) {
     var list = _.reduceRight(['foo', 'bar', 'baz'], function(memo, str){ return memo + str; }, '');
     assert.equal(list, 'bazbarfoo', 'can perform right folds');
 
@@ -256,11 +256,11 @@
     assert.deepEqual(args, expected);
   });
 
-  test('foldr', function(assert) {
+  QUnit.test('foldr', function(assert) {
     assert.strictEqual(_.foldr, _.reduceRight, 'is an alias for reduceRight');
   });
 
-  test('find', function(assert) {
+  QUnit.test('find', function(assert) {
     var array = [1, 2, 3, 4];
     assert.strictEqual(_.find(array, function(n) { return n > 2; }), 3, 'should return first found `value`');
     assert.strictEqual(_.find(array, function() { return false; }), void 0, 'should return `undefined` if `value` is not found');
@@ -298,11 +298,11 @@
     }, _);
   });
 
-  test('detect', function(assert) {
+  QUnit.test('detect', function(assert) {
     assert.strictEqual(_.detect, _.find, 'is an alias for find');
   });
 
-  test('filter', function(assert) {
+  QUnit.test('filter', function(assert) {
     var evenArray = [1, 2, 3, 4, 5, 6];
     var evenObject = {one: 1, two: 2, three: 3};
     var isEven = function(num){ return num % 2 === 0; };
@@ -323,11 +323,11 @@
     assert.deepEqual(_(list).filter({}), list, 'OO-filter');
   });
 
-  test('select', function(assert) {
+  QUnit.test('select', function(assert) {
     assert.strictEqual(_.select, _.filter, 'is an alias for filter');
   });
 
-  test('reject', function(assert) {
+  QUnit.test('reject', function(assert) {
     var odds = _.reject([1, 2, 3, 4, 5, 6], function(num){ return num % 2 === 0; });
     assert.deepEqual(odds, [1, 3, 5], 'rejected each even number');
 
@@ -349,7 +349,7 @@
     assert.deepEqual(_.reject(list, []), [], 'Returns empty list given empty array');
   });
 
-  test('every', function(assert) {
+  QUnit.test('every', function(assert) {
     assert.ok(_.every([], _.identity), 'the empty set');
     assert.ok(_.every([true, true, true], _.identity), 'every true values');
     assert.ok(!_.every([true, false, true], _.identity), 'one false value');
@@ -373,11 +373,11 @@
     assert.ok(!_.every(['a', 'b', 'c', 'd', 'f'], _.hasOwnProperty, {a: 1, b: 2, c: 3, d: 4}), 'context works');
   });
 
-  test('all', function(assert) {
+  QUnit.test('all', function(assert) {
     assert.strictEqual(_.all, _.every, 'is an alias for every');
   });
 
-  test('some', function(assert) {
+  QUnit.test('some', function(assert) {
     assert.ok(!_.some([]), 'the empty set');
     assert.ok(!_.some([false, false, false]), 'all false values');
     assert.ok(_.some([false, false, true]), 'one true value');
@@ -403,11 +403,11 @@
     assert.ok(!_.some(['x', 'y', 'z'], _.hasOwnProperty, {a: 1, b: 2, c: 3, d: 4}), 'context works');
   });
 
-  test('any', function(assert) {
+  QUnit.test('any', function(assert) {
     assert.strictEqual(_.any, _.some, 'is an alias for some');
   });
 
-  test('includes', function(assert) {
+  QUnit.test('includes', function(assert) {
     _.each([null, void 0, 0, 1, NaN, {}, []], function(val) {
       assert.strictEqual(_.includes(val, 'hasOwnProperty'), false);
     });
@@ -430,21 +430,21 @@
     assert.ok(_.every([1, 2, 3], _.partial(_.includes, numbers)), 'fromIndex is guarded');
   });
 
-  test('include', function(assert) {
+  QUnit.test('include', function(assert) {
     assert.strictEqual(_.include, _.includes, 'is an alias for includes');
   });
 
-  test('contains', function(assert) {
+  QUnit.test('contains', function(assert) {
     assert.strictEqual(_.contains, _.includes, 'is an alias for includes');
 
   });
 
-  test('includes with NaN', function(assert) {
+  QUnit.test('includes with NaN', function(assert) {
     assert.strictEqual(_.includes([1, 2, NaN, NaN], NaN), true, 'Expected [1, 2, NaN] to contain NaN');
     assert.strictEqual(_.includes([1, 2, Infinity], NaN), false, 'Expected [1, 2, NaN] to contain NaN');
   });
 
-  test('includes with +- 0', function(assert) {
+  QUnit.test('includes with +- 0', function(assert) {
     _.each([-0, +0], function(val) {
       assert.strictEqual(_.includes([1, 2, val, val], val), true);
       assert.strictEqual(_.includes([1, 2, val, val], -val), true);
@@ -453,7 +453,7 @@
   });
 
 
-  test('invoke', 5, function(assert) {
+  QUnit.test('invoke', 5, function(assert) {
     var list = [[5, 1, 7], [3, 2, 1]];
     var result = _.invoke(list, 'sort');
     assert.deepEqual(result[0], [1, 5, 7], 'first array sorted');
@@ -472,7 +472,7 @@
     }, TypeError, 'throws for non-functions');
   });
 
-  test('invoke w/ function reference', function(assert) {
+  QUnit.test('invoke w/ function reference', function(assert) {
     var list = [[5, 1, 7], [3, 2, 1]];
     var result = _.invoke(list, Array.prototype.sort);
     assert.deepEqual(result[0], [1, 5, 7], 'first array sorted');
@@ -484,7 +484,7 @@
   });
 
   // Relevant when using ClojureScript
-  test('invoke when strings have a call method', function(assert) {
+  QUnit.test('invoke when strings have a call method', function(assert) {
     String.prototype.call = function() {
       return 42;
     };
@@ -498,7 +498,7 @@
     assert.equal(s.call, void 0, 'call function removed');
   });
 
-  test('pluck', function(assert) {
+  QUnit.test('pluck', function(assert) {
     var people = [{name: 'moe', age: 30}, {name: 'curly', age: 50}];
     assert.deepEqual(_.pluck(people, 'name'), ['moe', 'curly'], 'pulls names out of objects');
     assert.deepEqual(_.pluck(people, 'address'), [void 0, void 0], 'missing properties are returned as undefined');
@@ -506,7 +506,7 @@
     assert.deepEqual(_.pluck([{'[object Object]': 1}], {}), [1]);
   });
 
-  test('where', function(assert) {
+  QUnit.test('where', function(assert) {
     var list = [{a: 1, b: 2}, {a: 2, b: 2}, {a: 1, b: 3}, {a: 1, b: 4}];
     var result = _.where(list, {a: 1});
     assert.equal(result.length, 3);
@@ -522,7 +522,7 @@
     assert.deepEqual(_.where([_, {a: 1, b: 2}, _], test), [_, _], 'checks properties given function');
   });
 
-  test('findWhere', function(assert) {
+  QUnit.test('findWhere', function(assert) {
     var list = [{a: 1, b: 2}, {a: 2, b: 2}, {a: 1, b: 3}, {a: 1, b: 4}, {a: 2, b: 4}];
     var result = _.findWhere(list, {a: 1});
     assert.deepEqual(result, {a: 1, b: 2});
@@ -547,7 +547,7 @@
     assert.deepEqual(_.findWhere([{y: 5, b: 6}, expect], new TestClass()), expect, 'uses class instance properties');
   });
 
-  test('max', function(assert) {
+  QUnit.test('max', function(assert) {
     assert.equal(-Infinity, _.max(null), 'can handle null/undefined');
     assert.equal(-Infinity, _.max(void 0), 'can handle null/undefined');
     assert.equal(-Infinity, _.max(null, _.identity), 'can handle null/undefined');
@@ -592,7 +592,7 @@
     assert.deepEqual(_.max([{0: 1}, {0: 2}, {0: -1}, {a: 1}], 0), {0: 2}, 'Lookup falsy iterator');
   });
 
-  test('min', function(assert) {
+  QUnit.test('min', function(assert) {
     assert.equal(Infinity, _.min(null), 'can handle null/undefined');
     assert.equal(Infinity, _.min(void 0), 'can handle null/undefined');
     assert.equal(Infinity, _.min(null, _.identity), 'can handle null/undefined');
@@ -635,7 +635,7 @@
     assert.deepEqual(_.min([{0: 1}, {0: 2}, {0: -1}, {a: 1}], 0), {0: -1}, 'Lookup falsy iterator');
   });
 
-  test('sortBy', function(assert) {
+  QUnit.test('sortBy', function(assert) {
     var people = [{name: 'curly', age: 50}, {name: 'moe', age: 30}];
     people = _.sortBy(people, function(person){ return person.age; });
     assert.deepEqual(_.pluck(people, 'name'), ['moe', 'curly'], 'stooges sorted by age');
@@ -683,7 +683,7 @@
     assert.deepEqual(_.sortBy(list), ['e', 'q', 'r', 't', 'w', 'y'], 'uses _.identity if iterator is not specified');
   });
 
-  test('groupBy', function(assert) {
+  QUnit.test('groupBy', function(assert) {
     var parity = _.groupBy([1, 2, 3, 4, 5, 6], function(num){ return num % 2; });
     assert.ok('0' in parity && '1' in parity, 'created a group for each value');
     assert.deepEqual(parity[0], [2, 4, 6], 'put each even number in the right group');
@@ -720,7 +720,7 @@
     assert.deepEqual(_.groupBy(matrix, 1), {2: [[1, 2]], 3: [[1, 3], [2, 3]]});
   });
 
-  test('indexBy', function(assert) {
+  QUnit.test('indexBy', function(assert) {
     var parity = _.indexBy([1, 2, 3, 4, 5], function(num){ return num % 2 === 0; });
     assert.equal(parity['true'], 4);
     assert.equal(parity['false'], 5);
@@ -738,7 +738,7 @@
     assert.equal(grouped['3'], 3);
   });
 
-  test('countBy', function(assert) {
+  QUnit.test('countBy', function(assert) {
     var parity = _.countBy([1, 2, 3, 4, 5], function(num){ return num % 2 === 0; });
     assert.equal(parity['true'], 2);
     assert.equal(parity['false'], 3);
@@ -767,7 +767,7 @@
     assert.equal(grouped['3'], 1);
   });
 
-  test('shuffle', function(assert) {
+  QUnit.test('shuffle', function(assert) {
     assert.deepEqual(_.shuffle([1]), [1], 'behaves correctly on size 1 arrays');
     var numbers = _.range(20);
     var shuffled = _.shuffle(numbers);
@@ -780,7 +780,7 @@
     assert.deepEqual(shuffled.sort(), [1, 2, 3, 4], 'works on objects');
   });
 
-  test('sample', function(assert) {
+  QUnit.test('sample', function(assert) {
     assert.strictEqual(_.sample([1]), 1, 'behaves correctly when no second parameter is given');
     assert.deepEqual(_.sample([1, 2, 3], -2), [], 'behaves correctly on negative n');
     var numbers = _.range(10);
@@ -799,7 +799,7 @@
     assert.notDeepEqual(partialSampleSorted, _.range(10), 'samples from the whole array, not just the beginning');
   });
 
-  test('toArray', function(assert) {
+  QUnit.test('toArray', function(assert) {
     assert.ok(!_.isArray(arguments), 'arguments object is not an array');
     assert.ok(_.isArray(_.toArray(arguments)), 'arguments object converted into array');
     var a = [1, 2, 3];
@@ -825,7 +825,7 @@
     }
   });
 
-  test('size', function(assert) {
+  QUnit.test('size', function(assert) {
     assert.equal(_.size({one: 1, two: 2, three: 3}), 3, 'can compute the size of an object');
     assert.equal(_.size([1, 2, 3]), 3, 'can compute the size of an array');
     assert.equal(_.size({length: 3, 0: 0, 1: 0, 2: 0}), 3, 'can compute the size of Array-likes');
@@ -843,7 +843,7 @@
     assert.equal(_.size(0), 0, 'handles numbers');
   });
 
-  test('partition', function(assert) {
+  QUnit.test('partition', function(assert) {
     var list = [0, 1, 2, 3, 4, 5];
     assert.deepEqual(_.partition(list, function(x) { return x < 4; }), [[0, 1, 2, 3], [4, 5]], 'handles bool return values');
     assert.deepEqual(_.partition(list, function(x) { return x & 1; }), [[1, 3, 5], [0, 2, 4]], 'handles 0 and 1 return values');
@@ -875,7 +875,7 @@
   });
 
   if (typeof document != 'undefined') {
-    test('Can use various collection methods on NodeLists', function(assert) {
+    QUnit.test('Can use various collection methods on NodeLists', function(assert) {
       var parent = document.createElement('div');
       parent.innerHTML = '<span id=id1></span>textnode<span id=id2></span>';
 

--- a/test/cross-document.js
+++ b/test/cross-document.js
@@ -33,7 +33,7 @@
   );
   iDoc.close();
 
-  test('isEqual', function(assert) {
+  QUnit.test('isEqual', function(assert) {
 
     assert.ok(!_.isEqual(iNumber, 101));
     assert.ok(_.isEqual(iNumber, 100));
@@ -45,73 +45,73 @@
     assert.ok(_.isEqual([1, 2, 3], iArray), 'Arrays with equivalent elements created in different documents are equal');
   });
 
-  test('isEmpty', function(assert) {
+  QUnit.test('isEmpty', function(assert) {
     assert.ok(!_([iNumber]).isEmpty(), '[1] is not empty');
     assert.ok(!_.isEmpty(iArray), '[] is empty');
     assert.ok(_.isEmpty(iObject), '{} is empty');
   });
 
-  test('isElement', function(assert) {
+  QUnit.test('isElement', function(assert) {
     assert.ok(!_.isElement('div'), 'strings are not dom elements');
     assert.ok(_.isElement(document.body), 'the body tag is a DOM element');
     assert.ok(_.isElement(iElement), 'even from another frame');
   });
 
-  test('isArguments', function(assert) {
+  QUnit.test('isArguments', function(assert) {
     assert.ok(_.isArguments(iArguments), 'even from another frame');
   });
 
-  test('isObject', function(assert) {
+  QUnit.test('isObject', function(assert) {
     assert.ok(_.isObject(iElement), 'even from another frame');
     assert.ok(_.isObject(iFunction), 'even from another frame');
   });
 
-  test('isArray', function(assert) {
+  QUnit.test('isArray', function(assert) {
     assert.ok(_.isArray(iArray), 'even from another frame');
   });
 
-  test('isString', function(assert) {
+  QUnit.test('isString', function(assert) {
     assert.ok(_.isString(iString), 'even from another frame');
   });
 
-  test('isNumber', function(assert) {
+  QUnit.test('isNumber', function(assert) {
     assert.ok(_.isNumber(iNumber), 'even from another frame');
   });
 
-  test('isBoolean', function(assert) {
+  QUnit.test('isBoolean', function(assert) {
     assert.ok(_.isBoolean(iBoolean), 'even from another frame');
   });
 
-  test('isFunction', function(assert) {
+  QUnit.test('isFunction', function(assert) {
     assert.ok(_.isFunction(iFunction), 'even from another frame');
   });
 
-  test('isDate', function(assert) {
+  QUnit.test('isDate', function(assert) {
     assert.ok(_.isDate(iDate), 'even from another frame');
   });
 
-  test('isRegExp', function(assert) {
+  QUnit.test('isRegExp', function(assert) {
     assert.ok(_.isRegExp(iRegExp), 'even from another frame');
   });
 
-  test('isNaN', function(assert) {
+  QUnit.test('isNaN', function(assert) {
     assert.ok(_.isNaN(iNaN), 'even from another frame');
   });
 
-  test('isNull', function(assert) {
+  QUnit.test('isNull', function(assert) {
     assert.ok(_.isNull(iNull), 'even from another frame');
   });
 
-  test('isUndefined', function(assert) {
+  QUnit.test('isUndefined', function(assert) {
     assert.ok(_.isUndefined(iUndefined), 'even from another frame');
   });
 
-  test('isError', function(assert) {
+  QUnit.test('isError', function(assert) {
     assert.ok(_.isError(iError), 'even from another frame');
   });
 
   if (typeof ActiveXObject != 'undefined') {
-    test('IE host objects', function(assert) {
+    QUnit.test('IE host objects', function(assert) {
       var xml = new ActiveXObject('Msxml2.DOMDocument.3.0');
       assert.ok(!_.isNumber(xml));
       assert.ok(!_.isBoolean(xml));
@@ -121,7 +121,7 @@
       assert.ok(!_.isUndefined(xml));
     });
 
-    test('#1621 IE 11 compat mode DOM elements are not functions', function(assert) {
+    QUnit.test('#1621 IE 11 compat mode DOM elements are not functions', function(assert) {
       var fn = function() {};
       var xml = new ActiveXObject('Msxml2.DOMDocument.3.0');
       var div = document.createElement('div');

--- a/test/functions.js
+++ b/test/functions.js
@@ -4,7 +4,7 @@
   QUnit.module('Functions');
   QUnit.config.asyncRetries = 3;
 
-  test('bind', function(assert) {
+  QUnit.test('bind', function(assert) {
     var context = {name: 'moe'};
     var func = function(arg) { return 'name: ' + (this.name || arg); };
     var bound = _.bind(func, context);
@@ -47,7 +47,7 @@
     assert.raises(function() { _.bind('notafunction'); }, TypeError, 'throws an error when binding to a non-function');
   });
 
-  test('partial', function(assert) {
+  QUnit.test('partial', function(assert) {
     var obj = {name: 'moe'};
     var func = function() { return this.name + ' ' + _.toArray(arguments).join(' '); };
 
@@ -89,7 +89,7 @@
     _.partial.placeholder = _;
   });
 
-  test('bindAll', function(assert) {
+  QUnit.test('bindAll', function(assert) {
     var curly = {name: 'curly'}, moe = {
       name: 'moe',
       getName: function() { return 'name: ' + this.name; },
@@ -125,7 +125,7 @@
     assert.equal(getName(), 'name: moe', 'flattens arguments into a single list');
   });
 
-  test('memoize', function(assert) {
+  QUnit.test('memoize', function(assert) {
     var fib = function(n) {
       return n < 2 ? n : fib(n - 1) + fib(n - 2);
     };
@@ -525,7 +525,7 @@
     }, 100);
   });
 
-  test('once', function(assert) {
+  QUnit.test('once', function(assert) {
     var num = 0;
     var increment = _.once(function(){ return ++num; });
     increment();
@@ -535,7 +535,7 @@
     assert.equal(increment(), 1, 'stores a memo to the last value');
   });
 
-  test('Recursive onced function.', 1, function(assert) {
+  QUnit.test('Recursive onced function.', 1, function(assert) {
     var f = _.once(function(){
       assert.ok(true);
       f();
@@ -543,7 +543,7 @@
     f();
   });
 
-  test('wrap', function(assert) {
+  QUnit.test('wrap', function(assert) {
     var greet = function(name){ return 'hi: ' + name; };
     var backwards = _.wrap(greet, function(func, name){ return func(name) + ' ' + name.split('').reverse().join(''); });
     assert.equal(backwards('moe'), 'hi: moe eom', 'wrapped the salutation function');
@@ -559,13 +559,13 @@
     assert.deepEqual(ret, [noop, ['whats', 'your'], 'vector', 'victor']);
   });
 
-  test('negate', function(assert) {
+  QUnit.test('negate', function(assert) {
     var isOdd = function(n){ return n & 1; };
     assert.equal(_.negate(isOdd)(2), true, 'should return the complement of the given function');
     assert.equal(_.negate(isOdd)(3), false, 'should return the complement of the given function');
   });
 
-  test('compose', function(assert) {
+  QUnit.test('compose', function(assert) {
     var greet = function(name){ return 'hi: ' + name; };
     var exclaim = function(sentence){ return sentence + '!'; };
     var composed = _.compose(exclaim, greet);
@@ -591,7 +591,7 @@
     assert.equal(composed(1, 2, 3), 12);
   });
 
-  test('after', function(assert) {
+  QUnit.test('after', function(assert) {
     var testAfter = function(afterAmount, timesCalled) {
       var afterCalled = 0;
       var after = _.after(afterAmount, function() {
@@ -607,7 +607,7 @@
     assert.equal(testAfter(0, 1), 1, 'after(0) should fire when first invoked');
   });
 
-  test('before', function(assert) {
+  QUnit.test('before', function(assert) {
     var testBefore = function(beforeAmount, timesCalled) {
       var beforeCalled = 0;
       var before = _.before(beforeAmount, function() { beforeCalled++; });
@@ -627,7 +627,7 @@
     assert.equal(context.num, 2, 'provides context');
   });
 
-  test('iteratee', function(assert) {
+  QUnit.test('iteratee', function(assert) {
     var identity = _.iteratee();
     assert.equal(identity, _.identity, '_.iteratee is exposed as an external function.');
 
@@ -642,7 +642,7 @@
 
   });
 
-  test('restArgs', 10, function(assert) {
+  QUnit.test('restArgs', 10, function(assert) {
     _.restArgs(function(a, args) {
       assert.strictEqual(a, 1);
       assert.deepEqual(args, [2, 3], 'collects rest arguments into an array');

--- a/test/functions.js
+++ b/test/functions.js
@@ -174,59 +174,66 @@
     assert.strictEqual(myObj.value, 'a', 'object is not modified if second argument used as key');
   });
 
-  asyncTest('delay', 2, function(assert) {
+  QUnit.test('delay', 2, function(assert) {
+    var done = assert.async();
     var delayed = false;
     _.delay(function(){ delayed = true; }, 100);
     setTimeout(function(){ assert.ok(!delayed, "didn't delay the function quite yet"); }, 50);
-    setTimeout(function(){ assert.ok(delayed, 'delayed the function'); start(); }, 150);
+    setTimeout(function(){ assert.ok(delayed, 'delayed the function'); done(); }, 150);
   });
 
-  asyncTest('defer', 1, function(assert) {
+  QUnit.test('defer', 1, function(assert) {
+    var done = assert.async();
     var deferred = false;
     _.defer(function(bool){ deferred = bool; }, true);
-    _.delay(function(){ assert.ok(deferred, 'deferred the function'); start(); }, 50);
+    _.delay(function(){ assert.ok(deferred, 'deferred the function'); done(); }, 50);
   });
 
-  asyncTest('throttle', 2, function(assert) {
+  QUnit.test('throttle', 2, function(assert) {
+    var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
     var throttledIncr = _.throttle(incr, 32);
     throttledIncr(); throttledIncr();
 
     assert.equal(counter, 1, 'incr was called immediately');
-    _.delay(function(){ assert.equal(counter, 2, 'incr was throttled'); start(); }, 64);
+    _.delay(function(){ assert.equal(counter, 2, 'incr was throttled'); done(); }, 64);
   });
 
-  asyncTest('throttle arguments', 2, function(assert) {
+  QUnit.test('throttle arguments', 2, function(assert) {
+    var done = assert.async();
     var value = 0;
     var update = function(val){ value = val; };
     var throttledUpdate = _.throttle(update, 32);
     throttledUpdate(1); throttledUpdate(2);
     _.delay(function(){ throttledUpdate(3); }, 64);
     assert.equal(value, 1, 'updated to latest value');
-    _.delay(function(){ assert.equal(value, 3, 'updated to latest value'); start(); }, 96);
+    _.delay(function(){ assert.equal(value, 3, 'updated to latest value'); done(); }, 96);
   });
 
-  asyncTest('throttle once', 2, function(assert) {
+  QUnit.test('throttle once', 2, function(assert) {
+    var done = assert.async();
     var counter = 0;
     var incr = function(){ return ++counter; };
     var throttledIncr = _.throttle(incr, 32);
     var result = throttledIncr();
     _.delay(function(){
       assert.equal(result, 1, 'throttled functions return their value');
-      assert.equal(counter, 1, 'incr was called once'); start();
+      assert.equal(counter, 1, 'incr was called once'); done();
     }, 64);
   });
 
-  asyncTest('throttle twice', 1, function(assert) {
+  QUnit.test('throttle twice', 1, function(assert) {
+    var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
     var throttledIncr = _.throttle(incr, 32);
     throttledIncr(); throttledIncr();
-    _.delay(function(){ assert.equal(counter, 2, 'incr was called twice'); start(); }, 64);
+    _.delay(function(){ assert.equal(counter, 2, 'incr was called twice'); done(); }, 64);
   });
 
-  asyncTest('more throttling', 3, function(assert) {
+  QUnit.test('more throttling', 3, function(assert) {
+    var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
     var throttledIncr = _.throttle(incr, 30);
@@ -236,11 +243,12 @@
       assert.equal(counter, 2);
       throttledIncr();
       assert.equal(counter, 3);
-      start();
+      done();
     }, 85);
   });
 
-  asyncTest('throttle repeatedly with results', 6, function(assert) {
+  QUnit.test('throttle repeatedly with results', 6, function(assert) {
+    var done = assert.async();
     var counter = 0;
     var incr = function(){ return ++counter; };
     var throttledIncr = _.throttle(incr, 100);
@@ -258,11 +266,12 @@
       assert.equal(results[3], 2, 'incr was called twice');
       assert.equal(results[4], 2, 'incr was throttled');
       assert.equal(results[5], 3, 'incr was called trailing');
-      start();
+      done();
     }, 300);
   });
 
-  asyncTest('throttle triggers trailing call when invoked repeatedly', 2, function(assert) {
+  QUnit.test('throttle triggers trailing call when invoked repeatedly', 2, function(assert) {
+    var done = assert.async();
     var counter = 0;
     var limit = 48;
     var incr = function(){ counter++; };
@@ -277,11 +286,12 @@
 
     _.delay(function() {
       assert.ok(counter > lastCount);
-      start();
+      done();
     }, 96);
   });
 
-  asyncTest('throttle does not trigger leading call when leading is set to false', 2, function(assert) {
+  QUnit.test('throttle does not trigger leading call when leading is set to false', 2, function(assert) {
+    var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
     var throttledIncr = _.throttle(incr, 60, {leading: false});
@@ -291,11 +301,12 @@
 
     _.delay(function() {
       assert.equal(counter, 1);
-      start();
+      done();
     }, 96);
   });
 
-  asyncTest('more throttle does not trigger leading call when leading is set to false', 3, function(assert) {
+  QUnit.test('more throttle does not trigger leading call when leading is set to false', 3, function(assert) {
+    var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
     var throttledIncr = _.throttle(incr, 100, {leading: false});
@@ -312,11 +323,12 @@
 
     _.delay(function() {
       assert.equal(counter, 2);
-      start();
+      done();
     }, 350);
   });
 
-  asyncTest('one more throttle with leading: false test', 2, function(assert) {
+  QUnit.test('one more throttle with leading: false test', 2, function(assert) {
+    var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
     var throttledIncr = _.throttle(incr, 100, {leading: false});
@@ -327,11 +339,12 @@
 
     _.delay(function() {
       assert.ok(counter <= 4);
-      start();
+      done();
     }, 200);
   });
 
-  asyncTest('throttle does not trigger trailing call when trailing is set to false', 4, function(assert) {
+  QUnit.test('throttle does not trigger trailing call when trailing is set to false', 4, function(assert) {
+    var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
     var throttledIncr = _.throttle(incr, 60, {trailing: false});
@@ -347,12 +360,13 @@
 
       _.delay(function() {
         assert.equal(counter, 2);
-        start();
+        done();
       }, 96);
     }, 96);
   });
 
-  asyncTest('throttle continues to function after system time is set backwards', 2, function(assert) {
+  QUnit.test('throttle continues to function after system time is set backwards', 2, function(assert) {
+    var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
     var throttledIncr = _.throttle(incr, 100);
@@ -367,12 +381,13 @@
     _.delay(function() {
       throttledIncr();
       assert.equal(counter, 2);
-      start();
+      done();
       _.now = origNowFunc;
     }, 200);
   });
 
-  asyncTest('throttle re-entrant', 2, function(assert) {
+  QUnit.test('throttle re-entrant', 2, function(assert) {
+    var done = assert.async();
     var sequence = [
       ['b1', 'b2'],
       ['c1', 'c2']
@@ -391,11 +406,12 @@
     assert.equal(value, 'a1a2');
     _.delay(function(){
       assert.equal(value, 'a1a2c1c2b1b2', 'append was throttled successfully');
-      start();
+      done();
     }, 100);
   });
 
-  asyncTest('throttle cancel', function(assert) {
+  QUnit.test('throttle cancel', function(assert) {
+    var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
     var throttledIncr = _.throttle(incr, 32);
@@ -405,10 +421,11 @@
     throttledIncr();
 
     assert.equal(counter, 2, 'incr was called immediately');
-    _.delay(function(){ assert.equal(counter, 3, 'incr was throttled'); start(); }, 64);
+    _.delay(function(){ assert.equal(counter, 3, 'incr was throttled'); done(); }, 64);
   });
 
-  asyncTest('throttle cancel with leading: false', function(assert) {
+  QUnit.test('throttle cancel with leading: false', function(assert) {
+    var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
     var throttledIncr = _.throttle(incr, 32, {leading: false});
@@ -416,28 +433,31 @@
     throttledIncr.cancel();
 
     assert.equal(counter, 0, 'incr was throttled');
-    _.delay(function(){ assert.equal(counter, 0, 'incr was throttled'); start(); }, 64);
+    _.delay(function(){ assert.equal(counter, 0, 'incr was throttled'); done(); }, 64);
   });
 
-  asyncTest('debounce', 1, function(assert) {
+  QUnit.test('debounce', 1, function(assert) {
+    var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
     var debouncedIncr = _.debounce(incr, 32);
     debouncedIncr(); debouncedIncr();
     _.delay(debouncedIncr, 16);
-    _.delay(function(){ assert.equal(counter, 1, 'incr was debounced'); start(); }, 96);
+    _.delay(function(){ assert.equal(counter, 1, 'incr was debounced'); done(); }, 96);
   });
 
-  asyncTest('debounce cancel', 1, function(assert) {
+  QUnit.test('debounce cancel', 1, function(assert) {
+    var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
     var debouncedIncr = _.debounce(incr, 32);
     debouncedIncr();
     debouncedIncr.cancel();
-    _.delay(function(){ assert.equal(counter, 0, 'incr was not called'); start(); }, 96);
+    _.delay(function(){ assert.equal(counter, 0, 'incr was not called'); done(); }, 96);
   });
 
-  asyncTest('debounce asap', 4, function(assert) {
+  QUnit.test('debounce asap', 4, function(assert) {
+    var done = assert.async();
     var a, b;
     var counter = 0;
     var incr = function(){ return ++counter; };
@@ -450,10 +470,11 @@
     _.delay(debouncedIncr, 16);
     _.delay(debouncedIncr, 32);
     _.delay(debouncedIncr, 48);
-    _.delay(function(){ assert.equal(counter, 1, 'incr was debounced'); start(); }, 128);
+    _.delay(function(){ assert.equal(counter, 1, 'incr was debounced'); done(); }, 128);
   });
 
-  asyncTest('debounce asap cancel', 4, function(assert) {
+  QUnit.test('debounce asap cancel', 4, function(assert) {
+    var done = assert.async();
     var a, b;
     var counter = 0;
     var incr = function(){ return ++counter; };
@@ -467,10 +488,11 @@
     _.delay(debouncedIncr, 16);
     _.delay(debouncedIncr, 32);
     _.delay(debouncedIncr, 48);
-    _.delay(function(){ assert.equal(counter, 2, 'incr was debounced'); start(); }, 128);
+    _.delay(function(){ assert.equal(counter, 2, 'incr was debounced'); done(); }, 128);
   });
 
-  asyncTest('debounce asap recursively', 2, function(assert) {
+  QUnit.test('debounce asap recursively', 2, function(assert) {
+    var done = assert.async();
     var counter = 0;
     var debouncedIncr = _.debounce(function(){
       counter++;
@@ -478,10 +500,11 @@
     }, 32, true);
     debouncedIncr();
     assert.equal(counter, 1, 'incr was called immediately');
-    _.delay(function(){ assert.equal(counter, 1, 'incr was debounced'); start(); }, 96);
+    _.delay(function(){ assert.equal(counter, 1, 'incr was debounced'); done(); }, 96);
   });
 
-  asyncTest('debounce after system time is set backwards', 2, function(assert) {
+  QUnit.test('debounce after system time is set backwards', 2, function(assert) {
+    var done = assert.async();
     var counter = 0;
     var origNowFunc = _.now;
     var debouncedIncr = _.debounce(function(){
@@ -498,12 +521,13 @@
     _.delay(function() {
       debouncedIncr();
       assert.equal(counter, 2, 'incr was debounced successfully');
-      start();
+      done();
       _.now = origNowFunc;
     }, 200);
   });
 
-  asyncTest('debounce re-entrant', 2, function(assert) {
+  QUnit.test('debounce re-entrant', 2, function(assert) {
+    var done = assert.async();
     var sequence = [
       ['b1', 'b2']
     ];
@@ -521,7 +545,7 @@
     assert.equal(value, '');
     _.delay(function(){
       assert.equal(value, 'a1a2b1b2', 'append was debounced successfully');
-      start();
+      done();
     }, 100);
   });
 

--- a/test/functions.js
+++ b/test/functions.js
@@ -174,7 +174,8 @@
     assert.strictEqual(myObj.value, 'a', 'object is not modified if second argument used as key');
   });
 
-  QUnit.test('delay', 2, function(assert) {
+  QUnit.test('delay', function(assert) {
+    assert.expect(2);
     var done = assert.async();
     var delayed = false;
     _.delay(function(){ delayed = true; }, 100);
@@ -182,14 +183,16 @@
     setTimeout(function(){ assert.ok(delayed, 'delayed the function'); done(); }, 150);
   });
 
-  QUnit.test('defer', 1, function(assert) {
+  QUnit.test('defer', function(assert) {
+    assert.expect(1);
     var done = assert.async();
     var deferred = false;
     _.defer(function(bool){ deferred = bool; }, true);
     _.delay(function(){ assert.ok(deferred, 'deferred the function'); done(); }, 50);
   });
 
-  QUnit.test('throttle', 2, function(assert) {
+  QUnit.test('throttle', function(assert) {
+    assert.expect(2);
     var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
@@ -200,7 +203,8 @@
     _.delay(function(){ assert.equal(counter, 2, 'incr was throttled'); done(); }, 64);
   });
 
-  QUnit.test('throttle arguments', 2, function(assert) {
+  QUnit.test('throttle arguments', function(assert) {
+    assert.expect(2);
     var done = assert.async();
     var value = 0;
     var update = function(val){ value = val; };
@@ -211,7 +215,8 @@
     _.delay(function(){ assert.equal(value, 3, 'updated to latest value'); done(); }, 96);
   });
 
-  QUnit.test('throttle once', 2, function(assert) {
+  QUnit.test('throttle once', function(assert) {
+    assert.expect(2);
     var done = assert.async();
     var counter = 0;
     var incr = function(){ return ++counter; };
@@ -223,7 +228,8 @@
     }, 64);
   });
 
-  QUnit.test('throttle twice', 1, function(assert) {
+  QUnit.test('throttle twice', function(assert) {
+    assert.expect(1);
     var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
@@ -232,7 +238,8 @@
     _.delay(function(){ assert.equal(counter, 2, 'incr was called twice'); done(); }, 64);
   });
 
-  QUnit.test('more throttling', 3, function(assert) {
+  QUnit.test('more throttling', function(assert) {
+    assert.expect(3);
     var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
@@ -247,7 +254,8 @@
     }, 85);
   });
 
-  QUnit.test('throttle repeatedly with results', 6, function(assert) {
+  QUnit.test('throttle repeatedly with results', function(assert) {
+    assert.expect(6);
     var done = assert.async();
     var counter = 0;
     var incr = function(){ return ++counter; };
@@ -270,7 +278,8 @@
     }, 300);
   });
 
-  QUnit.test('throttle triggers trailing call when invoked repeatedly', 2, function(assert) {
+  QUnit.test('throttle triggers trailing call when invoked repeatedly', function(assert) {
+    assert.expect(2);
     var done = assert.async();
     var counter = 0;
     var limit = 48;
@@ -290,7 +299,8 @@
     }, 96);
   });
 
-  QUnit.test('throttle does not trigger leading call when leading is set to false', 2, function(assert) {
+  QUnit.test('throttle does not trigger leading call when leading is set to false', function(assert) {
+    assert.expect(2);
     var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
@@ -305,7 +315,8 @@
     }, 96);
   });
 
-  QUnit.test('more throttle does not trigger leading call when leading is set to false', 3, function(assert) {
+  QUnit.test('more throttle does not trigger leading call when leading is set to false', function(assert) {
+    assert.expect(3);
     var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
@@ -327,7 +338,8 @@
     }, 350);
   });
 
-  QUnit.test('one more throttle with leading: false test', 2, function(assert) {
+  QUnit.test('one more throttle with leading: false test', function(assert) {
+    assert.expect(2);
     var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
@@ -343,7 +355,8 @@
     }, 200);
   });
 
-  QUnit.test('throttle does not trigger trailing call when trailing is set to false', 4, function(assert) {
+  QUnit.test('throttle does not trigger trailing call when trailing is set to false', function(assert) {
+    assert.expect(4);
     var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
@@ -365,7 +378,8 @@
     }, 96);
   });
 
-  QUnit.test('throttle continues to function after system time is set backwards', 2, function(assert) {
+  QUnit.test('throttle continues to function after system time is set backwards', function(assert) {
+    assert.expect(2);
     var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
@@ -386,7 +400,8 @@
     }, 200);
   });
 
-  QUnit.test('throttle re-entrant', 2, function(assert) {
+  QUnit.test('throttle re-entrant', function(assert) {
+    assert.expect(2);
     var done = assert.async();
     var sequence = [
       ['b1', 'b2'],
@@ -436,7 +451,8 @@
     _.delay(function(){ assert.equal(counter, 0, 'incr was throttled'); done(); }, 64);
   });
 
-  QUnit.test('debounce', 1, function(assert) {
+  QUnit.test('debounce', function(assert) {
+    assert.expect(1);
     var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
@@ -446,7 +462,8 @@
     _.delay(function(){ assert.equal(counter, 1, 'incr was debounced'); done(); }, 96);
   });
 
-  QUnit.test('debounce cancel', 1, function(assert) {
+  QUnit.test('debounce cancel', function(assert) {
+    assert.expect(1);
     var done = assert.async();
     var counter = 0;
     var incr = function(){ counter++; };
@@ -456,7 +473,8 @@
     _.delay(function(){ assert.equal(counter, 0, 'incr was not called'); done(); }, 96);
   });
 
-  QUnit.test('debounce asap', 4, function(assert) {
+  QUnit.test('debounce asap', function(assert) {
+    assert.expect(4);
     var done = assert.async();
     var a, b;
     var counter = 0;
@@ -473,7 +491,8 @@
     _.delay(function(){ assert.equal(counter, 1, 'incr was debounced'); done(); }, 128);
   });
 
-  QUnit.test('debounce asap cancel', 4, function(assert) {
+  QUnit.test('debounce asap cancel', function(assert) {
+    assert.expect(4);
     var done = assert.async();
     var a, b;
     var counter = 0;
@@ -491,7 +510,8 @@
     _.delay(function(){ assert.equal(counter, 2, 'incr was debounced'); done(); }, 128);
   });
 
-  QUnit.test('debounce asap recursively', 2, function(assert) {
+  QUnit.test('debounce asap recursively', function(assert) {
+    assert.expect(2);
     var done = assert.async();
     var counter = 0;
     var debouncedIncr = _.debounce(function(){
@@ -503,7 +523,8 @@
     _.delay(function(){ assert.equal(counter, 1, 'incr was debounced'); done(); }, 96);
   });
 
-  QUnit.test('debounce after system time is set backwards', 2, function(assert) {
+  QUnit.test('debounce after system time is set backwards', function(assert) {
+    assert.expect(2);
     var done = assert.async();
     var counter = 0;
     var origNowFunc = _.now;
@@ -526,7 +547,8 @@
     }, 200);
   });
 
-  QUnit.test('debounce re-entrant', 2, function(assert) {
+  QUnit.test('debounce re-entrant', function(assert) {
+    assert.expect(2);
     var done = assert.async();
     var sequence = [
       ['b1', 'b2']
@@ -559,7 +581,8 @@
     assert.equal(increment(), 1, 'stores a memo to the last value');
   });
 
-  QUnit.test('Recursive onced function.', 1, function(assert) {
+  QUnit.test('Recursive onced function.', function(assert) {
+    assert.expect(1);
     var f = _.once(function(){
       assert.ok(true);
       f();
@@ -666,7 +689,8 @@
 
   });
 
-  QUnit.test('restArgs', 10, function(assert) {
+  QUnit.test('restArgs', function(assert) {
+    assert.expect(10);
     _.restArgs(function(a, args) {
       assert.strictEqual(a, 1);
       assert.deepEqual(args, [2, 3], 'collects rest arguments into an array');

--- a/test/objects.js
+++ b/test/objects.js
@@ -5,7 +5,7 @@
 
   var testElement = typeof document === 'object' ? document.createElement('div') : void 0;
 
-  test('keys', function(assert) {
+  QUnit.test('keys', function(assert) {
     assert.deepEqual(_.keys({one: 1, two: 2}), ['one', 'two'], 'can extract the keys from an object');
     // the test above is not safe because it relies on for-in enumeration order
     var a = []; a[1] = 0;
@@ -35,7 +35,7 @@
     assert.deepEqual(_.keys(trouble).sort(), troubleKeys, 'matches non-enumerable properties');
   });
 
-  test('allKeys', function(assert) {
+  QUnit.test('allKeys', function(assert) {
     assert.deepEqual(_.allKeys({one: 1, two: 2}), ['one', 'two'], 'can extract the allKeys from an object');
     // the test above is not safe because it relies on for-in enumeration order
     var a = []; a[1] = 0;
@@ -73,17 +73,17 @@
     assert.deepEqual(_.allKeys(y), ['x'], 'should get keys from constructor');
   });
 
-  test('values', function(assert) {
+  QUnit.test('values', function(assert) {
     assert.deepEqual(_.values({one: 1, two: 2}), [1, 2], 'can extract the values from an object');
     assert.deepEqual(_.values({one: 1, two: 2, length: 3}), [1, 2, 3], '... even when one of them is "length"');
   });
 
-  test('pairs', function(assert) {
+  QUnit.test('pairs', function(assert) {
     assert.deepEqual(_.pairs({one: 1, two: 2}), [['one', 1], ['two', 2]], 'can convert an object into pairs');
     assert.deepEqual(_.pairs({one: 1, two: 2, length: 3}), [['one', 1], ['two', 2], ['length', 3]], '... even when one of them is "length"');
   });
 
-  test('invert', function(assert) {
+  QUnit.test('invert', function(assert) {
     var obj = {first: 'Moe', second: 'Larry', third: 'Curly'};
     assert.deepEqual(_.keys(_.invert(obj)), ['Moe', 'Larry', 'Curly'], 'can invert an object');
     assert.deepEqual(_.invert(_.invert(obj)), obj, 'two inverts gets you back where you started');
@@ -92,7 +92,7 @@
     assert.equal(_.invert(obj)['3'], 'length', 'can invert an object with "length"');
   });
 
-  test('functions', function(assert) {
+  QUnit.test('functions', function(assert) {
     var obj = {a: 'dash', b: _.map, c: /yo/, d: _.reduce};
     assert.deepEqual(['b', 'd'], _.functions(obj), 'can grab the function names of any passed-in object');
 
@@ -101,11 +101,11 @@
     assert.deepEqual(_.functions(new Animal), ['run'], 'also looks up functions on the prototype');
   });
 
-  test('methods', function(assert) {
+  QUnit.test('methods', function(assert) {
     assert.strictEqual(_.methods, _.functions, 'is an alias for functions');
   });
 
-  test('extend', function(assert) {
+  QUnit.test('extend', function(assert) {
     var result;
     assert.equal(_.extend({}, {a: 'b'}).a, 'b', 'can extend an object with the attributes of another');
     assert.equal(_.extend({a: 'x'}, {a: 'b'}).a, 'b', 'properties in source override destination');
@@ -136,7 +136,7 @@
     assert.strictEqual(_.extend(void 0, {a: 1}), void 0, 'extending undefined results in undefined');
   });
 
-  test('extendOwn', function(assert) {
+  QUnit.test('extendOwn', function(assert) {
     var result;
     assert.equal(_.extendOwn({}, {a: 'b'}).a, 'b', 'can extend an object with the attributes of another');
     assert.equal(_.extendOwn({a: 'x'}, {a: 'b'}).a, 'b', 'properties in source override destination');
@@ -166,11 +166,11 @@
     assert.deepEqual(result, {a: 1, 0: 1, 1: 2, length: 2}, 'should treat array-like objects like normal objects');
   });
 
-  test('assign', function(assert) {
+  QUnit.test('assign', function(assert) {
     assert.strictEqual(_.assign, _.extendOwn, 'is an alias for extendOwn');
   });
 
-  test('pick', function(assert) {
+  QUnit.test('pick', function(assert) {
     var result;
     result = _.pick({a: 1, b: 2, c: 3}, 'a', 'c');
     assert.deepEqual(result, {a: 1, c: 3}, 'can restrict properties to those named');
@@ -211,7 +211,7 @@
     });
   });
 
-  test('omit', function(assert) {
+  QUnit.test('omit', function(assert) {
     var result;
     result = _.omit({a: 1, b: 2, c: 3}, 'b');
     assert.deepEqual(result, {a: 1, c: 3}, 'can omit a single named property');
@@ -245,7 +245,7 @@
     }, instance), {a: 1, b: 2}, 'function is given context');
   });
 
-  test('defaults', function(assert) {
+  QUnit.test('defaults', function(assert) {
     var options = {zero: 0, one: 1, empty: '', nan: NaN, nothing: null};
 
     _.defaults(options, {zero: 1, one: 10, twenty: 20, nothing: 'str'});
@@ -270,7 +270,7 @@
     assert.deepEqual(_.defaults(void 0, {a: 1}), {a: 1}, 'defaults skips undefined');
   });
 
-  test('clone', function(assert) {
+  QUnit.test('clone', function(assert) {
     var moe = {name: 'moe', lucky: [13, 27, 34]};
     var clone = _.clone(moe);
     assert.equal(clone.name, 'moe', 'the clone as the attributes of the original');
@@ -286,7 +286,7 @@
     assert.equal(_.clone(null), null, 'non objects should not be changed by clone');
   });
 
-  test('create', function(assert) {
+  QUnit.test('create', function(assert) {
     var Parent = function() {};
     Parent.prototype = {foo: function() {}, bar: 2};
 
@@ -312,7 +312,7 @@
     assert.ok(!created.hasOwnProperty('foo'), 'should only add own properties');
   });
 
-  test('isEqual', function(assert) {
+  QUnit.test('isEqual', function(assert) {
     function First() {
       this.value = 1;
     }
@@ -567,7 +567,7 @@
     assert.equal(_.isEqual({a: NaN}, {a: NaN}), true);
   });
 
-  test('isEmpty', function(assert) {
+  QUnit.test('isEmpty', function(assert) {
     assert.ok(!_([1]).isEmpty(), '[1] is not empty');
     assert.ok(_.isEmpty([]), '[] is empty');
     assert.ok(!_.isEmpty({one: 1}), '{one: 1} is not empty');
@@ -592,13 +592,13 @@
   });
 
   if (typeof document === 'object') {
-    test('isElement', function(assert) {
+    QUnit.test('isElement', function(assert) {
       assert.ok(!_.isElement('div'), 'strings are not dom elements');
       assert.ok(_.isElement(testElement), 'an element is a DOM element');
     });
   }
 
-  test('isArguments', function(assert) {
+  QUnit.test('isArguments', function(assert) {
     var args = (function(){ return arguments; }(1, 2, 3));
     assert.ok(!_.isArguments('string'), 'a string is not an arguments object');
     assert.ok(!_.isArguments(_.isArguments), 'a function is not an arguments object');
@@ -607,7 +607,7 @@
     assert.ok(!_.isArguments([1, 2, 3]), 'and not vanilla arrays.');
   });
 
-  test('isObject', function(assert) {
+  QUnit.test('isObject', function(assert) {
     assert.ok(_.isObject(arguments), 'the arguments object is object');
     assert.ok(_.isObject([1, 2, 3]), 'and arrays');
     if (testElement) {
@@ -622,13 +622,13 @@
     assert.ok(_.isObject(new String('string')), 'but new String()');
   });
 
-  test('isArray', function(assert) {
+  QUnit.test('isArray', function(assert) {
     assert.ok(!_.isArray(void 0), 'undefined vars are not arrays');
     assert.ok(!_.isArray(arguments), 'the arguments object is not an array');
     assert.ok(_.isArray([1, 2, 3]), 'but arrays are');
   });
 
-  test('isString', function(assert) {
+  QUnit.test('isString', function(assert) {
     var obj = new String('I am a string object');
     if (testElement) {
       assert.ok(!_.isString(testElement), 'an element is not a string');
@@ -639,7 +639,7 @@
     assert.strictEqual(_.isString(1), false);
   });
 
-  test('isNumber', function(assert) {
+  QUnit.test('isNumber', function(assert) {
     assert.ok(!_.isNumber('string'), 'a string is not a number');
     assert.ok(!_.isNumber(arguments), 'the arguments object is not a number');
     assert.ok(!_.isNumber(void 0), 'undefined is not a number');
@@ -649,7 +649,7 @@
     assert.ok(!_.isNumber('1'), 'numeric strings are not numbers');
   });
 
-  test('isBoolean', function(assert) {
+  QUnit.test('isBoolean', function(assert) {
     assert.ok(!_.isBoolean(2), 'a number is not a boolean');
     assert.ok(!_.isBoolean('string'), 'a string is not a boolean');
     assert.ok(!_.isBoolean('false'), 'the string "false" is not a boolean');
@@ -662,7 +662,7 @@
     assert.ok(_.isBoolean(false), 'and so is false');
   });
 
-  test('isFunction', function(assert) {
+  QUnit.test('isFunction', function(assert) {
     assert.ok(!_.isFunction(void 0), 'undefined vars are not functions');
     assert.ok(!_.isFunction([1, 2, 3]), 'arrays are not functions');
     assert.ok(!_.isFunction('moe'), 'strings are not functions');
@@ -680,7 +680,7 @@
   });
 
   if (typeof Int8Array !== 'undefined') {
-    test('#1929 Typed Array constructors are functions', function(assert) {
+    QUnit.test('#1929 Typed Array constructors are functions', function(assert) {
       _.chain(['Float32Array', 'Float64Array', 'Int8Array', 'Int16Array', 'Int32Array', 'Uint8Array', 'Uint8ClampedArray', 'Uint16Array', 'Uint32Array'])
       .map(_.propertyOf(typeof GLOBAL != 'undefined' ? GLOBAL : window))
       .compact()
@@ -692,18 +692,18 @@
     });
   }
 
-  test('isDate', function(assert) {
+  QUnit.test('isDate', function(assert) {
     assert.ok(!_.isDate(100), 'numbers are not dates');
     assert.ok(!_.isDate({}), 'objects are not dates');
     assert.ok(_.isDate(new Date()), 'but dates are');
   });
 
-  test('isRegExp', function(assert) {
+  QUnit.test('isRegExp', function(assert) {
     assert.ok(!_.isRegExp(_.identity), 'functions are not RegExps');
     assert.ok(_.isRegExp(/identity/), 'but RegExps are');
   });
 
-  test('isFinite', function(assert) {
+  QUnit.test('isFinite', function(assert) {
     assert.ok(!_.isFinite(void 0), 'undefined is not finite');
     assert.ok(!_.isFinite(null), 'null is not finite');
     assert.ok(!_.isFinite(NaN), 'NaN is not finite');
@@ -719,7 +719,7 @@
     assert.ok(_.isFinite(-12.44), 'Floats are finite');
   });
 
-  test('isNaN', function(assert) {
+  QUnit.test('isNaN', function(assert) {
     assert.ok(!_.isNaN(void 0), 'undefined is not NaN');
     assert.ok(!_.isNaN(null), 'null is not NaN');
     assert.ok(!_.isNaN(0), '0 is not NaN');
@@ -728,13 +728,13 @@
     assert.ok(_.isNaN(new Number(NaN)), 'wrapped NaN is still NaN');
   });
 
-  test('isNull', function(assert) {
+  QUnit.test('isNull', function(assert) {
     assert.ok(!_.isNull(void 0), 'undefined is not null');
     assert.ok(!_.isNull(NaN), 'NaN is not null');
     assert.ok(_.isNull(null), 'but null is');
   });
 
-  test('isUndefined', function(assert) {
+  QUnit.test('isUndefined', function(assert) {
     assert.ok(!_.isUndefined(1), 'numbers are defined');
     assert.ok(!_.isUndefined(null), 'null is defined');
     assert.ok(!_.isUndefined(false), 'false is defined');
@@ -743,7 +743,7 @@
     assert.ok(_.isUndefined(void 0), 'undefined is undefined');
   });
 
-  test('isError', function(assert) {
+  QUnit.test('isError', function(assert) {
     assert.ok(!_.isError(1), 'numbers are not Errors');
     assert.ok(!_.isError(null), 'null is not an Error');
     assert.ok(!_.isError(Error), 'functions are not Errors');
@@ -756,7 +756,7 @@
     assert.ok(_.isError(new URIError()), 'URIErrors are Errors');
   });
 
-  test('tap', function(assert) {
+  QUnit.test('tap', function(assert) {
     var intercepted = null;
     var interceptor = function(obj) { intercepted = obj; };
     var returned = _.tap(1, interceptor);
@@ -772,7 +772,7 @@
     assert.equal(intercepted, returned, 'can use tapped objects in a chain');
   });
 
-  test('has', function(assert) {
+  QUnit.test('has', function(assert) {
     var obj = {foo: 'bar', func: function(){}};
     assert.ok(_.has(obj, 'foo'), 'has() checks that the object has a property.');
     assert.ok(!_.has(obj, 'baz'), "has() returns false if the object doesn't have the property.");
@@ -786,7 +786,7 @@
     assert.strictEqual(_.has(void 0, 'foo'), false, 'has() returns false for undefined');
   });
 
-  test('isMatch', function(assert) {
+  QUnit.test('isMatch', function(assert) {
     var moe = {name: 'Moe Howard', hair: true};
     var curly = {name: 'Curly Howard', hair: false};
 
@@ -826,7 +826,7 @@
     assert.deepEqual(_.map([null, void 0, 5, {}], _.partial(_.isMatch, _, oCon)), [false, false, false, true], 'doesnt falsey match constructor on undefined/null');
   });
 
-  test('matcher', function(assert) {
+  QUnit.test('matcher', function(assert) {
     var moe = {name: 'Moe Howard', hair: true};
     var curly = {name: 'Curly Howard', hair: false};
     var stooges = [moe, curly];
@@ -883,11 +883,11 @@
     assert.deepEqual(_.map([null, void 0, 5, {}], oCon), [false, false, false, true], 'doesnt falsey match constructor on undefined/null');
   });
 
-  test('matches', function(assert) {
+  QUnit.test('matches', function(assert) {
     assert.strictEqual(_.matches, _.matcher, 'is an alias for matcher');
   });
 
-  test('findKey', function(assert) {
+  QUnit.test('findKey', function(assert) {
     var objects = {
       a: {a: 0, b: 0},
       b: {a: 1, b: 1},
@@ -928,7 +928,7 @@
   });
 
 
-  test('mapObject', function(assert) {
+  QUnit.test('mapObject', function(assert) {
     var obj = {a: 1, b: 2};
     var objects = {
       a: {a: 0, b: 0},

--- a/test/utility.js
+++ b/test/utility.js
@@ -15,7 +15,7 @@
   });
 
   if (typeof this == 'object') {
-    test('noConflict', function(assert) {
+    QUnit.test('noConflict', function(assert) {
       var underscore = _.noConflict();
       assert.equal(underscore.identity(1), 1);
       if (typeof require != 'function') {
@@ -47,34 +47,34 @@
     });
   }
 
-  test('#750 - Return _ instance.', 2, function(assert) {
+  QUnit.test('#750 - Return _ instance.', 2, function(assert) {
     var instance = _([]);
     assert.ok(_(instance) === instance);
     assert.ok(new _(instance) === instance);
   });
 
-  test('identity', function(assert) {
+  QUnit.test('identity', function(assert) {
     var stooge = {name: 'moe'};
     assert.equal(_.identity(stooge), stooge, 'stooge is the same as his identity');
   });
 
-  test('constant', function(assert) {
+  QUnit.test('constant', function(assert) {
     var stooge = {name: 'moe'};
     assert.equal(_.constant(stooge)(), stooge, 'should create a function that returns stooge');
   });
 
-  test('noop', function(assert) {
+  QUnit.test('noop', function(assert) {
     assert.strictEqual(_.noop('curly', 'larry', 'moe'), void 0, 'should always return undefined');
   });
 
-  test('property', function(assert) {
+  QUnit.test('property', function(assert) {
     var stooge = {name: 'moe'};
     assert.equal(_.property('name')(stooge), 'moe', 'should return the property with the given name');
     assert.equal(_.property('name')(null), void 0, 'should return undefined for null values');
     assert.equal(_.property('name')(void 0), void 0, 'should return undefined for undefined values');
   });
 
-  test('propertyOf', function(assert) {
+  QUnit.test('propertyOf', function(assert) {
     var stoogeRanks = _.propertyOf({curly: 2, moe: 1, larry: 3});
     assert.equal(stoogeRanks('curly'), 2, 'should return the property with the given name');
     assert.equal(stoogeRanks(null), void 0, 'should return undefined for null values');
@@ -92,7 +92,7 @@
     assert.equal(undefPropertyOf('curly'), void 0, 'should return undefined when obj is undefined');
   });
 
-  test('random', function(assert) {
+  QUnit.test('random', function(assert) {
     var array = _.range(1000);
     var min = Math.pow(2, 31);
     var max = Math.pow(2, 62);
@@ -106,18 +106,18 @@
     }), 'should produce a random number when passed `Number.MAX_VALUE`');
   });
 
-  test('now', function(assert) {
+  QUnit.test('now', function(assert) {
     var diff = _.now() - new Date().getTime();
     assert.ok(diff <= 0 && diff > -5, 'Produces the correct time in milliseconds');//within 5ms
   });
 
-  test('uniqueId', function(assert) {
+  QUnit.test('uniqueId', function(assert) {
     var ids = [], i = 0;
     while (i++ < 100) ids.push(_.uniqueId());
     assert.equal(_.uniq(ids).length, ids.length, 'can generate a globally-unique stream of ids');
   });
 
-  test('times', function(assert) {
+  QUnit.test('times', function(assert) {
     var vals = [];
     _.times(3, function(i) { vals.push(i); });
     assert.deepEqual(vals, [0, 1, 2], 'is 0 indexed');
@@ -133,7 +133,7 @@
     assert.deepEqual(_.times(parseFloat('-Infinity'), _.identity), []);
   });
 
-  test('mixin', function(assert) {
+  QUnit.test('mixin', function(assert) {
     _.mixin({
       myReverse: function(string) {
         return string.split('').reverse().join('');
@@ -143,11 +143,11 @@
     assert.equal(_('champ').myReverse(), 'pmahc', 'mixed in a function to the OOP wrapper');
   });
 
-  test('_.escape', function(assert) {
+  QUnit.test('_.escape', function(assert) {
     assert.equal(_.escape(null), '');
   });
 
-  test('_.unescape', function(assert) {
+  QUnit.test('_.unescape', function(assert) {
     var string = 'Curly & Moe';
     assert.equal(_.unescape(null), '');
     assert.equal(_.unescape(_.escape(string)), string);
@@ -155,7 +155,7 @@
   });
 
   // Don't care what they escape them to just that they're escaped and can be unescaped
-  test('_.escape & unescape', function(assert) {
+  QUnit.test('_.escape & unescape', function(assert) {
     // test & (&amp;) seperately obviously
     var escapeCharacters = ['<', '>', '"', '\'', '`'];
 
@@ -189,7 +189,7 @@
     assert.equal(_.unescape(str), str, 'can unescape &amp;');
   });
 
-  test('template', function(assert) {
+  QUnit.test('template', function(assert) {
     var basicTemplate = _.template("<%= thing %> is gettin' on my noives!");
     var result = basicTemplate({thing: 'This'});
     assert.equal(result, "This is gettin' on my noives!", 'can do basic attribute interpolation');
@@ -298,7 +298,7 @@
     assert.equal(templateWithNull({planet: 'world'}), 'a null undefined world', 'can handle missing escape and evaluate settings');
   });
 
-  test('_.template provides the generated function source, when a SyntaxError occurs', function(assert) {
+  QUnit.test('_.template provides the generated function source, when a SyntaxError occurs', function(assert) {
     var source;
     try {
       _.template('<b><%= if x %></b>');
@@ -308,12 +308,12 @@
     assert.ok(/__p/.test(source));
   });
 
-  test('_.template handles \\u2028 & \\u2029', function(assert) {
+  QUnit.test('_.template handles \\u2028 & \\u2029', function(assert) {
     var tmpl = _.template('<p>\u2028<%= "\\u2028\\u2029" %>\u2029</p>');
     assert.strictEqual(tmpl(), '<p>\u2028\u2028\u2029\u2029</p>');
   });
 
-  test('result calls functions and returns primitives', function(assert) {
+  QUnit.test('result calls functions and returns primitives', function(assert) {
     var obj = {w: '', x: 'x', y: function(){ return this.x; }};
     assert.strictEqual(_.result(obj, 'w'), '');
     assert.strictEqual(_.result(obj, 'x'), 'x');
@@ -322,34 +322,34 @@
     assert.strictEqual(_.result(null, 'x'), void 0);
   });
 
-  test('result returns a default value if object is null or undefined', function(assert) {
+  QUnit.test('result returns a default value if object is null or undefined', function(assert) {
     assert.strictEqual(_.result(null, 'b', 'default'), 'default');
     assert.strictEqual(_.result(void 0, 'c', 'default'), 'default');
     assert.strictEqual(_.result(''.match('missing'), 1, 'default'), 'default');
   });
 
-  test('result returns a default value if property of object is missing', function(assert) {
+  QUnit.test('result returns a default value if property of object is missing', function(assert) {
     assert.strictEqual(_.result({d: null}, 'd', 'default'), null);
     assert.strictEqual(_.result({e: false}, 'e', 'default'), false);
   });
 
-  test('result only returns the default value if the object does not have the property or is undefined', function(assert) {
+  QUnit.test('result only returns the default value if the object does not have the property or is undefined', function(assert) {
     assert.strictEqual(_.result({}, 'b', 'default'), 'default');
     assert.strictEqual(_.result({d: void 0}, 'd', 'default'), 'default');
   });
 
-  test('result does not return the default if the property of an object is found in the prototype', function(assert) {
+  QUnit.test('result does not return the default if the property of an object is found in the prototype', function(assert) {
     var Foo = function(){};
     Foo.prototype.bar = 1;
     assert.strictEqual(_.result(new Foo, 'bar', 2), 1);
   });
 
-  test('result does use the fallback when the result of invoking the property is undefined', function(assert) {
+  QUnit.test('result does use the fallback when the result of invoking the property is undefined', function(assert) {
     var obj = {a: function() {}};
     assert.strictEqual(_.result(obj, 'a', 'failed'), void 0);
   });
 
-  test('result fallback can use a function', function(assert) {
+  QUnit.test('result fallback can use a function', function(assert) {
     var obj = {a: [1, 2, 3]};
     assert.strictEqual(_.result(obj, 'b', _.constant(5)), 5);
     assert.strictEqual(_.result(obj, 'b', function() {
@@ -357,7 +357,7 @@
     }), obj.a, 'called with context');
   });
 
-  test('_.templateSettings.variable', function(assert) {
+  QUnit.test('_.templateSettings.variable', function(assert) {
     var s = '<%=data.x%>';
     var data = {x: 'x'};
     var tmp = _.template(s, {variable: 'data'});
@@ -366,13 +366,13 @@
     assert.strictEqual(_.template(s)(data), 'x');
   });
 
-  test('#547 - _.templateSettings is unchanged by custom settings.', function(assert) {
+  QUnit.test('#547 - _.templateSettings is unchanged by custom settings.', function(assert) {
     assert.ok(!_.templateSettings.variable);
     _.template('', {}, {variable: 'x'});
     assert.ok(!_.templateSettings.variable);
   });
 
-  test('#556 - undefined template variables.', function(assert) {
+  QUnit.test('#556 - undefined template variables.', function(assert) {
     var template = _.template('<%=x%>');
     assert.strictEqual(template({x: null}), '');
     assert.strictEqual(template({x: void 0}), '');
@@ -390,7 +390,7 @@
     assert.strictEqual(templateWithPropertyEscaped({x: {}}), '');
   });
 
-  test('interpolate evaluates code only once.', 2, function(assert) {
+  QUnit.test('interpolate evaluates code only once.', 2, function(assert) {
     var count = 0;
     var template = _.template('<%= f() %>');
     template({f: function(){ assert.ok(!count++); }});
@@ -400,13 +400,13 @@
     templateEscaped({f: function(){ assert.ok(!countEscaped++); }});
   });
 
-  test('#746 - _.template settings are not modified.', 1, function(assert) {
+  QUnit.test('#746 - _.template settings are not modified.', 1, function(assert) {
     var settings = {};
     _.template('', null, settings);
     assert.deepEqual(settings, {});
   });
 
-  test('#779 - delimeters are applied to unescaped text.', 1, function(assert) {
+  QUnit.test('#779 - delimeters are applied to unescaped text.', 1, function(assert) {
     var template = _.template('<<\nx\n>>', null, {evaluate: /<<(.*?)>>/g});
     assert.strictEqual(template(), '<<\nx\n>>');
   });

--- a/test/utility.js
+++ b/test/utility.js
@@ -28,7 +28,8 @@
   }
 
   if (typeof require == 'function') {
-    asyncTest('noConflict (node vm)', 2, function(assert) {
+    QUnit.test('noConflict (node vm)', 2, function(assert) {
+      var done = assert.async();
       var fs = require('fs');
       var vm = require('vm');
       var filename = __dirname + '/../underscore.js';
@@ -42,7 +43,7 @@
         assert.equal(context._, 'oldvalue');
         assert.equal(context.underscore.VERSION, _.VERSION);
 
-        start();
+        done();
       });
     });
   }

--- a/test/utility.js
+++ b/test/utility.js
@@ -4,11 +4,11 @@
 
   QUnit.module('Utility', {
 
-    setup: function() {
+    beforeEach: function() {
       templateSettings = _.clone(_.templateSettings);
     },
 
-    teardown: function() {
+    afterEach: function() {
       _.templateSettings = templateSettings;
     }
 

--- a/test/utility.js
+++ b/test/utility.js
@@ -28,7 +28,8 @@
   }
 
   if (typeof require == 'function') {
-    QUnit.test('noConflict (node vm)', 2, function(assert) {
+    QUnit.test('noConflict (node vm)', function(assert) {
+      assert.expect(2);
       var done = assert.async();
       var fs = require('fs');
       var vm = require('vm');
@@ -48,7 +49,8 @@
     });
   }
 
-  QUnit.test('#750 - Return _ instance.', 2, function(assert) {
+  QUnit.test('#750 - Return _ instance.', function(assert) {
+    assert.expect(2);
     var instance = _([]);
     assert.ok(_(instance) === instance);
     assert.ok(new _(instance) === instance);
@@ -391,7 +393,8 @@
     assert.strictEqual(templateWithPropertyEscaped({x: {}}), '');
   });
 
-  QUnit.test('interpolate evaluates code only once.', 2, function(assert) {
+  QUnit.test('interpolate evaluates code only once.', function(assert) {
+    assert.expect(2);
     var count = 0;
     var template = _.template('<%= f() %>');
     template({f: function(){ assert.ok(!count++); }});
@@ -401,13 +404,15 @@
     templateEscaped({f: function(){ assert.ok(!countEscaped++); }});
   });
 
-  QUnit.test('#746 - _.template settings are not modified.', 1, function(assert) {
+  QUnit.test('#746 - _.template settings are not modified.', function(assert) {
+    assert.expect(1);
     var settings = {};
     _.template('', null, settings);
     assert.deepEqual(settings, {});
   });
 
-  QUnit.test('#779 - delimeters are applied to unescaped text.', 1, function(assert) {
+  QUnit.test('#779 - delimeters are applied to unescaped text.', function(assert) {
+    assert.expect(1);
     var template = _.template('<<\nx\n>>', null, {evaluate: /<<(.*?)>>/g});
     assert.strictEqual(template(), '<<\nx\n>>');
   });


### PR DESCRIPTION
Inspired by a similar pull request against Backbone (https://github.com/jashkenas/backbone/pull/3816), this brings our test up to date with the QUnit 2.x. As one might infer, this syntax is already available in our version of QUnit.

I used this article as my guide: http://qunitjs.com/upgrade-guide-2.x/#replace-asynctest-with-qunit-test-and-assert-async

Each commit should be self contained, so feel free to review one commit at a time. If people would like this split up into smaller pieces, I'm happy to submit the commits one at a time.