### PR TITLE
lift, unlift, and orElse, for use of map/orElse in functional style.

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,6 +331,7 @@
       <li>- <a href="#result">result</a></li>
       <li>- <a href="#now">now</a></li>
       <li>- <a href="#template">template</a></li>
+      <li>- <a href="#orElse">orElse</a></li>
     </ul>
 
     <a class="toc_title" href="#chaining">
@@ -339,6 +340,8 @@
     <ul class="toc_section">
       <li>- <a href="#chain">chain</a></li>
       <li>- <a href="#value">value</a></li>
+      <li>- <a href="#lift">lift</a></li>
+      <li>- <a href="#unlift">unlift</a></li>
     </ul>
 
     <a class="toc_title" href="#links">
@@ -1964,6 +1967,19 @@ _.now();
 =&gt; 1392066795351
 </pre>
 
+      <p id="orElse">
+        <b class="header">orElse</b><code>_.orElse(arr, func)</code>
+        <br />
+        Returns the result of calling the function <code>func</code> in an array, if the
+        array argument is empty, otherwise it returns the array argument.
+      </p>
+
+      <pre>
+var arr = [1,2,3,4,5];
+var large = _.filter(arr, function(x){ return x > 5; });
+_.orElse(large, function(x){ return 100; });
+=&gt; 100</pre>
+
       <p id="template">
         <b class="header">template</b><code>_.template(templateString, [settings])</code>
         <br />
@@ -2114,6 +2130,31 @@ var youngest = _.chain(stooges)
       <pre>
 _([1, 2, 3]).value();
 =&gt; [1, 2, 3]
+</pre>
+
+      <p id="lift">
+        <b class="header">lift</b><code>_.lift(obj)</code>
+        <br />
+        Lifts a value into a wrapped array object. Calling methods on this object will continue
+        to return wrapped array objects until <tt>unlift</tt> is called.
+      </p>
+      <pre>
+var stooge = {name: 'curly', age: 25};
+_.lift(stooge.age)
+  .filter(function(age){ return age > 18})
+  .map(function(age){ return "adult"; })
+  .orElse(function(){ return "child";})
+  .unlift()
+=&gt; "adult"</pre>
+
+      <p id="unlift">
+        <b class="header">unlift</b><code>_(obj).unlift()</code>
+        <br />
+        Extracts the value of a wrapped array object.
+      </p>
+      <pre>
+_.lift(4).unlift();
+=&gt; 4
 </pre>
 
       <h2 id="links">Links &amp; Suggested Reading</h2>

--- a/test/chaining.js
+++ b/test/chaining.js
@@ -23,6 +23,21 @@
     assert.equal(counts.e, 10, 'counted all the letters in the song');
   });
 
+  QUnit.test('filter/map/orElse', function(assert) {
+    var lyrics = [
+      'I\'m a lumberjack and I\'m okay',
+      'I sleep all night and I work all day',
+      'He\'s a lumberjack and he\'s okay',
+      'He sleeps all night and he works all day'
+    ];
+    var songKind = _.lift(lyrics.length)
+      .filter(function(length){ return length > 3; })
+      .map(function() { return 'long song'; })
+      .orElse(function() { return 'short song'; })
+      .unlift();
+    assert.equal(songKind, 'long song', 'correctly classified song');
+  });
+
   QUnit.test('select/reject/sortBy', function(assert) {
     var numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     numbers = _(numbers).chain().select(function(n) {

--- a/underscore.js
+++ b/underscore.js
@@ -184,6 +184,17 @@
     return results;
   };
 
+  _.orElse = function(obj, iteratee, context) {
+    var results;
+    iteratee = cb(iteratee, context);
+    if (_.isEmpty(obj)) {
+      results = [iteratee()];
+    } else {
+      results = obj;
+    }
+    return results;
+  };
+
   // Create a reducing function iterating left or right.
   var createReduce = function(dir) {
     // Wrap code that reassigns argument variables in a separate function than
@@ -1548,6 +1559,14 @@
     return instance;
   };
 
+  // Lifts an object into an Array, starting a chain that can be used with map/orElse.
+  _.lift = function(obj) {
+    var arr = [];
+    if (!_.isEmpty(obj) || _.isNumber(obj)) {
+      arr = [obj];
+    }
+    return _.chain(arr);
+  };
   // OOP
   // ---------------
   // If Underscore is called as a function, it returns a wrapped object that
@@ -1596,6 +1615,11 @@
   // Extracts the result from a wrapped and chained object.
   _.prototype.value = function() {
     return this._wrapped;
+  };
+
+  // Extracts a lifted value from a lifted object.
+  _.prototype.unlift = function() {
+    return _.first(this.value());
   };
 
   // Provide unwrapping proxy for some methods used in engine operations


### PR DESCRIPTION
Compare:

```
const doStuff = arr => {
  let res;
  if (arr.length > 10) {
    res = "long array";
  } else {
    res = "short array";
  }
  return res;
};
```
to:

```
const doStuff2 = arr =>
  _.lift(arr.length)
  .filter(len => len > 10)
  .map(() => "long array")
  .orElse(() => "short array")
  .unlift();
```

```
doStuff([1,2,3,4,5,6,7,8]);
> "short array"
doStuff2([1,2,3,4,5,6,7,8]);
> "short array"
```