### PR TITLE
Add reversed option for sortBy

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -636,9 +636,16 @@
     var people = [{name: 'curly', age: 50}, {name: 'moe', age: 30}];
     people = _.sortBy(people, function(person){ return person.age; });
     assert.deepEqual(_.pluck(people, 'name'), ['moe', 'curly'], 'stooges sorted by age');
+    people = _.sortBy(people, function(person){ return person.age; }, true);
+    assert.deepEqual(_.pluck(people, 'name'), ['curly', 'moe'], 'stooges sorted by age in descending order');
 
     var list = [void 0, 4, 1, void 0, 3, 2];
     assert.deepEqual(_.sortBy(list, _.identity), [1, 2, 3, 4, void 0, void 0], 'sortBy with undefined values');
+    list = [void 0, 4, 1, void 0, 3, 2];
+    assert.deepEqual(_.sortBy(list, _.identity), [1, 2, 3, 4, void 0, void 0],
+        'sortBy with undefined values and explicitly ascending order');
+    assert.deepEqual(_.sortBy(list, _.identity, true), [void 0, void 0, 4, 3, 2, 1],
+        'reversed sortBy with undefined values and explicitly descending order');
 
     list = ['one', 'two', 'three', 'four', 'five'];
     var sorted = _.sortBy(list, 'length');

--- a/underscore.js
+++ b/underscore.js
@@ -381,7 +381,17 @@
   };
 
   // Sort the object's values by a criterion produced by an iteratee.
-  _.sortBy = function(obj, iteratee, context) {
+  _.sortBy = function(obj, iteratee, reversed, context) {
+    var greater = 1;
+    var lesser = -1;
+    if (typeof reversed === 'boolean') {
+      if (reversed) {
+        greater = -1;
+        lesser = 1;
+      }
+    } else {
+      context = reversed;
+    }
     var index = 0;
     iteratee = cb(iteratee, context);
     return _.pluck(_.map(obj, function(value, key, list) {
@@ -394,8 +404,8 @@
       var a = left.criteria;
       var b = right.criteria;
       if (a !== b) {
-        if (a > b || a === void 0) return 1;
-        if (a < b || b === void 0) return -1;
+        if (a > b || a === void 0) return greater;
+        if (a < b || b === void 0) return lesser;
       }
       return left.index - right.index;
     }), 'value');


### PR DESCRIPTION
It would be nice to have an option to sort the array with `_.sortBy` in a descending order, like it's done in Python's sorting function for lists.