### PR TITLE
Docs copy-paste mistake with _.unzip function

### DIFF
--- a/index.html
+++ b/index.html
@@ -978,8 +978,8 @@ _.zip(['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]);
         and so on.
       </p>
       <pre>
-_.unzip([['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]])
-=&gt; ["moe", 30, true], ["larry", 40, false], ["curly", 50, false]
+_.unzip([["moe", 30, true], ["larry", 40, false], ["curly", 50, false]]);
+=&gt; [['moe', 'larry', 'curly'], [30, 40, 50], [true, false, false]]
 </pre>
 
       <p id="object">


### PR DESCRIPTION
There is a misinformation about "unzip" function in the docs. Seems like
a example was copied from "zip" description and someone forgot to change
this.