### PR TITLE
Add `npm run weight` tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     "coveralls": "^2.11.2",
     "docco": "*",
     "eslint": "1.10.x",
+    "gzip-size-cli": "^1.0.0",
     "karma": "^0.13.13",
     "karma-qunit": "~0.1.4",
     "nyc": "^2.1.3",
+    "pretty-bytes-cli": "^1.0.0",
     "qunit-cli": "~0.2.0",
     "qunitjs": "^1.18.0",
     "uglify-js": "2.4.x"
@@ -34,8 +36,10 @@
     "lint": "eslint underscore.js test/*.js",
     "test-node": "qunit-cli test/*.js",
     "test-browser": "npm i karma-phantomjs-launcher && karma start",
-    "build": "uglifyjs underscore.js -c \"evaluate=false\" --comments \"/    .*/\" -m --source-map underscore-min.map --source-map-url \" \" -o underscore-min.js",
-    "doc": "docco underscore.js"
+    "minify":  "uglifyjs underscore.js -c \"evaluate=false\" --comments \"/    .*/\" -m",
+    "build": "npm run minify -- --source-map underscore-min.map --source-map-url \" \" -o underscore-min.js",
+    "doc": "docco underscore.js",
+    "weight": "npm run minify | gzip-size | pretty-bytes"
   },
   "license": "MIT",
   "files": [


### PR DESCRIPTION
The way a code change maps to a change in minified/gzipped size is not always intuitive (#2383). To help folks in our effort to slim down (#2060), they can now issue the command:

    npm run weight

And get output like:

    6.27 kB

Which should give a fairly good estimate of the "over-the-wire" size of their `underscore.js`.

Caveat: The weight reported does not include the source-map comment at the end of the file.