### PR TITLE
Document customizing `_.iteratee`

### DIFF
--- a/index.html
+++ b/index.html
@@ -1932,6 +1932,17 @@ _.iteratee('firstName');
         <tt>sortedIndex</tt>, and <tt>uniq</tt>
       </p>
 
+      <p>
+        You may overwrite <tt>_.iteratee</tt> with your own custom function,
+        if you want additional or different shorthand syntaxes:
+      </p>
+      <pre>
+// Support `RegExp` predicate shorthand.
+var builtinIteratee = _.iteratee;
+_.iteratee = function(value, context) {
+  if (_.isRegExp(value)) return function(obj) { return value.test(obj) };
+  return builtinIteratee(value, context);
+};</pre>
       <p id="uniqueId">
         <b class="header">uniqueId</b><code>_.uniqueId([prefix])</code>
         <br />


### PR DESCRIPTION
For visual review: http://rawgit.com/captbaritone/underscore/custom-iteratee-docs/index.html#iteratee

Note, mostly for myself: This should not be cherry-picked onto `gh-pages`, since the functionality is not available in the latest tagged release.

Credit: Uses @olleicua's `RegExp` proposal from #2475 as the example customization.