### PR TITLE
Configurable option: on interpolation, ignore missing template variables

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -428,6 +428,6 @@
     assert.expect(1);
     var settings = {'ignore_missing_template_variables': true};
     var template = _.template('<%=foo%><%=bar%>', settings);
-    assert.deepEqual(template({"foo": "Handle"}), 'Handle<%=bar%>');
+    assert.deepEqual(template({'foo': 'Handle'}), 'Handle<%=bar%>');
   });
 }());

--- a/test/utility.js
+++ b/test/utility.js
@@ -417,4 +417,17 @@
     assert.strictEqual(template(), '<<\nx\n>>');
   });
 
+  QUnit.test('template returns cleanly and unchanged if template variables are missing.', function(assert) {
+    assert.expect(1);
+    var settings = {'ignore_missing_template_variables': true};
+    var template = _.template('<%=foo%>', settings);
+    assert.deepEqual(template({}), '<%=foo%>');
+  });
+
+  QUnit.test('template interpolates values and ignores missing template variables.', function(assert) {
+    assert.expect(1);
+    var settings = {'ignore_missing_template_variables': true};
+    var template = _.template('<%=foo%><%=bar%>', settings);
+    assert.deepEqual(template({"foo": "Handle"}), 'Handle<%=bar%>');
+  });
 }());

--- a/underscore.js
+++ b/underscore.js
@@ -1480,19 +1480,17 @@
     return '\\' + escapes[match];
   };
 
-// When customizing `templateSettings`, it is important to know how the
+  // When customizing `templateSettings`, it is important to know how the
   // template begin and end tags are defined. This way, we can ignore template variables
   // that are not defined.
-  // var find_template_begin_tag = /\/(.+)(?=\(\[)/g;
-  // var find_template_end_tag = /\?\)(.*)(?=\/g)/g;
 
   // JavaScript micro-templating, similar to John Resig's implementation.
   // Underscore templating handles arbitrary delimiters, preserves whitespace,
   // and correctly escapes quotes within interpolated code.
   // NB: `oldSettings` only exists for backwards compatibility.
   _.template = function(text, settings, oldSettings) {
-    var find_template_begin_tag = /\/(.+)(?=\(\[)/g;
-    var find_template_end_tag = /\?\)(.*)(?=\/g)/g;
+    var findTemplateBeginTag = /\/(.+)(?=\(\[)/g;
+    var findTemplateEndTag = /\?\)(.*)(?=\/g)/g;
     if (!settings && oldSettings) settings = oldSettings;
     settings = _.defaults({}, settings, _.templateSettings);
 
@@ -1505,14 +1503,14 @@
 
     // Find the template tags for the defined interpolation settings.
     // This is used to substitute undefined variables with the pre-existing tags.
-    if(settings.ignore_missing_template_variables) {
-      var template_begin_results = find_template_begin_tag.exec(settings.interpolate.toString()) || [];
-      var template_begin_tag = template_begin_results[1] || null;      
-      if(!template_begin_tag) throw new Error('Could not find template begin tag from: ' + settings.interpolate);
+    if (settings.ignore_missing_template_variables) {
+      var templateBeginResults = findTemplateBeginTag.exec(settings.interpolate.toString()) || [];
+      var templateBeginTag = templateBeginResults[1] || null;
+      if(!templateBeginTag) throw new Error('Could not find template begin tag from: ' + settings.interpolate);
 
-      var template_end_results = find_template_end_tag.exec(settings.interpolate.toString()) || [];
-      var template_end_tag = template_end_results[1] || null;
-      if(!template_end_tag) throw new Error('Could not find template end tag from: ' + settings.interpolate);
+      var templateEndResults = findTemplateEndTag.exec(settings.interpolate.toString()) || [];
+      var templateEndTag = templateEndResults[1] || null;
+      if (!templateEndTag) throw new Error('Could not find template end tag from: ' + settings.interpolate);
     }
 
     // Compile the template source, escaping string literals appropriately.
@@ -1527,7 +1525,7 @@
       } else if (interpolate) {
         source +=
           settings.ignore_missing_template_variables
-            ? "'+\n(__t=(typeof(" + interpolate + ") === \"undefined\") ? \"" + template_begin_tag + "\" + '" + interpolate + "' + \"" + template_end_tag + "\" : " + interpolate + ")+\n'"
+            ? "'+\n(__t=(typeof(" + interpolate + ") === \"undefined\") ? \"" + templateBeginTag + "\" + '" + interpolate + "' + \"" + templateEndTag + "\" : " + interpolate + ")+\n'"
             : "'+\n((__t=(" + interpolate + "))==null?'':__t)+\n'";
       } else if (evaluate) {
         source += "';\n" + evaluate + "\n__p+='";

--- a/underscore.js
+++ b/underscore.js
@@ -1525,7 +1525,7 @@
       } else if (interpolate) {
         source +=
           settings.ignore_missing_template_variables
-            ? '\'+\n(__t=(typeof(\'' + interpolate + '\') === \'undefined\') ? \'' + templateBeginTag + '\' + ' + interpolate + ' + \'' + templateEndTag + '\' : ' + interpolate + ')+\n\''
+            ? '\'+\n(__t=(typeof(' + interpolate + ') === \'undefined\') ? \'' + templateBeginTag + '\' + \'' + interpolate + '\' + \'' + templateEndTag + '\' : ' + interpolate + ')+\n\''
             : '\'+\n((__t=(' + interpolate + '))==null ? \'\':__t)+\n\'';
       } else if (evaluate) {
         source += "';\n" + evaluate + "\n__p+='";

--- a/underscore.js
+++ b/underscore.js
@@ -1507,8 +1507,7 @@
     // This is used to substitute undefined variables with the pre-existing tags.
     if(settings.ignore_missing_template_variables) {
       var template_begin_results = find_template_begin_tag.exec(settings.interpolate.toString()) || [];
-      var template_begin_tag = template_begin_results[1] || null;
-      alert(template_begin_results);
+      var template_begin_tag = template_begin_results[1] || null;      
       if(!template_begin_tag) throw new Error('Could not find template begin tag from: ' + settings.interpolate);
 
       var template_end_results = find_template_end_tag.exec(settings.interpolate.toString()) || [];

--- a/underscore.js
+++ b/underscore.js
@@ -1506,7 +1506,7 @@
     if (settings.ignore_missing_template_variables) {
       var templateBeginResults = findTemplateBeginTag.exec(settings.interpolate.toString()) || [];
       var templateBeginTag = templateBeginResults[1] || null;
-      if(!templateBeginTag) throw new Error('Could not find template begin tag from: ' + settings.interpolate);
+      if (!templateBeginTag) throw new Error('Could not find template begin tag from: ' + settings.interpolate);
 
       var templateEndResults = findTemplateEndTag.exec(settings.interpolate.toString()) || [];
       var templateEndTag = templateEndResults[1] || null;
@@ -1525,8 +1525,8 @@
       } else if (interpolate) {
         source +=
           settings.ignore_missing_template_variables
-            ? "'+\n(__t=(typeof(" + interpolate + ") === \"undefined\") ? \"" + templateBeginTag + "\" + '" + interpolate + "' + \"" + templateEndTag + "\" : " + interpolate + ")+\n'"
-            : "'+\n((__t=(" + interpolate + "))==null?'':__t)+\n'";
+            ? '\'+\n(__t=(typeof(\'' + interpolate + '\') === \'undefined\') ? \'' + templateBeginTag + '\' + ' + interpolate + ' + \'' + templateEndTag + '\' : ' + interpolate + ')+\n\''
+            : '\'+\n((__t=(' + interpolate + '))==null ? \'\':__t)+\n\'';
       } else if (evaluate) {
         source += "';\n" + evaluate + "\n__p+='";
       }


### PR DESCRIPTION
I propose a configurable option here. The option to have underscore partially interpolate templates. 

The idea here is that all template variables are required to be present on interpolation. This relaxes that restraint and leaves a missing template variable exactly as it was before in the template. Leaving it for future interpolation. 

I use underscore in nodejs, as well as backbone in the same application. I have a centralized configuration file that the application uses. The template I use requires configuration information, and user inputted information. The template then is filled out in two stages, once in nodejs and finished in backbone. 

This really helps with with staged templating and accomplishes my and possibility other's use cases. 

The modification is to the **settings** object. 

The addition is the **ignore_missing_template_variables** key. It accepts a boolean value.

The added usage is as follows:

`// partial replace`
`var example_template = '<%= foo %><%= bar %>;`
`var settings = {'ignore_missing_template_variables': true};`
`var template = _.template(example_template, settings);`
`var example_templated = template({'foo': '123'}); // '123<%= bar%>'`

`// ignore variable`
`var example_template = '<%= foo %>;`
`var settings = {'ignore_missing_template_variables': true};`
`var template = _.template(example_template, settings);`
`var example_templated = template({}); // '<%=foo%>';`

This option can be disabled or omitted for original functionality, and custom interpolation tags are preserved.