### PR TITLE
Use assert.raises instead of .throws

### DIFF
--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -21,7 +21,6 @@
   },
   "rules": {
     "brace-style": 0,
-    "dot-notation": 1,
     "no-new-wrappers": 0,
     "no-sparse-arrays": 0,
     "no-extend-native": 0

--- a/test/collections.js
+++ b/test/collections.js
@@ -467,7 +467,7 @@
 
     assert.deepEqual(_.invoke([{a: null}, {}, {a: _.constant(1)}], 'a'), [null, void 0, 1], 'handles null & undefined');
 
-    assert.throws(function() {
+    assert.raises(function() {
       _.invoke([{a: 1}], 'a');
     }, TypeError, 'throws for non-functions');
   });

--- a/test/functions.js
+++ b/test/functions.js
@@ -44,7 +44,7 @@
     assert.equal(boundf().hello, 'moe curly', "When called without the new operator, it's OK to be bound to the context");
     assert.ok(newBoundf instanceof F, 'a bound instance is an instance of the original function');
 
-    assert.throws(function() { _.bind('notafunction'); }, TypeError, 'throws an error when binding to a non-function');
+    assert.raises(function() { _.bind('notafunction'); }, TypeError, 'throws an error when binding to a non-function');
   });
 
   test('partial', function(assert) {
@@ -109,9 +109,9 @@
       sayLast: function() { return this.sayHi(_.last(arguments)); }
     };
 
-    assert.throws(function() { _.bindAll(moe); }, Error, 'throws an error for bindAll with no functions named');
-    assert.throws(function() { _.bindAll(moe, 'sayBye'); }, TypeError, 'throws an error for bindAll if the given key is undefined');
-    assert.throws(function() { _.bindAll(moe, 'name'); }, TypeError, 'throws an error for bindAll if the given key is not a function');
+    assert.raises(function() { _.bindAll(moe); }, Error, 'throws an error for bindAll with no functions named');
+    assert.raises(function() { _.bindAll(moe, 'sayBye'); }, TypeError, 'throws an error for bindAll if the given key is undefined');
+    assert.raises(function() { _.bindAll(moe, 'name'); }, TypeError, 'throws an error for bindAll if the given key is not a function');
 
     _.bindAll(moe, 'sayHi', 'sayLast');
     curly.sayHi = moe.sayHi;


### PR DESCRIPTION
In some environments `.throws()` is a reserved word, so QUnit offers an alias `.raises()`.

Using `.raises` seems safer, and also allows us to remove an eslint exception.