### PR TITLE
Improves `_.memoize` performance

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -173,6 +173,16 @@
     assert.notStrictEqual(myObj, void 0, 'object is created if second argument used as key');
     assert.strictEqual(myObj, myObjAlias, 'object is cached if second argument used as key');
     assert.strictEqual(myObj.value, 'a', 'object is not modified if second argument used as key');
+
+    // `undefined` return values should be memoized.
+    var execCount = 0;
+    var returnUndef = _.memoize(function() {
+      execCount++;
+      return;
+    });
+    returnUndef(1);
+    returnUndef(1);
+    assert.deepEqual(execCount, 1);
   });
 
   QUnit.test('delay', function(assert) {

--- a/underscore.js
+++ b/underscore.js
@@ -779,13 +779,20 @@
 
   // Memoize an expensive function by storing its results.
   _.memoize = function(func, hasher) {
+    function getCache() {
+      if (Object.create) {
+        return Object.create(null);
+      }
+      return {};
+    }
+
     var memoize = function(key) {
       var cache = memoize.cache;
       var address = '' + (hasher ? hasher.apply(this, arguments) : key);
-      if (!_.has(cache, address)) cache[address] = func.apply(this, arguments);
+      if (typeof cache[address] === 'undefined') cache[address] = func.apply(this, arguments);
       return cache[address];
     };
-    memoize.cache = {};
+    memoize.cache = getCache();
     return memoize;
   };
 

--- a/underscore.js
+++ b/underscore.js
@@ -786,23 +786,14 @@
       return {};
     }
 
-    function hasKey(cache, address) {
-      // Objects created with `Object.create(null)` don't have a constructor
-      // property.
-      if (cache.constructor === Object) {
-        return _.has(cache, address);
-      } else {
-        return (typeof cache[address] !== 'undefined');
-      }
-    }
-
     var memoize = function(key) {
       var cache = memoize.cache;
       var address = '' + (hasher ? hasher.apply(this, arguments) : key);
-      if (!hasKey(cache, address)) cache[address] = func.apply(this, arguments);
+      if (!(_.has(cache, address))) cache[address] = func.apply(this, arguments);
       return cache[address];
     };
     memoize.cache = getCache();
+
     return memoize;
   };
 

--- a/underscore.js
+++ b/underscore.js
@@ -786,10 +786,20 @@
       return {};
     }
 
+    function hasKey(cache, address) {
+      // Objects created with `Object.create(null)` don't have a constructor
+      // property.
+      if (cache.constructor === Object) {
+        return _.has(cache, address);
+      } else {
+        return (typeof cache[address] !== 'undefined');
+      }
+    }
+
     var memoize = function(key) {
       var cache = memoize.cache;
       var address = '' + (hasher ? hasher.apply(this, arguments) : key);
-      if (typeof cache[address] === 'undefined') cache[address] = func.apply(this, arguments);
+      if (!hasKey(cache, address)) cache[address] = func.apply(this, arguments);
       return cache[address];
     };
     memoize.cache = getCache();


### PR DESCRIPTION
Creating an object without prototype proves to be faster than a literal
object, since we don't have to go through the prototype chain to check
if a key already exists.

With a memoized recursive fibonacci implementation, we could do on a
MacBook 13 Retina Late 2013 ~9.6M ops/sec, while with the improved
implementation we could get ~26M ops/sec. Almost a 3x improvement.
