### PR TITLE
Allow users to customize _.iteratee

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -165,6 +165,14 @@
     // Passing a property name like _.pluck.
     var people = [{name: 'moe', age: 30}, {name: 'curly', age: 50}];
     assert.deepEqual(_.map(people, 'name'), ['moe', 'curly'], 'predicate string map to object properties');
+
+    var iteratee = _.iteratee;
+    _.iteratee = function(n) { return function(value) { return value * n; }; };
+
+    assert.deepEqual(_.map([1, 2, 3], 2), [2, 4, 6], 'will use a user-defined _.iteratee function');
+
+    // Replace the built-in iteratee so as to not break other tests
+    _.iteratee = iteratee;
   });
 
   QUnit.test('collect', function(assert) {

--- a/test/collections.js
+++ b/test/collections.js
@@ -165,14 +165,6 @@
     // Passing a property name like _.pluck.
     var people = [{name: 'moe', age: 30}, {name: 'curly', age: 50}];
     assert.deepEqual(_.map(people, 'name'), ['moe', 'curly'], 'predicate string map to object properties');
-
-    var iteratee = _.iteratee;
-    _.iteratee = function(n) { return function(value) { return value * n; }; };
-
-    assert.deepEqual(_.map([1, 2, 3], 2), [2, 4, 6], 'will use a user-defined _.iteratee function');
-
-    // Replace the built-in iteratee so as to not break other tests
-    _.iteratee = iteratee;
   });
 
   QUnit.test('collect', function(assert) {

--- a/test/functions.js
+++ b/test/functions.js
@@ -688,6 +688,43 @@
       assert.deepEqual(_.toArray(cb(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), _.range(1, 11));
     });
 
+    // Test custom iteratee
+    var builtinIteratee = _.iteratee;
+    _.iteratee = function(value) {
+      // RegEx values return a function that returns the number of matches
+      if (_.isRegExp(value)) return function(obj) {
+        return (obj.match(value) || []).length;
+      };
+      return value;
+    };
+
+    var collection = ['foo', 'bar', 'bbiz'];
+
+    // Test all methods that claim to be transformed through `_.iteratee`
+    assert.deepEqual(_.countBy(collection, /b/g), {0: 1, 1: 1, 2: 1});
+    assert.equal(_.every(collection, /b/g), false);
+    assert.deepEqual(_.filter(collection, /b/g), ['bar', 'bbiz']);
+    assert.equal(_.find(collection, /b/g), 'bar');
+    assert.equal(_.findIndex(collection, /b/g), 1);
+    assert.equal(_.findKey(collection, /b/g), 1);
+    assert.equal(_.findLastIndex(collection, /b/g), 2);
+    assert.deepEqual(_.groupBy(collection, /b/g), {0: ['foo'], 1: ['bar'], 2: ['bbiz']});
+    assert.deepEqual(_.indexBy(collection, /b/g), {0: 'foo', 1: 'bar', 2: 'bbiz'});
+    assert.deepEqual(_.map(collection, /b/g), [0, 1, 2]);
+    assert.equal(_.max(collection, /b/g), 'bbiz');
+    assert.equal(_.min(collection, /b/g), 'foo');
+    assert.deepEqual(_.partition(collection, /b/g), [['bar', 'bbiz'], ['foo']]);
+    assert.deepEqual(_.reject(collection, /b/g), ['foo']);
+    assert.equal(_.some(collection, /b/g), true);
+    assert.deepEqual(_.sortBy(collection, /b/g), ['foo', 'bar', 'bbiz']);
+    assert.equal(_.sortedIndex(collection, 'blah', /b/g), 1);
+    assert.deepEqual(_.uniq(collection, /b/g), ['foo', 'bar', 'bbiz']);
+
+    var objCollection = {a: 'foo', b: 'bar', c: 'bbiz'};
+    assert.deepEqual(_.mapObject(objCollection, /b/g), {a: 0, b: 1, c: 2});
+
+    // Restore the builtin iteratee
+    _.iteratee = builtinIteratee;
   });
 
   QUnit.test('restArgs', function(assert) {

--- a/underscore.js
+++ b/underscore.js
@@ -84,18 +84,23 @@
     };
   };
 
+  var builtinIteratee;
+
   // An internal function to generate callbacks that can be applied to each
   // element in a collection, returning the desired result — either `identity`,
   // an arbitrary callback, a property matcher, or a property accessor.
   var cb = function(value, context, argCount) {
+    if (_.iteratee !== builtinIteratee) return _.iteratee(value, context);
     if (value == null) return _.identity;
     if (_.isFunction(value)) return optimizeCb(value, context, argCount);
     if (_.isObject(value)) return _.matcher(value);
     return _.property(value);
   };
 
-  // An external wrapper for the internal callback generator.
-  _.iteratee = function(value, context) {
+  // External wrapper for our callback generator. Users may customize
+  // `_.iteratee` if they want additional predicate/iteratee shorthand styles.
+  // This abstraction hides the internal-only argCount argument.
+  _.iteratee = builtinIteratee = function(value, context) {
     return cb(value, context, Infinity);
   };
 
@@ -443,7 +448,7 @@
       // Keep surrogate pair characters together
       return obj.match(reStrSymbol);
     }
-    if (isArrayLike(obj)) return _.map(obj);
+    if (isArrayLike(obj)) return _.map(obj, _.identity);
     return _.values(obj);
   };
 
@@ -495,7 +500,7 @@
 
   // Trim out all falsy values from an array.
   _.compact = function(array) {
-    return _.filter(array);
+    return _.filter(array, Boolean);
   };
 
   // Internal implementation of a recursive `flatten` function.


### PR DESCRIPTION
This fix was originally proposed by @jridgewell in #1965 but it was unable to gain consensus since his approach added an additional layer of abstraction to which @akre54 objected. I've refactored @jridgewell's approach to avoid that abstraction.

This PR was motivated by a renewed interest in customizable shorthand syntaxes such as the RegEx syntax proposed in #2475.

If this approach looks good to people, I can look into more robusts tests and documentation.