### PR TITLE
Separate object-oriented style and chaining in docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,6 +334,9 @@
       <li>- <a href="#template">template</a></li>
     </ul>
 
+    <a class="toc_title" href="#oop">
+      OOP Style
+    </a>
     <a class="toc_title" href="#chaining">
       Chaining
     </a>
@@ -1861,7 +1864,7 @@ obj.initialize = _.noop;
         <b>iteratee</b> is called with an <tt>index</tt> argument. Produces an
         array of the returned values.
         <br />
-        <i>Note: this example uses the <a href="#chaining">chaining syntax</a></i>.
+        <i>Note: this example uses the <a href="#oop">object-oriented syntax</a></i>.
       </p>
       <pre>
 _(3).times(function(n){ genie.grantWishNumber(n); });</pre>
@@ -2055,7 +2058,7 @@ _.template("Using 'with': <%= data.answer %>", {variable: 'data'})({answer: 'no'
 &lt;/script&gt;</pre>
 
 
-      <h2 id="chaining">Chaining</h2>
+      <h2 id="oop">Object-Oriented Style</h2>
 
       <p>
         You can use Underscore in either an object-oriented or a functional style,
@@ -2066,6 +2069,8 @@ _.template("Using 'with': <%= data.answer %>", {variable: 'data'})({answer: 'no'
     <pre>
 _.map([1, 2, 3], function(n){ return n * 2; });
 _([1, 2, 3]).map(function(n){ return n * 2; });</pre>
+
+      <h2 id="chaining">Chaining</h2>
 
       <p>
         Calling <tt>chain</tt> will cause all future method calls to return
@@ -2119,13 +2124,13 @@ var youngest = _.chain(stooges)
 </pre>
 
       <p id="value">
-        <b class="header">value</b><code>_(obj).value()</code>
+        <b class="header">value</b><code>_.chain(obj).value()</code>
         <br />
         Extracts the value of a wrapped object.
       </p>
       <pre>
-_([1, 2, 3]).value();
-=&gt; [1, 2, 3]
+_.chain([1, 2, 3]).reverse().value();
+=&gt; [3, 2, 1]
 </pre>
 
       <h2 id="links">Links &amp; Suggested Reading</h2>


### PR DESCRIPTION
I think the fact that the object-oriented style and chaining share implementation details has lead us to conflate them in the docs. In practice, the two features have almost nothing to do with each other.

The existing documentation could easily lead one to believe that they could start a chain using the OOP style.

This confusion is compounded by a few factors:

1. Lodash supports chains starting with the OOP wrapper.
2. The fact that we share names with native Array methods can lead to manual
   tests that appear to work.

For example:

    _([1,2,3]).reverse().map(function(n){ return n * 2; });

This appears to be an example of successfully starting a chain with the OOP style. The astute observer will note that the lack of a `.value()` call, proves this is not Underscore chaining, but a new user attempting to clarify the behavior for herself may not catch that detail.