### PR TITLE
Fix debounce immediate

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -475,9 +475,9 @@
   });
 
   QUnit.test('debounce asap', function(assert) {
-    assert.expect(4);
+    assert.expect(6);
     var done = assert.async();
-    var a, b;
+    var a, b, c;
     var counter = 0;
     var incr = function(){ return ++counter; };
     var debouncedIncr = _.debounce(incr, 64, true);
@@ -489,7 +489,13 @@
     _.delay(debouncedIncr, 16);
     _.delay(debouncedIncr, 32);
     _.delay(debouncedIncr, 48);
-    _.delay(function(){ assert.equal(counter, 1, 'incr was debounced'); done(); }, 128);
+    _.delay(function(){
+      assert.equal(counter, 1, 'incr was debounced');
+      c = debouncedIncr();
+      assert.equal(c, 2);
+      assert.equal(counter, 2, 'incr was called again');
+      done();
+    }, 128);
   });
 
   QUnit.test('debounce asap cancel', function(assert) {

--- a/underscore.js
+++ b/underscore.js
@@ -860,12 +860,12 @@
     };
 
     var debounced = restArgs(function(args) {
-      var callNow = immediate && !timeout;
       if (timeout) clearTimeout(timeout);
-      if (callNow) {
+      if (immediate) {
+        var callNow = !timeout;
         timeout = setTimeout(later, wait);
-        result = func.apply(this, args);
-      } else if (!immediate) {
+        if (callNow) result = func.apply(this, args);
+      } else {
         timeout = _.delay(later, wait, this, args);
       }
 


### PR DESCRIPTION
Fixes an issue with `_.debounce` when `{ immediate: true }`. When
called twice within `wait` ms, we cleared the `timeout`. Because it is
truthy on the second run, it was cleared but `timeout` remained
truthy (on any later run, `timeout` remains truthy). Because `timeout`
was cleared, the `later` function is never run to null out `timeout`.

Anyways, we should always be setting a fresh timeout function when
`{ immediate: true }`, to prevent further calls to the debounced
function until the `wait` ms after the last call.

Fixes #2478, supersedes #2479. Thanks for the bug report @hanzichi.