### PR TITLE
Improve example for _.every()

### DIFF
--- a/index.html
+++ b/index.html
@@ -602,7 +602,7 @@ var odds = _.reject([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
         if a false element is found.
       </p>
       <pre>
-_.every([true, 1, null, 'yes'], _.identity);
+_.every([2, 4, 5], function(num) { return num % 2 == 0; });
 =&gt; false
 </pre>
 


### PR DESCRIPTION
Using `_.identity` (the default predicate) as an example predicate is confusing. It implies that `predicate` is actually a required argument and if you want to evaluate the values untransformed, you must pass `_.identity` explicitly.