### PR TITLE
Make `_.iteratee` docs more explicit

### DIFF
--- a/index.html
+++ b/index.html
@@ -1900,22 +1900,37 @@ _("fabio").capitalize();
       <p id="iteratee">
         <b class="header">iteratee</b><code>_.iteratee(value, [context])</code>
         <br />
-        A mostly-internal function to generate callbacks that can be applied
-        to each element in a collection, returning the desired result — either
-        identity, an arbitrary callback, a property matcher, or a property accessor.
-        <br />
-        The full list of Underscore methods that transform predicates
-        through <tt>_.iteratee</tt> is <tt>countBy</tt>, <tt>every</tt>, <tt>filter</tt>,
-        <tt>find</tt>, <tt>findIndex</tt>, <tt>findKey</tt>, <tt>findLastIndex</tt>,
-        <tt>groupBy</tt>, <tt>indexBy</tt>, <tt>map</tt>, <tt>mapObject</tt>, <tt>max</tt>,
-        <tt>min</tt>, <tt>partition</tt>, <tt>reject</tt>, <tt>some</tt>, <tt>sortBy</tt>,
-        <tt>sortedIndex</tt>, and <tt>uniq</tt>
+        Generates a callback that can be applied to each element in
+        a collection. <tt>_.iteratee</tt> supports a number of shorthand
+        syntaxes for common callback use cases. Depending <tt>value</tt>'s type
+        <tt>_.iteratee</tt> will return:
       </p>
       <pre>
-var stooges = [{name: 'curly', age: 25}, {name: 'moe', age: 21}, {name: 'larry', age: 23}];
-_.map(stooges, _.iteratee('age'));
-=&gt; [25, 21, 23];
-</pre>
+// No value
+_.iteratee();
+=> _.identity()
+
+// Function
+_.iteratee(function(n) { return n * 2; });
+=> function(n) { return n * 2; }
+
+// Object
+_.iteratee({firstName: 'Chelsea'});
+=> _.matcher({firstName: 'Chelsea'});
+
+// Anything else
+_.iteratee('firstName');
+=> _.property('firstName');</pre>
+
+      <p>
+        The following Underscore methods transform their predicates through
+        <tt>_.iteratee</tt>: <tt>countBy</tt>, <tt>every</tt>,
+        <tt>filter</tt>, <tt>find</tt>, <tt>findIndex</tt>, <tt>findKey</tt>,
+        <tt>findLastIndex</tt>, <tt>groupBy</tt>, <tt>indexBy</tt>,
+        <tt>map</tt>, <tt>mapObject</tt>, <tt>max</tt>, <tt>min</tt>,
+        <tt>partition</tt>, <tt>reject</tt>, <tt>some</tt>, <tt>sortBy</tt>,
+        <tt>sortedIndex</tt>, and <tt>uniq</tt>
+      </p>
 
       <p id="uniqueId">
         <b class="header">uniqueId</b><code>_.uniqueId([prefix])</code>


### PR DESCRIPTION
`_.iteratee` contains a huge amount of power/magic, and based upon my [personal experience](https://jordaneldredge.com/blog/youre-underusing-underscore/), it is one of the most underused aspects of Underscore.

The issue of `_.iteratee`'s functionality being hard to discover has been raised before (#2052).

Hopefully this more explicit documentation can help. Additionally it lays groundwork for documenting `_.iteratee` as user definable if #2480 ends up getting merged.

To aid in review, you can see my proposed version here: http://rawgit.com/captbaritone/underscore/iteratee-docs/index.html#iteratee