### PR TITLE
Add missing methods to _.iteratee docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1902,10 +1902,11 @@ _("fabio").capitalize();
         identity, an arbitrary callback, a property matcher, or a property accessor.
         <br />
         The full list of Underscore methods that transform predicates
-        through <tt>_.iteratee</tt> is <tt>map</tt>, <tt>find</tt>,
-        <tt>filter</tt>, <tt>reject</tt>, <tt>every</tt>, <tt>some</tt>, <tt>max</tt>,
-        <tt>min</tt>, <tt>sortBy</tt>, <tt>groupBy</tt>, <tt>indexBy</tt>,
-        <tt>countBy</tt>, <tt>sortedIndex</tt>, <tt>partition</tt>, and <tt>uniq</tt>.
+        through <tt>_.iteratee</tt> is <tt>countBy<tt>, <tt>every<tt>, <tt>filter<tt>,
+        <tt>find<tt>, <tt>findIndex<tt>, <tt>findKey<tt>, <tt>findLastIndex<tt>,
+        <tt>groupBy<tt>, <tt>indexBy<tt>, <tt>map<tt>, <tt>mapObject<tt>, <tt>max<tt>,
+        <tt>min<tt>, <tt>partition<tt>, <tt>reject<tt>, <tt>some<tt>, <tt>sortBy<tt>,
+        <tt>sortedIndex<tt>, and <tt>uniq<tt>
       </p>
       <pre>
 var stooges = [{name: 'curly', age: 25}, {name: 'moe', age: 21}, {name: 'larry', age: 23}];


### PR DESCRIPTION
The following methods are transformed through `cb()` but are not listed in the
`_.itereatee` documentation:

* findIndex
* findKey
* findLastIndex
* mapObject

I've added them here, and alphabetized the list.