### PR TITLE
Add _.sort as alias of _.sortBy

### DIFF
--- a/index.html
+++ b/index.html
@@ -689,6 +689,7 @@ _.min(numbers);
 
       <p id="sortBy">
         <b class="header">sortBy</b><code>_.sortBy(list, iteratee, [context])</code>
+        <span class="alias">Alias: <b>sort</b></span>
         <br />
         Returns a (stably) sorted copy of <b>list</b>, ranked in ascending
         order by the results of running each value through <b>iteratee</b>.

--- a/test/collections.js
+++ b/test/collections.js
@@ -680,6 +680,10 @@
     assert.deepEqual(_.sortBy(list), ['e', 'q', 'r', 't', 'w', 'y'], 'uses _.identity if iterator is not specified');
   });
 
+  QUnit.test('sort', function(assert) {
+    assert.strictEqual(_.sort, _.sortBy, 'is an alias for sortBy');
+  });
+
   QUnit.test('groupBy', function(assert) {
     var parity = _.groupBy([1, 2, 3, 4, 5, 6], function(num){ return num % 2; });
     assert.ok('0' in parity && '1' in parity, 'created a group for each value');

--- a/underscore.js
+++ b/underscore.js
@@ -381,7 +381,7 @@
   };
 
   // Sort the object's values by a criterion produced by an iteratee.
-  _.sortBy = function(obj, iteratee, context) {
+  _.sortBy = _.sort = function(obj, iteratee, context) {
     var index = 0;
     iteratee = cb(iteratee, context);
     return _.pluck(_.map(obj, function(value, key, list) {


### PR DESCRIPTION
When using the `_.identity` feature of `_.iteratee`, the name "sortBy" does not
make sense.

    // Confusing:
    _.sortBy([5, 4, 3]);
    => [3, 4, 5]

    // Better
    _.sort([5, 4, 3]);
    => [3, 4, 5]