### PR TITLE
Allow deep property matching via array syntax

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -694,6 +694,9 @@
       assert.deepEqual(_.toArray(cb(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), _.range(1, 11));
     });
 
+    var deepProperty = _.iteratee(['a', 'b']);
+    assert.equal(deepProperty({a: {b: 2}}), 2, 'treats an array as a deep property accessor');
+
     // Test custom iteratee
     var builtinIteratee = _.iteratee;
     _.iteratee = function(value) {

--- a/test/utility.js
+++ b/test/utility.js
@@ -75,6 +75,12 @@
     assert.equal(_.property('name')(stooge), 'moe', 'should return the property with the given name');
     assert.equal(_.property('name')(null), void 0, 'should return undefined for null values');
     assert.equal(_.property('name')(void 0), void 0, 'should return undefined for undefined values');
+    assert.equal(_.property(null)('foo'), void 0, 'should return undefined for null object');
+
+    // Deep property access
+    assert.strictEqual(_.property('a')({a: 1}), 1, 'can get a direct property');
+    assert.strictEqual(_.property(['a', 'b'])({a: {b: 2}}), 2, 'can get a nested property');
+    assert.strictEqual(_.property(['a'])({a: false}), false, 'can fetch falsey values');
   });
 
   QUnit.test('propertyOf', function(assert) {
@@ -358,6 +364,16 @@
     assert.strictEqual(_.result(obj, 'b', function() {
       return this.a;
     }), obj.a, 'called with context');
+  });
+
+  QUnit.test('get', function(assert) {
+    assert.strictEqual(_.get({a: 1}, 'a'), 1, 'can get a direct property');
+    assert.strictEqual(_.get({a: {b: 2}}, ['a', 'b']), 2, 'can get a nested property');
+    assert.strictEqual(_.get({a: 1}, 'b', 2), 2, 'uses the fallback value when property is missing');
+    assert.strictEqual(_.get({a: 1}, ['b', 'c'], 2), 2, 'uses the fallback value when any property is missing');
+    assert.strictEqual(_.get({a: void 0}, ['a'], 1), 1, 'uses the fallback when value is undefined');
+    assert.strictEqual(_.get({a: null}, ['a'], 1), 1, 'uses the fallback when value is null');
+    assert.strictEqual(_.get({a: false}, ['a'], 'foo'), false, 'can fetch falsey values');
   });
 
   QUnit.test('_.templateSettings.variable', function(assert) {


### PR DESCRIPTION
Inspired by `underscore-contrib`'s _.getPath` and lodash's deep property access, this adds a deep property access array shorthand to many aspects of Underscore, including:

* `_.property`
* `_.iteratee` and all methods that depend on it.

It also exposes a convenience function `_.get` for accessing deep properties with a default.

Possible Concerns
-----------------

While `_.property` does not get called in any place that would present a performance concern, `getLength` (which is created by `_.property`) gets used in many places which _may_ have performance ramifications.

I've placed the `isArray` call in the outer function of `_.property` in an attempt to reduce complexity inside the generated function. This required defining `isArray` earlier.

It's possible that this still isn't fast enough, and we should just define `getLength` manually.

Adds ~0.06kB (minified/gzipped)

Further work
------------

The following methods should probably also accept the array syntax:

* `_.result`
* `_.has`

The following companion methods should be created:

* `_.set`

Fixes: #2372, an elegant solution to an oft requested feature: (see: #2370, #2268, #1169, #1266)