### PR TITLE
Prefer `assert.notOk()` to `assert.ok(!)`

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -268,8 +268,8 @@
     var list = [{a: 1, b: 2}, {a: 2, b: 2}, {a: 1, b: 3}, {a: 1, b: 4}, {a: 2, b: 4}];
     assert.deepEqual(_.find(list, {a: 1}), {a: 1, b: 2}, 'can be used as findWhere');
     assert.deepEqual(_.find(list, {b: 4}), {a: 1, b: 4});
-    assert.ok(!_.find(list, {c: 1}), 'undefined when not found');
-    assert.ok(!_.find([], {c: 1}), 'undefined when searching empty list');
+    assert.notOk(_.find(list, {c: 1}), 'undefined when not found');
+    assert.notOk(_.find([], {c: 1}), 'undefined when searching empty list');
 
     var result = _.find([1, 2, 3], function(num){ return num * 2 === 4; });
     assert.equal(result, 2, 'found the first "2" and broke the loop');
@@ -348,25 +348,25 @@
   QUnit.test('every', function(assert) {
     assert.ok(_.every([], _.identity), 'the empty set');
     assert.ok(_.every([true, true, true], _.identity), 'every true values');
-    assert.ok(!_.every([true, false, true], _.identity), 'one false value');
+    assert.notOk(_.every([true, false, true], _.identity), 'one false value');
     assert.ok(_.every([0, 10, 28], function(num){ return num % 2 === 0; }), 'even numbers');
-    assert.ok(!_.every([0, 11, 28], function(num){ return num % 2 === 0; }), 'an odd number');
+    assert.notOk(_.every([0, 11, 28], function(num){ return num % 2 === 0; }), 'an odd number');
     assert.strictEqual(_.every([1], _.identity), true, 'cast to boolean - true');
     assert.strictEqual(_.every([0], _.identity), false, 'cast to boolean - false');
-    assert.ok(!_.every([void 0, void 0, void 0], _.identity), 'works with arrays of undefined');
+    assert.notOk(_.every([void 0, void 0, void 0], _.identity), 'works with arrays of undefined');
 
     var list = [{a: 1, b: 2}, {a: 2, b: 2}, {a: 1, b: 3}, {a: 1, b: 4}];
-    assert.ok(!_.every(list, {a: 1, b: 2}), 'Can be called with object');
+    assert.notOk(_.every(list, {a: 1, b: 2}), 'Can be called with object');
     assert.ok(_.every(list, 'a'), 'String mapped to object property');
 
     list = [{a: 1, b: 2}, {a: 2, b: 2, c: true}];
     assert.ok(_.every(list, {b: 2}), 'Can be called with object');
-    assert.ok(!_.every(list, 'c'), 'String mapped to object property');
+    assert.notOk(_.every(list, 'c'), 'String mapped to object property');
 
     assert.ok(_.every({a: 1, b: 2, c: 3, d: 4}, _.isNumber), 'takes objects');
-    assert.ok(!_.every({a: 1, b: 2, c: 3, d: 4}, _.isObject), 'takes objects');
+    assert.notOk(_.every({a: 1, b: 2, c: 3, d: 4}, _.isObject), 'takes objects');
     assert.ok(_.every(['a', 'b', 'c', 'd'], _.hasOwnProperty, {a: 1, b: 2, c: 3, d: 4}), 'context works');
-    assert.ok(!_.every(['a', 'b', 'c', 'd', 'f'], _.hasOwnProperty, {a: 1, b: 2, c: 3, d: 4}), 'context works');
+    assert.notOk(_.every(['a', 'b', 'c', 'd', 'f'], _.hasOwnProperty, {a: 1, b: 2, c: 3, d: 4}), 'context works');
   });
 
   QUnit.test('all', function(assert) {
@@ -374,29 +374,29 @@
   });
 
   QUnit.test('some', function(assert) {
-    assert.ok(!_.some([]), 'the empty set');
-    assert.ok(!_.some([false, false, false]), 'all false values');
+    assert.notOk(_.some([]), 'the empty set');
+    assert.notOk(_.some([false, false, false]), 'all false values');
     assert.ok(_.some([false, false, true]), 'one true value');
     assert.ok(_.some([null, 0, 'yes', false]), 'a string');
-    assert.ok(!_.some([null, 0, '', false]), 'falsy values');
-    assert.ok(!_.some([1, 11, 29], function(num){ return num % 2 === 0; }), 'all odd numbers');
+    assert.notOk(_.some([null, 0, '', false]), 'falsy values');
+    assert.notOk(_.some([1, 11, 29], function(num){ return num % 2 === 0; }), 'all odd numbers');
     assert.ok(_.some([1, 10, 29], function(num){ return num % 2 === 0; }), 'an even number');
     assert.strictEqual(_.some([1], _.identity), true, 'cast to boolean - true');
     assert.strictEqual(_.some([0], _.identity), false, 'cast to boolean - false');
     assert.ok(_.some([false, false, true]));
 
     var list = [{a: 1, b: 2}, {a: 2, b: 2}, {a: 1, b: 3}, {a: 1, b: 4}];
-    assert.ok(!_.some(list, {a: 5, b: 2}), 'Can be called with object');
+    assert.notOk(_.some(list, {a: 5, b: 2}), 'Can be called with object');
     assert.ok(_.some(list, 'a'), 'String mapped to object property');
 
     list = [{a: 1, b: 2}, {a: 2, b: 2, c: true}];
     assert.ok(_.some(list, {b: 2}), 'Can be called with object');
-    assert.ok(!_.some(list, 'd'), 'String mapped to object property');
+    assert.notOk(_.some(list, 'd'), 'String mapped to object property');
 
     assert.ok(_.some({a: '1', b: '2', c: '3', d: '4', e: 6}, _.isNumber), 'takes objects');
-    assert.ok(!_.some({a: 1, b: 2, c: 3, d: 4}, _.isObject), 'takes objects');
+    assert.notOk(_.some({a: 1, b: 2, c: 3, d: 4}, _.isObject), 'takes objects');
     assert.ok(_.some(['a', 'b', 'c', 'd'], _.hasOwnProperty, {a: 1, b: 2, c: 3, d: 4}), 'context works');
-    assert.ok(!_.some(['x', 'y', 'z'], _.hasOwnProperty, {a: 1, b: 2, c: 3, d: 4}), 'context works');
+    assert.notOk(_.some(['x', 'y', 'z'], _.hasOwnProperty, {a: 1, b: 2, c: 3, d: 4}), 'context works');
   });
 
   QUnit.test('any', function(assert) {
@@ -408,7 +408,7 @@
       assert.strictEqual(_.includes(val, 'hasOwnProperty'), false);
     });
     assert.strictEqual(_.includes([1, 2, 3], 2), true, 'two is in the array');
-    assert.ok(!_.includes([1, 3, 9], 2), 'two is not in the array');
+    assert.notOk(_.includes([1, 3, 9], 2), 'two is not in the array');
 
     assert.strictEqual(_.includes([5, 4, 3, 2, 1], 5, true), true, 'doesn\'t delegate to binary search');
 
@@ -797,7 +797,7 @@
   });
 
   QUnit.test('toArray', function(assert) {
-    assert.ok(!_.isArray(arguments), 'arguments object is not an array');
+    assert.notOk(_.isArray(arguments), 'arguments object is not an array');
     assert.ok(_.isArray(_.toArray(arguments)), 'arguments object converted into array');
     var a = [1, 2, 3];
     assert.notStrictEqual(_.toArray(a), a, 'array is cloned');
@@ -882,7 +882,7 @@
       assert.deepEqual(_.map(elementChildren, 'id'), ['id1', 'id2']);
       assert.deepEqual(_.map(parent.childNodes, 'nodeType'), [1, 3, 1]);
 
-      assert.ok(!_.every(parent.childNodes, _.isElement));
+      assert.notOk(_.every(parent.childNodes, _.isElement));
       assert.ok(_.some(parent.childNodes, _.isElement));
 
       function compareNode(node) {

--- a/test/cross-document.js
+++ b/test/cross-document.js
@@ -35,7 +35,7 @@
 
   QUnit.test('isEqual', function(assert) {
 
-    assert.ok(!_.isEqual(iNumber, 101));
+    assert.notOk(_.isEqual(iNumber, 101));
     assert.ok(_.isEqual(iNumber, 100));
 
     // Objects from another frame.
@@ -46,13 +46,13 @@
   });
 
   QUnit.test('isEmpty', function(assert) {
-    assert.ok(!_([iNumber]).isEmpty(), '[1] is not empty');
-    assert.ok(!_.isEmpty(iArray), '[] is empty');
+    assert.notOk(_([iNumber]).isEmpty(), '[1] is not empty');
+    assert.notOk(_.isEmpty(iArray), '[] is empty');
     assert.ok(_.isEmpty(iObject), '{} is empty');
   });
 
   QUnit.test('isElement', function(assert) {
-    assert.ok(!_.isElement('div'), 'strings are not dom elements');
+    assert.notOk(_.isElement('div'), 'strings are not dom elements');
     assert.ok(_.isElement(document.body), 'the body tag is a DOM element');
     assert.ok(_.isElement(iElement), 'even from another frame');
   });
@@ -113,12 +113,12 @@
   if (typeof ActiveXObject != 'undefined') {
     QUnit.test('IE host objects', function(assert) {
       var xml = new ActiveXObject('Msxml2.DOMDocument.3.0');
-      assert.ok(!_.isNumber(xml));
-      assert.ok(!_.isBoolean(xml));
-      assert.ok(!_.isNaN(xml));
-      assert.ok(!_.isFunction(xml));
-      assert.ok(!_.isNull(xml));
-      assert.ok(!_.isUndefined(xml));
+      assert.notOk(_.isNumber(xml));
+      assert.notOk(_.isBoolean(xml));
+      assert.notOk(_.isNaN(xml));
+      assert.notOk(_.isFunction(xml));
+      assert.notOk(_.isNull(xml));
+      assert.notOk(_.isUndefined(xml));
     });
 
     QUnit.test('#1621 IE 11 compat mode DOM elements are not functions', function(assert) {

--- a/test/functions.js
+++ b/test/functions.js
@@ -180,7 +180,7 @@
     var done = assert.async();
     var delayed = false;
     _.delay(function(){ delayed = true; }, 100);
-    setTimeout(function(){ assert.ok(!delayed, "didn't delay the function quite yet"); }, 50);
+    setTimeout(function(){ assert.notOk(delayed, "didn't delay the function quite yet"); }, 50);
     setTimeout(function(){ assert.ok(delayed, 'delayed the function'); done(); }, 150);
   });
 

--- a/test/objects.js
+++ b/test/objects.js
@@ -123,7 +123,7 @@
     subObj.c = 'd';
     assert.deepEqual(_.extend({}, subObj), {a: 'b', c: 'd'}, 'extend copies all properties from source');
     _.extend(subObj, {});
-    assert.ok(!subObj.hasOwnProperty('a'), "extend does not convert destination object's 'in' properties to 'own' properties");
+    assert.notOk(subObj.hasOwnProperty('a'), "extend does not convert destination object's 'in' properties to 'own' properties");
 
     try {
       result = {};
@@ -205,7 +205,7 @@
       return this[key] === 3 && this === instance;
     }, instance), {c: 3}, 'function is given context');
 
-    assert.ok(!_.has(_.pick({}, 'foo'), 'foo'), 'does not set own property if property not in object');
+    assert.notOk(_.has(_.pick({}, 'foo'), 'foo'), 'does not set own property if property not in object');
     _.pick(data, function(value, key, obj) {
       assert.equal(obj, data, 'passes same object as third parameter of iteratee');
     });
@@ -309,7 +309,7 @@
 
     Child.prototype.foo = 'foo';
     var created = _.create(Child.prototype, new Child);
-    assert.ok(!created.hasOwnProperty('foo'), 'should only add own properties');
+    assert.notOk(created.hasOwnProperty('foo'), 'should only add own properties');
   });
 
   QUnit.test('isEqual', function(assert) {
@@ -326,10 +326,10 @@
     assert.ok(_.isEqual(null, null), '`null` is equal to `null`');
     assert.ok(_.isEqual(), '`undefined` is equal to `undefined`');
 
-    assert.ok(!_.isEqual(0, -0), '`0` is not equal to `-0`');
-    assert.ok(!_.isEqual(-0, 0), 'Commutative equality is implemented for `0` and `-0`');
-    assert.ok(!_.isEqual(null, void 0), '`null` is not equal to `undefined`');
-    assert.ok(!_.isEqual(void 0, null), 'Commutative equality is implemented for `null` and `undefined`');
+    assert.notOk(_.isEqual(0, -0), '`0` is not equal to `-0`');
+    assert.notOk(_.isEqual(-0, 0), 'Commutative equality is implemented for `0` and `-0`');
+    assert.notOk(_.isEqual(null, void 0), '`null` is not equal to `undefined`');
+    assert.notOk(_.isEqual(void 0, null), 'Commutative equality is implemented for `null` and `undefined`');
 
     // String object and primitive comparisons.
     assert.ok(_.isEqual('Curly', 'Curly'), 'Identical string primitives are equal');
@@ -337,76 +337,76 @@
     assert.ok(_.isEqual(new String('Curly'), 'Curly'), 'String primitives and their corresponding object wrappers are equal');
     assert.ok(_.isEqual('Curly', new String('Curly')), 'Commutative equality is implemented for string objects and primitives');
 
-    assert.ok(!_.isEqual('Curly', 'Larry'), 'String primitives with different values are not equal');
-    assert.ok(!_.isEqual(new String('Curly'), new String('Larry')), 'String objects with different primitive values are not equal');
-    assert.ok(!_.isEqual(new String('Curly'), {toString: function(){ return 'Curly'; }}), 'String objects and objects with a custom `toString` method are not equal');
+    assert.notOk(_.isEqual('Curly', 'Larry'), 'String primitives with different values are not equal');
+    assert.notOk(_.isEqual(new String('Curly'), new String('Larry')), 'String objects with different primitive values are not equal');
+    assert.notOk(_.isEqual(new String('Curly'), {toString: function(){ return 'Curly'; }}), 'String objects and objects with a custom `toString` method are not equal');
 
     // Number object and primitive comparisons.
     assert.ok(_.isEqual(75, 75), 'Identical number primitives are equal');
     assert.ok(_.isEqual(new Number(75), new Number(75)), 'Number objects with identical primitive values are equal');
     assert.ok(_.isEqual(75, new Number(75)), 'Number primitives and their corresponding object wrappers are equal');
     assert.ok(_.isEqual(new Number(75), 75), 'Commutative equality is implemented for number objects and primitives');
-    assert.ok(!_.isEqual(new Number(0), -0), '`new Number(0)` and `-0` are not equal');
-    assert.ok(!_.isEqual(0, new Number(-0)), 'Commutative equality is implemented for `new Number(0)` and `-0`');
+    assert.notOk(_.isEqual(new Number(0), -0), '`new Number(0)` and `-0` are not equal');
+    assert.notOk(_.isEqual(0, new Number(-0)), 'Commutative equality is implemented for `new Number(0)` and `-0`');
 
-    assert.ok(!_.isEqual(new Number(75), new Number(63)), 'Number objects with different primitive values are not equal');
-    assert.ok(!_.isEqual(new Number(63), {valueOf: function(){ return 63; }}), 'Number objects and objects with a `valueOf` method are not equal');
+    assert.notOk(_.isEqual(new Number(75), new Number(63)), 'Number objects with different primitive values are not equal');
+    assert.notOk(_.isEqual(new Number(63), {valueOf: function(){ return 63; }}), 'Number objects and objects with a `valueOf` method are not equal');
 
     // Comparisons involving `NaN`.
     assert.ok(_.isEqual(NaN, NaN), '`NaN` is equal to `NaN`');
     assert.ok(_.isEqual(new Number(NaN), NaN), 'Object(`NaN`) is equal to `NaN`');
-    assert.ok(!_.isEqual(61, NaN), 'A number primitive is not equal to `NaN`');
-    assert.ok(!_.isEqual(new Number(79), NaN), 'A number object is not equal to `NaN`');
-    assert.ok(!_.isEqual(Infinity, NaN), '`Infinity` is not equal to `NaN`');
+    assert.notOk(_.isEqual(61, NaN), 'A number primitive is not equal to `NaN`');
+    assert.notOk(_.isEqual(new Number(79), NaN), 'A number object is not equal to `NaN`');
+    assert.notOk(_.isEqual(Infinity, NaN), '`Infinity` is not equal to `NaN`');
 
     // Boolean object and primitive comparisons.
     assert.ok(_.isEqual(true, true), 'Identical boolean primitives are equal');
     assert.ok(_.isEqual(new Boolean, new Boolean), 'Boolean objects with identical primitive values are equal');
     assert.ok(_.isEqual(true, new Boolean(true)), 'Boolean primitives and their corresponding object wrappers are equal');
     assert.ok(_.isEqual(new Boolean(true), true), 'Commutative equality is implemented for booleans');
-    assert.ok(!_.isEqual(new Boolean(true), new Boolean), 'Boolean objects with different primitive values are not equal');
+    assert.notOk(_.isEqual(new Boolean(true), new Boolean), 'Boolean objects with different primitive values are not equal');
 
     // Common type coercions.
-    assert.ok(!_.isEqual(new Boolean(false), true), '`new Boolean(false)` is not equal to `true`');
-    assert.ok(!_.isEqual('75', 75), 'String and number primitives with like values are not equal');
-    assert.ok(!_.isEqual(new Number(63), new String(63)), 'String and number objects with like values are not equal');
-    assert.ok(!_.isEqual(75, '75'), 'Commutative equality is implemented for like string and number values');
-    assert.ok(!_.isEqual(0, ''), 'Number and string primitives with like values are not equal');
-    assert.ok(!_.isEqual(1, true), 'Number and boolean primitives with like values are not equal');
-    assert.ok(!_.isEqual(new Boolean(false), new Number(0)), 'Boolean and number objects with like values are not equal');
-    assert.ok(!_.isEqual(false, new String('')), 'Boolean primitives and string objects with like values are not equal');
-    assert.ok(!_.isEqual(12564504e5, new Date(2009, 9, 25)), 'Dates and their corresponding numeric primitive values are not equal');
+    assert.notOk(_.isEqual(new Boolean(false), true), '`new Boolean(false)` is not equal to `true`');
+    assert.notOk(_.isEqual('75', 75), 'String and number primitives with like values are not equal');
+    assert.notOk(_.isEqual(new Number(63), new String(63)), 'String and number objects with like values are not equal');
+    assert.notOk(_.isEqual(75, '75'), 'Commutative equality is implemented for like string and number values');
+    assert.notOk(_.isEqual(0, ''), 'Number and string primitives with like values are not equal');
+    assert.notOk(_.isEqual(1, true), 'Number and boolean primitives with like values are not equal');
+    assert.notOk(_.isEqual(new Boolean(false), new Number(0)), 'Boolean and number objects with like values are not equal');
+    assert.notOk(_.isEqual(false, new String('')), 'Boolean primitives and string objects with like values are not equal');
+    assert.notOk(_.isEqual(12564504e5, new Date(2009, 9, 25)), 'Dates and their corresponding numeric primitive values are not equal');
 
     // Dates.
     assert.ok(_.isEqual(new Date(2009, 9, 25), new Date(2009, 9, 25)), 'Date objects referencing identical times are equal');
-    assert.ok(!_.isEqual(new Date(2009, 9, 25), new Date(2009, 11, 13)), 'Date objects referencing different times are not equal');
-    assert.ok(!_.isEqual(new Date(2009, 11, 13), {
+    assert.notOk(_.isEqual(new Date(2009, 9, 25), new Date(2009, 11, 13)), 'Date objects referencing different times are not equal');
+    assert.notOk(_.isEqual(new Date(2009, 11, 13), {
       getTime: function(){
         return 12606876e5;
       }
     }), 'Date objects and objects with a `getTime` method are not equal');
-    assert.ok(!_.isEqual(new Date('Curly'), new Date('Curly')), 'Invalid dates are not equal');
+    assert.notOk(_.isEqual(new Date('Curly'), new Date('Curly')), 'Invalid dates are not equal');
 
     // Functions.
-    assert.ok(!_.isEqual(First, Second), 'Different functions with identical bodies and source code representations are not equal');
+    assert.notOk(_.isEqual(First, Second), 'Different functions with identical bodies and source code representations are not equal');
 
     // RegExps.
     assert.ok(_.isEqual(/(?:)/gim, /(?:)/gim), 'RegExps with equivalent patterns and flags are equal');
     assert.ok(_.isEqual(/(?:)/gi, /(?:)/ig), 'Flag order is not significant');
-    assert.ok(!_.isEqual(/(?:)/g, /(?:)/gi), 'RegExps with equivalent patterns and different flags are not equal');
-    assert.ok(!_.isEqual(/Moe/gim, /Curly/gim), 'RegExps with different patterns and equivalent flags are not equal');
-    assert.ok(!_.isEqual(/(?:)/gi, /(?:)/g), 'Commutative equality is implemented for RegExps');
-    assert.ok(!_.isEqual(/Curly/g, {source: 'Larry', global: true, ignoreCase: false, multiline: false}), 'RegExps and RegExp-like objects are not equal');
+    assert.notOk(_.isEqual(/(?:)/g, /(?:)/gi), 'RegExps with equivalent patterns and different flags are not equal');
+    assert.notOk(_.isEqual(/Moe/gim, /Curly/gim), 'RegExps with different patterns and equivalent flags are not equal');
+    assert.notOk(_.isEqual(/(?:)/gi, /(?:)/g), 'Commutative equality is implemented for RegExps');
+    assert.notOk(_.isEqual(/Curly/g, {source: 'Larry', global: true, ignoreCase: false, multiline: false}), 'RegExps and RegExp-like objects are not equal');
 
     // Empty arrays, array-like objects, and object literals.
     assert.ok(_.isEqual({}, {}), 'Empty object literals are equal');
     assert.ok(_.isEqual([], []), 'Empty array literals are equal');
     assert.ok(_.isEqual([{}], [{}]), 'Empty nested arrays and objects are equal');
-    assert.ok(!_.isEqual({length: 0}, []), 'Array-like objects and arrays are not equal.');
-    assert.ok(!_.isEqual([], {length: 0}), 'Commutative equality is implemented for array-like objects');
+    assert.notOk(_.isEqual({length: 0}, []), 'Array-like objects and arrays are not equal.');
+    assert.notOk(_.isEqual([], {length: 0}), 'Commutative equality is implemented for array-like objects');
 
-    assert.ok(!_.isEqual({}, []), 'Object literals and array literals are not equal');
-    assert.ok(!_.isEqual([], {}), 'Commutative equality is implemented for objects and arrays');
+    assert.notOk(_.isEqual({}, []), 'Object literals and array literals are not equal');
+    assert.notOk(_.isEqual([], {}), 'Commutative equality is implemented for objects and arrays');
 
     // Arrays with primitive and object values.
     assert.ok(_.isEqual([1, 'Larry', true], [1, 'Larry', true]), 'Arrays containing identical primitives are equal');
@@ -424,14 +424,14 @@
     // Array elements and properties.
     assert.ok(_.isEqual(a, b), 'Arrays containing equivalent elements and different non-numeric properties are equal');
     a.push('White Rocks');
-    assert.ok(!_.isEqual(a, b), 'Arrays of different lengths are not equal');
+    assert.notOk(_.isEqual(a, b), 'Arrays of different lengths are not equal');
     a.push('East Boulder');
     b.push('Gunbarrel Ranch', 'Teller Farm');
-    assert.ok(!_.isEqual(a, b), 'Arrays of identical lengths containing different elements are not equal');
+    assert.notOk(_.isEqual(a, b), 'Arrays of identical lengths containing different elements are not equal');
 
     // Sparse arrays.
     assert.ok(_.isEqual(Array(3), Array(3)), 'Sparse arrays of identical lengths are equal');
-    assert.ok(!_.isEqual(Array(3), Array(6)), 'Sparse arrays of different lengths are not equal when both are empty');
+    assert.notOk(_.isEqual(Array(3), Array(6)), 'Sparse arrays of different lengths are not equal when both are empty');
 
     var sparse = [];
     sparse[1] = 5;
@@ -440,11 +440,11 @@
     // Simple objects.
     assert.ok(_.isEqual({a: 'Curly', b: 1, c: true}, {a: 'Curly', b: 1, c: true}), 'Objects containing identical primitives are equal');
     assert.ok(_.isEqual({a: /Curly/g, b: new Date(2009, 11, 13)}, {a: /Curly/g, b: new Date(2009, 11, 13)}), 'Objects containing equivalent members are equal');
-    assert.ok(!_.isEqual({a: 63, b: 75}, {a: 61, b: 55}), 'Objects of identical sizes with different values are not equal');
-    assert.ok(!_.isEqual({a: 63, b: 75}, {a: 61, c: 55}), 'Objects of identical sizes with different property names are not equal');
-    assert.ok(!_.isEqual({a: 1, b: 2}, {a: 1}), 'Objects of different sizes are not equal');
-    assert.ok(!_.isEqual({a: 1}, {a: 1, b: 2}), 'Commutative equality is implemented for objects');
-    assert.ok(!_.isEqual({x: 1, y: void 0}, {x: 1, z: 2}), 'Objects with identical keys and different values are not equivalent');
+    assert.notOk(_.isEqual({a: 63, b: 75}, {a: 61, b: 55}), 'Objects of identical sizes with different values are not equal');
+    assert.notOk(_.isEqual({a: 63, b: 75}, {a: 61, c: 55}), 'Objects of identical sizes with different property names are not equal');
+    assert.notOk(_.isEqual({a: 1, b: 2}, {a: 1}), 'Objects of different sizes are not equal');
+    assert.notOk(_.isEqual({a: 1}, {a: 1, b: 2}), 'Commutative equality is implemented for objects');
+    assert.notOk(_.isEqual({x: 1, y: void 0}, {x: 1, z: 2}), 'Objects with identical keys and different values are not equivalent');
 
     // `A` contains nested objects and arrays.
     a = {
@@ -479,9 +479,9 @@
 
     // Instances.
     assert.ok(_.isEqual(new First, new First), 'Object instances are equal');
-    assert.ok(!_.isEqual(new First, new Second), 'Objects with different constructors and identical own properties are not equal');
-    assert.ok(!_.isEqual({value: 1}, new First), 'Object instances and objects sharing equivalent properties are not equal');
-    assert.ok(!_.isEqual({value: 2}, new Second), 'The prototype chain of objects should not be examined');
+    assert.notOk(_.isEqual(new First, new Second), 'Objects with different constructors and identical own properties are not equal');
+    assert.notOk(_.isEqual({value: 1}, new First), 'Object instances and objects sharing equivalent properties are not equal');
+    assert.notOk(_.isEqual({value: 2}, new Second), 'The prototype chain of objects should not be examined');
 
     // Circular Arrays.
     (a = []).push(a);
@@ -492,13 +492,13 @@
     assert.ok(_.isEqual(a, b), 'Arrays containing circular references and equivalent properties are equal');
     a.push('Shemp');
     b.push('Curly');
-    assert.ok(!_.isEqual(a, b), 'Arrays containing circular references and different properties are not equal');
+    assert.notOk(_.isEqual(a, b), 'Arrays containing circular references and different properties are not equal');
 
     // More circular arrays #767.
     a = ['everything is checked but', 'this', 'is not'];
     a[1] = a;
     b = ['everything is checked but', ['this', 'array'], 'is not'];
-    assert.ok(!_.isEqual(a, b), 'Comparison of circular references with non-circular references are not equal');
+    assert.notOk(_.isEqual(a, b), 'Comparison of circular references with non-circular references are not equal');
 
     // Circular Objects.
     a = {abc: null};
@@ -511,13 +511,13 @@
     assert.ok(_.isEqual(a, b), 'Objects containing circular references and equivalent properties are equal');
     a.def = new Number(75);
     b.def = new Number(63);
-    assert.ok(!_.isEqual(a, b), 'Objects containing circular references and different properties are not equal');
+    assert.notOk(_.isEqual(a, b), 'Objects containing circular references and different properties are not equal');
 
     // More circular objects #767.
     a = {everything: 'is checked', but: 'this', is: 'not'};
     a.but = a;
     b = {everything: 'is checked', but: {that: 'object'}, is: 'not'};
-    assert.ok(!_.isEqual(a, b), 'Comparison of circular references with non-circular object references are not equal');
+    assert.notOk(_.isEqual(a, b), 'Comparison of circular references with non-circular object references are not equal');
 
     // Cyclic Structures.
     a = [{abc: null}];
@@ -530,7 +530,7 @@
     assert.ok(_.isEqual(a, b), 'Cyclic structures containing equivalent properties are equal');
     a[0].def = new String('Larry');
     b[0].def = new String('Curly');
-    assert.ok(!_.isEqual(a, b), 'Cyclic structures containing different properties are not equal');
+    assert.notOk(_.isEqual(a, b), 'Cyclic structures containing different properties are not equal');
 
     // Complex Circular References.
     a = {foo: {b: {foo: {c: {foo: null}}}}};
@@ -540,7 +540,7 @@
     assert.ok(_.isEqual(a, b), 'Cyclic structures with nested and identically-named properties are equal');
 
     // Chaining.
-    assert.ok(!_.isEqual(_({x: 1, y: void 0}).chain(), _({x: 1, z: 2}).chain()), 'Chained objects containing different values are not equal');
+    assert.notOk(_.isEqual(_({x: 1, y: void 0}).chain(), _({x: 1, z: 2}).chain()), 'Chained objects containing different values are not equal');
 
     a = _({x: 1, y: 2}).chain();
     b = _({x: 1, y: 2}).chain();
@@ -576,15 +576,15 @@
   });
 
   QUnit.test('isEmpty', function(assert) {
-    assert.ok(!_([1]).isEmpty(), '[1] is not empty');
+    assert.notOk(_([1]).isEmpty(), '[1] is not empty');
     assert.ok(_.isEmpty([]), '[] is empty');
-    assert.ok(!_.isEmpty({one: 1}), '{one: 1} is not empty');
+    assert.notOk(_.isEmpty({one: 1}), '{one: 1} is not empty');
     assert.ok(_.isEmpty({}), '{} is empty');
     assert.ok(_.isEmpty(new RegExp('')), 'objects with prototype properties are empty');
     assert.ok(_.isEmpty(null), 'null is empty');
     assert.ok(_.isEmpty(), 'undefined is empty');
     assert.ok(_.isEmpty(''), 'the empty string is empty');
-    assert.ok(!_.isEmpty('moe'), 'but other strings are not');
+    assert.notOk(_.isEmpty('moe'), 'but other strings are not');
 
     var obj = {one: 1};
     delete obj.one;
@@ -592,27 +592,27 @@
 
     var args = function(){ return arguments; };
     assert.ok(_.isEmpty(args()), 'empty arguments object is empty');
-    assert.ok(!_.isEmpty(args('')), 'non-empty arguments object is not empty');
+    assert.notOk(_.isEmpty(args('')), 'non-empty arguments object is not empty');
 
     // covers collecting non-enumerable properties in IE < 9
     var nonEnumProp = {toString: 5};
-    assert.ok(!_.isEmpty(nonEnumProp), 'non-enumerable property is not empty');
+    assert.notOk(_.isEmpty(nonEnumProp), 'non-enumerable property is not empty');
   });
 
   if (typeof document === 'object') {
     QUnit.test('isElement', function(assert) {
-      assert.ok(!_.isElement('div'), 'strings are not dom elements');
+      assert.notOk(_.isElement('div'), 'strings are not dom elements');
       assert.ok(_.isElement(testElement), 'an element is a DOM element');
     });
   }
 
   QUnit.test('isArguments', function(assert) {
     var args = (function(){ return arguments; }(1, 2, 3));
-    assert.ok(!_.isArguments('string'), 'a string is not an arguments object');
-    assert.ok(!_.isArguments(_.isArguments), 'a function is not an arguments object');
+    assert.notOk(_.isArguments('string'), 'a string is not an arguments object');
+    assert.notOk(_.isArguments(_.isArguments), 'a function is not an arguments object');
     assert.ok(_.isArguments(args), 'but the arguments object is an arguments object');
-    assert.ok(!_.isArguments(_.toArray(args)), 'but not when it\'s converted into an array');
-    assert.ok(!_.isArguments([1, 2, 3]), 'and not vanilla arrays.');
+    assert.notOk(_.isArguments(_.toArray(args)), 'but not when it\'s converted into an array');
+    assert.notOk(_.isArguments([1, 2, 3]), 'and not vanilla arrays.');
   });
 
   QUnit.test('isObject', function(assert) {
@@ -622,24 +622,24 @@
       assert.ok(_.isObject(testElement), 'and DOM element');
     }
     assert.ok(_.isObject(function() {}), 'and functions');
-    assert.ok(!_.isObject(null), 'but not null');
-    assert.ok(!_.isObject(void 0), 'and not undefined');
-    assert.ok(!_.isObject('string'), 'and not string');
-    assert.ok(!_.isObject(12), 'and not number');
-    assert.ok(!_.isObject(true), 'and not boolean');
+    assert.notOk(_.isObject(null), 'but not null');
+    assert.notOk(_.isObject(void 0), 'and not undefined');
+    assert.notOk(_.isObject('string'), 'and not string');
+    assert.notOk(_.isObject(12), 'and not number');
+    assert.notOk(_.isObject(true), 'and not boolean');
     assert.ok(_.isObject(new String('string')), 'but new String()');
   });
 
   QUnit.test('isArray', function(assert) {
-    assert.ok(!_.isArray(void 0), 'undefined vars are not arrays');
-    assert.ok(!_.isArray(arguments), 'the arguments object is not an array');
+    assert.notOk(_.isArray(void 0), 'undefined vars are not arrays');
+    assert.notOk(_.isArray(arguments), 'the arguments object is not an array');
     assert.ok(_.isArray([1, 2, 3]), 'but arrays are');
   });
 
   QUnit.test('isString', function(assert) {
     var obj = new String('I am a string object');
     if (testElement) {
-      assert.ok(!_.isString(testElement), 'an element is not a string');
+      assert.notOk(_.isString(testElement), 'an element is not a string');
     }
     assert.ok(_.isString([1, 2, 3].join(', ')), 'but strings are');
     assert.strictEqual(_.isString('I am a string literal'), true, 'string literals are');
@@ -648,9 +648,9 @@
   });
 
   QUnit.test('isSymbol', function(assert) {
-    assert.ok(!_.isSymbol(0), 'numbers are not symbols');
-    assert.ok(!_.isSymbol(''), 'strings are not symbols');
-    assert.ok(!_.isSymbol(_.isSymbol), 'functions are not symbols');
+    assert.notOk(_.isSymbol(0), 'numbers are not symbols');
+    assert.notOk(_.isSymbol(''), 'strings are not symbols');
+    assert.notOk(_.isSymbol(_.isSymbol), 'functions are not symbols');
     if (typeof Symbol === 'function') {
       assert.ok(_.isSymbol(Symbol()), 'symbols are symbols');
       assert.ok(_.isSymbol(Symbol('description')), 'described symbols are symbols');
@@ -659,43 +659,43 @@
   });
 
   QUnit.test('isNumber', function(assert) {
-    assert.ok(!_.isNumber('string'), 'a string is not a number');
-    assert.ok(!_.isNumber(arguments), 'the arguments object is not a number');
-    assert.ok(!_.isNumber(void 0), 'undefined is not a number');
+    assert.notOk(_.isNumber('string'), 'a string is not a number');
+    assert.notOk(_.isNumber(arguments), 'the arguments object is not a number');
+    assert.notOk(_.isNumber(void 0), 'undefined is not a number');
     assert.ok(_.isNumber(3 * 4 - 7 / 10), 'but numbers are');
     assert.ok(_.isNumber(NaN), 'NaN *is* a number');
     assert.ok(_.isNumber(Infinity), 'Infinity is a number');
-    assert.ok(!_.isNumber('1'), 'numeric strings are not numbers');
+    assert.notOk(_.isNumber('1'), 'numeric strings are not numbers');
   });
 
   QUnit.test('isBoolean', function(assert) {
-    assert.ok(!_.isBoolean(2), 'a number is not a boolean');
-    assert.ok(!_.isBoolean('string'), 'a string is not a boolean');
-    assert.ok(!_.isBoolean('false'), 'the string "false" is not a boolean');
-    assert.ok(!_.isBoolean('true'), 'the string "true" is not a boolean');
-    assert.ok(!_.isBoolean(arguments), 'the arguments object is not a boolean');
-    assert.ok(!_.isBoolean(void 0), 'undefined is not a boolean');
-    assert.ok(!_.isBoolean(NaN), 'NaN is not a boolean');
-    assert.ok(!_.isBoolean(null), 'null is not a boolean');
+    assert.notOk(_.isBoolean(2), 'a number is not a boolean');
+    assert.notOk(_.isBoolean('string'), 'a string is not a boolean');
+    assert.notOk(_.isBoolean('false'), 'the string "false" is not a boolean');
+    assert.notOk(_.isBoolean('true'), 'the string "true" is not a boolean');
+    assert.notOk(_.isBoolean(arguments), 'the arguments object is not a boolean');
+    assert.notOk(_.isBoolean(void 0), 'undefined is not a boolean');
+    assert.notOk(_.isBoolean(NaN), 'NaN is not a boolean');
+    assert.notOk(_.isBoolean(null), 'null is not a boolean');
     assert.ok(_.isBoolean(true), 'but true is');
     assert.ok(_.isBoolean(false), 'and so is false');
   });
 
   QUnit.test('isMap', function(assert) {
-    assert.ok(!_.isMap('string'), 'a string is not a map');
-    assert.ok(!_.isMap(2), 'a number is not a map');
-    assert.ok(!_.isMap({}), 'an object is not a map');
-    assert.ok(!_.isMap(false), 'a boolean is not a map');
-    assert.ok(!_.isMap(void 0), 'undefined is not a map');
-    assert.ok(!_.isMap([1, 2, 3]), 'an array is not a map');
+    assert.notOk(_.isMap('string'), 'a string is not a map');
+    assert.notOk(_.isMap(2), 'a number is not a map');
+    assert.notOk(_.isMap({}), 'an object is not a map');
+    assert.notOk(_.isMap(false), 'a boolean is not a map');
+    assert.notOk(_.isMap(void 0), 'undefined is not a map');
+    assert.notOk(_.isMap([1, 2, 3]), 'an array is not a map');
     if (typeof Set === 'function') {
-      assert.ok(!_.isMap(new Set()), 'a set is not a map');
+      assert.notOk(_.isMap(new Set()), 'a set is not a map');
     }
     if (typeof WeakSet === 'function') {
-      assert.ok(!_.isMap(new WeakSet()), 'a weakset is not a map');
+      assert.notOk(_.isMap(new WeakSet()), 'a weakset is not a map');
     }
     if (typeof WeakMap === 'function') {
-      assert.ok(!_.isMap(new WeakMap()), 'a weakmap is not a map');
+      assert.notOk(_.isMap(new WeakMap()), 'a weakmap is not a map');
     }
     if (typeof Map === 'function') {
       var keyString = 'a string';
@@ -706,20 +706,20 @@
   });
 
   QUnit.test('isWeakMap', function(assert) {
-    assert.ok(!_.isWeakMap('string'), 'a string is not a weakmap');
-    assert.ok(!_.isWeakMap(2), 'a number is not a weakmap');
-    assert.ok(!_.isWeakMap({}), 'an object is not a weakmap');
-    assert.ok(!_.isWeakMap(false), 'a boolean is not a weakmap');
-    assert.ok(!_.isWeakMap(void 0), 'undefined is not a weakmap');
-    assert.ok(!_.isWeakMap([1, 2, 3]), 'an array is not a weakmap');
+    assert.notOk(_.isWeakMap('string'), 'a string is not a weakmap');
+    assert.notOk(_.isWeakMap(2), 'a number is not a weakmap');
+    assert.notOk(_.isWeakMap({}), 'an object is not a weakmap');
+    assert.notOk(_.isWeakMap(false), 'a boolean is not a weakmap');
+    assert.notOk(_.isWeakMap(void 0), 'undefined is not a weakmap');
+    assert.notOk(_.isWeakMap([1, 2, 3]), 'an array is not a weakmap');
     if (typeof Set === 'function') {
-      assert.ok(!_.isWeakMap(new Set()), 'a set is not a weakmap');
+      assert.notOk(_.isWeakMap(new Set()), 'a set is not a weakmap');
     }
     if (typeof WeakSet === 'function') {
-      assert.ok(!_.isWeakMap(new WeakSet()), 'a weakset is not a weakmap');
+      assert.notOk(_.isWeakMap(new WeakSet()), 'a weakset is not a weakmap');
     }
     if (typeof Map === 'function') {
-      assert.ok(!_.isWeakMap(new Map()), 'a map is not a weakmap');
+      assert.notOk(_.isWeakMap(new Map()), 'a map is not a weakmap');
     }
     if (typeof WeakMap === 'function') {
       var keyObj = {}, obj = new WeakMap();
@@ -729,20 +729,20 @@
   });
 
   QUnit.test('isSet', function(assert) {
-    assert.ok(!_.isSet('string'), 'a string is not a set');
-    assert.ok(!_.isSet(2), 'a number is not a set');
-    assert.ok(!_.isSet({}), 'an object is not a set');
-    assert.ok(!_.isSet(false), 'a boolean is not a set');
-    assert.ok(!_.isSet(void 0), 'undefined is not a set');
-    assert.ok(!_.isSet([1, 2, 3]), 'an array is not a set');
+    assert.notOk(_.isSet('string'), 'a string is not a set');
+    assert.notOk(_.isSet(2), 'a number is not a set');
+    assert.notOk(_.isSet({}), 'an object is not a set');
+    assert.notOk(_.isSet(false), 'a boolean is not a set');
+    assert.notOk(_.isSet(void 0), 'undefined is not a set');
+    assert.notOk(_.isSet([1, 2, 3]), 'an array is not a set');
     if (typeof Map === 'function') {
-      assert.ok(!_.isSet(new Map()), 'a map is not a set');
+      assert.notOk(_.isSet(new Map()), 'a map is not a set');
     }
     if (typeof WeakMap === 'function') {
-      assert.ok(!_.isSet(new WeakMap()), 'a weakmap is not a set');
+      assert.notOk(_.isSet(new WeakMap()), 'a weakmap is not a set');
     }
     if (typeof WeakSet === 'function') {
-      assert.ok(!_.isSet(new WeakSet()), 'a weakset is not a set');
+      assert.notOk(_.isSet(new WeakSet()), 'a weakset is not a set');
     }
     if (typeof Set === 'function') {
       var obj = new Set();
@@ -753,20 +753,20 @@
 
   QUnit.test('isWeakSet', function(assert) {
 
-    assert.ok(!_.isWeakSet('string'), 'a string is not a weakset');
-    assert.ok(!_.isWeakSet(2), 'a number is not a weakset');
-    assert.ok(!_.isWeakSet({}), 'an object is not a weakset');
-    assert.ok(!_.isWeakSet(false), 'a boolean is not a weakset');
-    assert.ok(!_.isWeakSet(void 0), 'undefined is not a weakset');
-    assert.ok(!_.isWeakSet([1, 2, 3]), 'an array is not a weakset');
+    assert.notOk(_.isWeakSet('string'), 'a string is not a weakset');
+    assert.notOk(_.isWeakSet(2), 'a number is not a weakset');
+    assert.notOk(_.isWeakSet({}), 'an object is not a weakset');
+    assert.notOk(_.isWeakSet(false), 'a boolean is not a weakset');
+    assert.notOk(_.isWeakSet(void 0), 'undefined is not a weakset');
+    assert.notOk(_.isWeakSet([1, 2, 3]), 'an array is not a weakset');
     if (typeof Map === 'function') {
-      assert.ok(!_.isWeakSet(new Map()), 'a map is not a weakset');
+      assert.notOk(_.isWeakSet(new Map()), 'a map is not a weakset');
     }
     if (typeof WeakMap === 'function') {
-      assert.ok(!_.isWeakSet(new WeakMap()), 'a weakmap is not a weakset');
+      assert.notOk(_.isWeakSet(new WeakMap()), 'a weakmap is not a weakset');
     }
     if (typeof Set === 'function') {
-      assert.ok(!_.isWeakSet(new Set()), 'a set is not a weakset');
+      assert.notOk(_.isWeakSet(new Set()), 'a set is not a weakset');
     }
     if (typeof WeakSet === 'function') {
       var obj = new WeakSet();
@@ -776,19 +776,19 @@
   });
 
   QUnit.test('isFunction', function(assert) {
-    assert.ok(!_.isFunction(void 0), 'undefined vars are not functions');
-    assert.ok(!_.isFunction([1, 2, 3]), 'arrays are not functions');
-    assert.ok(!_.isFunction('moe'), 'strings are not functions');
+    assert.notOk(_.isFunction(void 0), 'undefined vars are not functions');
+    assert.notOk(_.isFunction([1, 2, 3]), 'arrays are not functions');
+    assert.notOk(_.isFunction('moe'), 'strings are not functions');
     assert.ok(_.isFunction(_.isFunction), 'but functions are');
     assert.ok(_.isFunction(function(){}), 'even anonymous ones');
 
     if (testElement) {
-      assert.ok(!_.isFunction(testElement), 'elements are not functions');
+      assert.notOk(_.isFunction(testElement), 'elements are not functions');
     }
 
     var nodelist = typeof document != 'undefined' && document.childNodes;
     if (nodelist) {
-      assert.ok(!_.isFunction(nodelist));
+      assert.notOk(_.isFunction(nodelist));
     }
   });
 
@@ -806,65 +806,65 @@
   }
 
   QUnit.test('isDate', function(assert) {
-    assert.ok(!_.isDate(100), 'numbers are not dates');
-    assert.ok(!_.isDate({}), 'objects are not dates');
+    assert.notOk(_.isDate(100), 'numbers are not dates');
+    assert.notOk(_.isDate({}), 'objects are not dates');
     assert.ok(_.isDate(new Date()), 'but dates are');
   });
 
   QUnit.test('isRegExp', function(assert) {
-    assert.ok(!_.isRegExp(_.identity), 'functions are not RegExps');
+    assert.notOk(_.isRegExp(_.identity), 'functions are not RegExps');
     assert.ok(_.isRegExp(/identity/), 'but RegExps are');
   });
 
   QUnit.test('isFinite', function(assert) {
-    assert.ok(!_.isFinite(void 0), 'undefined is not finite');
-    assert.ok(!_.isFinite(null), 'null is not finite');
-    assert.ok(!_.isFinite(NaN), 'NaN is not finite');
-    assert.ok(!_.isFinite(Infinity), 'Infinity is not finite');
-    assert.ok(!_.isFinite(-Infinity), '-Infinity is not finite');
+    assert.notOk(_.isFinite(void 0), 'undefined is not finite');
+    assert.notOk(_.isFinite(null), 'null is not finite');
+    assert.notOk(_.isFinite(NaN), 'NaN is not finite');
+    assert.notOk(_.isFinite(Infinity), 'Infinity is not finite');
+    assert.notOk(_.isFinite(-Infinity), '-Infinity is not finite');
     assert.ok(_.isFinite('12'), 'Numeric strings are numbers');
-    assert.ok(!_.isFinite('1a'), 'Non numeric strings are not numbers');
-    assert.ok(!_.isFinite(''), 'Empty strings are not numbers');
+    assert.notOk(_.isFinite('1a'), 'Non numeric strings are not numbers');
+    assert.notOk(_.isFinite(''), 'Empty strings are not numbers');
     var obj = new Number(5);
     assert.ok(_.isFinite(obj), 'Number instances can be finite');
     assert.ok(_.isFinite(0), '0 is finite');
     assert.ok(_.isFinite(123), 'Ints are finite');
     assert.ok(_.isFinite(-12.44), 'Floats are finite');
     if (typeof Symbol === 'function') {
-      assert.ok(!_.isFinite(Symbol()), 'symbols are not numbers');
-      assert.ok(!_.isFinite(Symbol('description')), 'described symbols are not numbers');
-      assert.ok(!_.isFinite(Object(Symbol())), 'boxed symbols are not numbers');
+      assert.notOk(_.isFinite(Symbol()), 'symbols are not numbers');
+      assert.notOk(_.isFinite(Symbol('description')), 'described symbols are not numbers');
+      assert.notOk(_.isFinite(Object(Symbol())), 'boxed symbols are not numbers');
     }
   });
 
   QUnit.test('isNaN', function(assert) {
-    assert.ok(!_.isNaN(void 0), 'undefined is not NaN');
-    assert.ok(!_.isNaN(null), 'null is not NaN');
-    assert.ok(!_.isNaN(0), '0 is not NaN');
-    assert.ok(!_.isNaN(new Number(0)), 'wrapped 0 is not NaN');
+    assert.notOk(_.isNaN(void 0), 'undefined is not NaN');
+    assert.notOk(_.isNaN(null), 'null is not NaN');
+    assert.notOk(_.isNaN(0), '0 is not NaN');
+    assert.notOk(_.isNaN(new Number(0)), 'wrapped 0 is not NaN');
     assert.ok(_.isNaN(NaN), 'but NaN is');
     assert.ok(_.isNaN(new Number(NaN)), 'wrapped NaN is still NaN');
   });
 
   QUnit.test('isNull', function(assert) {
-    assert.ok(!_.isNull(void 0), 'undefined is not null');
-    assert.ok(!_.isNull(NaN), 'NaN is not null');
+    assert.notOk(_.isNull(void 0), 'undefined is not null');
+    assert.notOk(_.isNull(NaN), 'NaN is not null');
     assert.ok(_.isNull(null), 'but null is');
   });
 
   QUnit.test('isUndefined', function(assert) {
-    assert.ok(!_.isUndefined(1), 'numbers are defined');
-    assert.ok(!_.isUndefined(null), 'null is defined');
-    assert.ok(!_.isUndefined(false), 'false is defined');
-    assert.ok(!_.isUndefined(NaN), 'NaN is defined');
+    assert.notOk(_.isUndefined(1), 'numbers are defined');
+    assert.notOk(_.isUndefined(null), 'null is defined');
+    assert.notOk(_.isUndefined(false), 'false is defined');
+    assert.notOk(_.isUndefined(NaN), 'NaN is defined');
     assert.ok(_.isUndefined(), 'nothing is undefined');
     assert.ok(_.isUndefined(void 0), 'undefined is undefined');
   });
 
   QUnit.test('isError', function(assert) {
-    assert.ok(!_.isError(1), 'numbers are not Errors');
-    assert.ok(!_.isError(null), 'null is not an Error');
-    assert.ok(!_.isError(Error), 'functions are not Errors');
+    assert.notOk(_.isError(1), 'numbers are not Errors');
+    assert.notOk(_.isError(null), 'null is not an Error');
+    assert.notOk(_.isError(Error), 'functions are not Errors');
     assert.ok(_.isError(new Error()), 'Errors are Errors');
     assert.ok(_.isError(new EvalError()), 'EvalErrors are Errors');
     assert.ok(_.isError(new RangeError()), 'RangeErrors are Errors');
@@ -893,13 +893,13 @@
   QUnit.test('has', function(assert) {
     var obj = {foo: 'bar', func: function(){}};
     assert.ok(_.has(obj, 'foo'), 'has() checks that the object has a property.');
-    assert.ok(!_.has(obj, 'baz'), "has() returns false if the object doesn't have the property.");
+    assert.notOk(_.has(obj, 'baz'), "has() returns false if the object doesn't have the property.");
     assert.ok(_.has(obj, 'func'), 'has() works for functions too.');
     obj.hasOwnProperty = null;
     assert.ok(_.has(obj, 'foo'), 'has() works even when the hasOwnProperty method is deleted.');
     var child = {};
     child.prototype = obj;
-    assert.ok(!_.has(child, 'foo'), 'has() does not check the prototype chain for a property.');
+    assert.notOk(_.has(child, 'foo'), 'has() does not check the prototype chain for a property.');
     assert.strictEqual(_.has(null, 'foo'), false, 'has() returns false for null');
     assert.strictEqual(_.has(void 0, 'foo'), false, 'has() returns false for undefined');
   });

--- a/test/utility.js
+++ b/test/utility.js
@@ -370,9 +370,9 @@
   });
 
   QUnit.test('#547 - _.templateSettings is unchanged by custom settings.', function(assert) {
-    assert.ok(!_.templateSettings.variable);
+    assert.notOk(_.templateSettings.variable);
     _.template('', {}, {variable: 'x'});
-    assert.ok(!_.templateSettings.variable);
+    assert.notOk(_.templateSettings.variable);
   });
 
   QUnit.test('#556 - undefined template variables.', function(assert) {
@@ -397,11 +397,11 @@
     assert.expect(2);
     var count = 0;
     var template = _.template('<%= f() %>');
-    template({f: function(){ assert.ok(!count++); }});
+    template({f: function(){ assert.notOk(count++); }});
 
     var countEscaped = 0;
     var templateEscaped = _.template('<%- f() %>');
-    templateEscaped({f: function(){ assert.ok(!countEscaped++); }});
+    templateEscaped({f: function(){ assert.notOk(countEscaped++); }});
   });
 
   QUnit.test('#746 - _.template settings are not modified.', function(assert) {


### PR DESCRIPTION
In #2389 we upgraded our browser tests to QUnit 1.18.0 which means we can now
use the `assert.notOk()` assertion. Using this gives a less confusing error
message when the assertion fails. Assuming my `shouldBeFalse()` function is
failing:

    assert.ok(!shouldBeFalse());
    => failed, expected argument to be truthy, was: false

    assert.notOk(shouldBeFalse());
    => failed, expected argument to be falsy, was: true