### PR TITLE
Make no-use-before-define eslint rule a warning.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -74,7 +74,7 @@
     "no-unreachable": 2,
     "no-unused-expressions": 2,
     "no-unused-vars": 2,
-    "no-use-before-define": [2, "nofunc"],
+    "no-use-before-define": [1, "nofunc"],
     "no-with": 2,
     "object-curly-spacing": [2, "never"],
     "quote-props": [1, "as-needed"],


### PR DESCRIPTION
As per https://github.com/jashkenas/underscore/pull/2480#discussion_r57190276, changing this to a warning.