### PR TITLE
Allow a specified depth for flatten

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -90,6 +90,8 @@
     assert.deepEqual(result, [1, 2, 3, 4], 'works on an arguments object');
     list = [[1], [2], [3], [[4]]];
     assert.deepEqual(_.flatten(list, true), [1, 2, 3, [4]], 'can shallowly flatten arrays containing only other arrays');
+    list = [1, [2], [[3]], [[[4]]]];
+    assert.deepEqual(_.flatten(list, 2), [1, 2, 3, [4]], 'can flatten arrays to a given depth');
 
     assert.equal(_.flatten([_.range(10), _.range(10), 5, 1, 3], true).length, 23, 'can flatten medium length arrays');
     assert.equal(_.flatten([_.range(10), _.range(10), 5, 1, 3]).length, 23, 'can shallowly flatten medium length arrays');

--- a/test/arrays.js
+++ b/test/arrays.js
@@ -92,6 +92,8 @@
     assert.deepEqual(_.flatten(list, true), [1, 2, 3, [4]], 'can shallowly flatten arrays containing only other arrays');
     list = [1, [2], [[3]], [[[4]]]];
     assert.deepEqual(_.flatten(list, 2), [1, 2, 3, [4]], 'can flatten arrays to a given depth');
+    assert.deepEqual(_.flatten(list, 0), list, 'can flatten arrays to depth of 0');
+    assert.deepEqual(_.flatten(list, -1), list, 'can flatten arrays to depth of -1');
 
     assert.equal(_.flatten([_.range(10), _.range(10), 5, 1, 3], true).length, 23, 'can flatten medium length arrays');
     assert.equal(_.flatten([_.range(10), _.range(10), 5, 1, 3]).length, 23, 'can shallowly flatten medium length arrays');

--- a/underscore.js
+++ b/underscore.js
@@ -522,7 +522,11 @@
 
   // Flatten out an array, either recursively (by default), or just one level.
   _.flatten = function(array, depth) {
-    if (!depth) depth = Infinity;
+    if (!depth && depth !== 0) {
+      depth = Infinity;
+    } else if (depth <= 0) {
+      return _.clone(array);
+    }
     return flatten(array, depth, false);
   };
 

--- a/underscore.js
+++ b/underscore.js
@@ -499,19 +499,19 @@
   };
 
   // Internal implementation of a recursive `flatten` function.
-  var flatten = function(input, shallow, strict, output) {
+  var flatten = function(input, depth, strict, output) {
     output = output || [];
     var idx = output.length;
     for (var i = 0, length = getLength(input); i < length; i++) {
       var value = input[i];
       if (isArrayLike(value) && (_.isArray(value) || _.isArguments(value))) {
-        // Flatten current level of array or arguments object.
-        if (shallow) {
+        if (depth > 1) {
+          flatten(value, depth - 1, strict, output);
+          idx = output.length;
+        } else {
+          // Flatten current level of array or arguments object.
           var j = 0, len = value.length;
           while (j < len) output[idx++] = value[j++];
-        } else {
-          flatten(value, shallow, strict, output);
-          idx = output.length;
         }
       } else if (!strict) {
         output[idx++] = value;
@@ -521,8 +521,9 @@
   };
 
   // Flatten out an array, either recursively (by default), or just one level.
-  _.flatten = function(array, shallow) {
-    return flatten(array, shallow, false);
+  _.flatten = function(array, depth) {
+    if (!depth) depth = Infinity;
+    return flatten(array, depth, false);
   };
 
   // Return a version of the array that does not contain the specified value(s).


### PR DESCRIPTION
Per a new TC39 proposal http://bterlson.github.io/proposal-flatMap/#sec-Array.prototype.flatten they're suggesting a depth argument.

This was fairly trivial to implement without breaking the current functionality.

Thoughts?
