### PR TITLE
Allow deep property matching via array syntax

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -697,7 +697,7 @@
     });
 
     var deepProperty = _.iteratee(['a', 'b']);
-    assert.equal(deepProperty({a: {b: 2}}), 2, 'treats an array as a deep property accessor');
+    assert.strictEqual(deepProperty({a: {b: 2}}), 2, 'treats an array as a deep property accessor');
 
     // Test custom iteratee
     var builtinIteratee = _.iteratee;

--- a/test/functions.js
+++ b/test/functions.js
@@ -696,6 +696,9 @@
       assert.deepEqual(_.toArray(cb(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), _.range(1, 11));
     });
 
+    var deepProperty = _.iteratee(['a', 'b']);
+    assert.equal(deepProperty({a: {b: 2}}), 2, 'treats an array as a deep property accessor');
+
     // Test custom iteratee
     var builtinIteratee = _.iteratee;
     _.iteratee = function(value) {

--- a/test/objects.js
+++ b/test/objects.js
@@ -916,11 +916,15 @@
     assert.strictEqual(_.property('name')(null), void 0, 'should return undefined for null values');
     assert.strictEqual(_.property('name')(void 0), void 0, 'should return undefined for undefined values');
     assert.strictEqual(_.property(null)('foo'), void 0, 'should return undefined for null object');
+    assert.strictEqual(_.property('x')({x: null}), null, 'can fetch null values');
+    assert.strictEqual(_.property('length')(null), void 0, 'does not crash on property access of non-objects');
 
     // Deep property access
     assert.strictEqual(_.property('a')({a: 1}), 1, 'can get a direct property');
     assert.strictEqual(_.property(['a', 'b'])({a: {b: 2}}), 2, 'can get a nested property');
     assert.strictEqual(_.property(['a'])({a: false}), false, 'can fetch falsey values');
+    assert.strictEqual(_.property(['x', 'y'])({x: {y: null}}), null, 'can fetch null values deeply');
+    assert.strictEqual(_.property(['x', 'y'])({x: null}), void 0, 'does not crash on property access of nested non-objects');
   });
 
   QUnit.test('propertyOf', function(assert) {

--- a/test/objects.js
+++ b/test/objects.js
@@ -925,6 +925,7 @@
     assert.strictEqual(_.property(['a'])({a: false}), false, 'can fetch falsey values');
     assert.strictEqual(_.property(['x', 'y'])({x: {y: null}}), null, 'can fetch null values deeply');
     assert.strictEqual(_.property(['x', 'y'])({x: null}), void 0, 'does not crash on property access of nested non-objects');
+    assert.strictEqual(_.property([])({x: 'y'}), void 0, 'returns `undefined` for a path that is an empty array');
   });
 
   QUnit.test('propertyOf', function(assert) {

--- a/test/objects.js
+++ b/test/objects.js
@@ -905,6 +905,9 @@
     assert.notOk(_.has(child, 'foo'), 'does not check the prototype chain for a property.');
     assert.strictEqual(_.has(null, 'foo'), false, 'returns false for null');
     assert.strictEqual(_.has(void 0, 'foo'), false, 'returns false for undefined');
+
+    assert.ok(_.has({a: {b: 'foo'}}, ['a', 'b']), 'can check for nested properties.');
+    assert.notOk(_.has({a: child}, ['a', 'foo']), 'does not check the prototype of nested props.');
   });
 
   QUnit.test('property', function(assert) {
@@ -912,6 +915,12 @@
     assert.strictEqual(_.property('name')(stooge), 'moe', 'should return the property with the given name');
     assert.strictEqual(_.property('name')(null), void 0, 'should return undefined for null values');
     assert.strictEqual(_.property('name')(void 0), void 0, 'should return undefined for undefined values');
+    assert.strictEqual(_.property(null)('foo'), void 0, 'should return undefined for null object');
+
+    // Deep property access
+    assert.strictEqual(_.property('a')({a: 1}), 1, 'can get a direct property');
+    assert.strictEqual(_.property(['a', 'b'])({a: {b: 2}}), 2, 'can get a nested property');
+    assert.strictEqual(_.property(['a'])({a: false}), false, 'can fetch falsey values');
   });
 
   QUnit.test('propertyOf', function(assert) {
@@ -930,8 +939,10 @@
 
     var undefPropertyOf = _.propertyOf(void 0);
     assert.strictEqual(undefPropertyOf('curly'), void 0, 'should return undefined when obj is undefined');
-  });
 
+    var deepPropertyOf = _.propertyOf({curly: {number: 2}});
+    assert.equal(deepPropertyOf(['curly', 'number']), 2, 'can fetch nested properties of obj');
+  });
 
   QUnit.test('isMatch', function(assert) {
     var moe = {name: 'Moe Howard', hair: true};

--- a/test/utility.js
+++ b/test/utility.js
@@ -365,6 +365,20 @@
     assert.strictEqual(_.result({}, [], 'a'), 'a', 'returns the default when prop is empty');
     assert.strictEqual(_.result(obj, [], context), obj, 'uses the object as context when path is empty');
 
+    var nested = {
+      d: function() {
+        return {
+          e: function() {
+            return obj;
+          },
+          f: context
+        };
+      }
+    };
+    assert.strictEqual(_.result(nested, ['d', 'e']), obj, 'can unpack nested function calls');
+    assert.strictEqual(_.result(nested, ['d', 'f']).e(), obj, 'uses parent as context for nested function calls');
+    assert.strictEqual(_.result(nested, ['d', 'x'], context).e(), obj, 'uses last valid child as context for fallback');
+
     if (typeof Symbol !== 'undefined') {
       var x = Symbol('x');
       var symbolObject = {};

--- a/test/utility.js
+++ b/test/utility.js
@@ -336,6 +336,35 @@
     }), obj.a, 'called with context');
   });
 
+  QUnit.test('result can accept an array of properties for deep access', function(assert) {
+    var func = function() { return 'f'; };
+    var context = function() { return this; };
+
+    assert.strictEqual(_.result({a: 1}, 'a'), 1, 'can get a direct property');
+    assert.strictEqual(_.result({a: {b: 2}}, ['a', 'b']), 2, 'can get a nested property');
+    assert.strictEqual(_.result({a: 1}, 'b', 2), 2, 'uses the fallback value when property is missing');
+    assert.strictEqual(_.result({a: 1}, ['b', 'c'], 2), 2, 'uses the fallback value when any property is missing');
+    assert.strictEqual(_.result({a: void 0}, ['a'], 1), 1, 'uses the fallback when value is undefined');
+    assert.strictEqual(_.result({a: false}, ['a'], 'foo'), false, 'can fetch falsey values');
+
+    assert.strictEqual(_.result({a: func}, 'a'), 'f', 'can get a direct method');
+    assert.strictEqual(_.result({a: {b: func}}, ['a', 'b']), 'f', 'can get a nested method');
+    assert.strictEqual(_.result(), void 0, 'returns udefined if obj is not passed');
+    assert.strictEqual(_.result(void 1, 'a', 2), 2, 'returns default if obj is not passed');
+    assert.strictEqual(_.result(void 1, 'a', func), 'f', 'executes default if obj is not passed');
+    assert.strictEqual(_.result({}, void 0, 2), 2, 'returns default if prop is not passed');
+    assert.strictEqual(_.result({}, void 0, func), 'f', 'executes default if prop is not passed');
+
+    var childObj = {c: context};
+    var obj = {a: context, b: childObj};
+    assert.strictEqual(_.result(obj, 'a'), obj, 'uses the parent object as context');
+    assert.strictEqual(_.result(obj, 'e', context), obj, 'uses the object as context when executing the fallback');
+    assert.strictEqual(_.result(obj, ['a', 'x'], context), obj, 'uses the object as context when executing the fallback');
+    assert.strictEqual(_.result(obj, ['b', 'c']), childObj, 'uses the parent as context when accessing deep methods');
+
+    assert.strictEqual(_.result({}, [], 'a'), 'a', 'returns the default when prop is empty');
+  });
+
   QUnit.test('_.templateSettings.variable', function(assert) {
     var s = '<%=data.x%>';
     var data = {x: 'x'};

--- a/test/utility.js
+++ b/test/utility.js
@@ -363,6 +363,7 @@
     assert.strictEqual(_.result(obj, ['b', 'c']), childObj, 'uses the parent as context when accessing deep methods');
 
     assert.strictEqual(_.result({}, [], 'a'), 'a', 'returns the default when prop is empty');
+    assert.strictEqual(_.result(obj, [], context), obj, 'uses the object as context when path is empty');
 
     if (typeof Symbol !== 'undefined') {
       var x = Symbol('x');

--- a/test/utility.js
+++ b/test/utility.js
@@ -363,6 +363,18 @@
     assert.strictEqual(_.result(obj, ['b', 'c']), childObj, 'uses the parent as context when accessing deep methods');
 
     assert.strictEqual(_.result({}, [], 'a'), 'a', 'returns the default when prop is empty');
+
+    if (typeof Symbol !== 'undefined') {
+      var x = Symbol('x');
+      var symbolObject = {};
+      symbolObject[x] = 'foo';
+      assert.strictEqual(_.result(symbolObject, x), 'foo', 'can use symbols as keys');
+
+      var y = Symbol('y');
+      symbolObject[y] = {};
+      symbolObject[y][x] = 'bar';
+      assert.strictEqual(_.result(symbolObject, [y, x]), 'bar', 'can use symbols as keys for deep matching');
+    }
   });
 
   QUnit.test('_.templateSettings.variable', function(assert) {

--- a/underscore.js
+++ b/underscore.js
@@ -1354,7 +1354,7 @@
       }
       obj = obj[key];
     }
-    return true;
+    return !!length;
   };
 
   // Utility Functions
@@ -1391,7 +1391,7 @@
         if (obj == null) return void 0;
         obj = obj[path[i]];
       }
-      return obj;
+      return length ? obj : void 0;
     };
   };
 

--- a/underscore.js
+++ b/underscore.js
@@ -1385,8 +1385,8 @@
     if (!_.isArray(path)) {
       return shallowProperty(path);
     }
-    var length = path.length;
     return function(obj) {
+      var length = path.length;
       for (var i = 0; i < length; i++) {
         if (obj == null) return void 0;
         obj = obj[path[i]];

--- a/underscore.js
+++ b/underscore.js
@@ -1342,16 +1342,17 @@
 
   // Shortcut function for checking if an object has a given property directly
   // on itself (in other words, not on a prototype).
-  _.has = function(object, path) {
+  _.has = function(obj, path) {
     if (!_.isArray(path)) {
-      return object != null && hasOwnProperty.call(object, path);
+      return obj != null && hasOwnProperty.call(obj, path);
     }
-    for (var i = 0, length = path.length; i < length; i++) {
+    var length = path.length;
+    for (var i = 0; i < length; i++) {
       var key = path[i];
-      if (object == null || !hasOwnProperty.call(object, key)) {
+      if (obj == null || !hasOwnProperty.call(obj, key)) {
         return false;
       }
-      object = object[key];
+      obj = obj[key];
     }
     return true;
   };
@@ -1385,12 +1386,12 @@
       return shallowProperty(path);
     }
     var length = path.length;
-    return function(object) {
+    return function(obj) {
       for (var i = 0; i < length; i++) {
-        if (object == null) return void 0;
-        object = object[path[i]];
+        if (obj == null) return void 0;
+        obj = obj[path[i]];
       }
-      return object;
+      return obj;
     };
   };
 
@@ -1463,25 +1464,26 @@
   _.escape = createEscaper(escapeMap);
   _.unescape = createEscaper(unescapeMap);
 
-  // If the value at the named `path` is a function then invoke it with its
-  // parent object as context; otherwise, return it.
-  _.result = function(object, path, fallback) {
+  // Traverses the children of `obj` along `path`. If a child is a function, it
+  // is invoked with its parent as context. Returns the value of the final
+  // child, or `fallback` if any child is undefined.
+  _.result = function(obj, path, fallback) {
     if (!_.isArray(path)) path = [path];
     var length = path.length;
     // If path is `[]`, step through the loop once so `fallback` gets used.
     if (!length) {
       length = 1;
-      object = void 0;
+      obj = void 0;
     }
     for (var i = 0; i < length; i++) {
-      var prop = object == null ? void 0 : object[path[i]];
+      var prop = obj == null ? void 0 : obj[path[i]];
       if (prop === void 0) {
         prop = fallback;
         i = length; // Ensure we don't continue iterating.
       }
-      object = _.isFunction(prop) ? prop.call(object) : prop;
+      obj = _.isFunction(prop) ? prop.call(obj) : prop;
     }
-    return object;
+    return obj;
   };
 
   // Generate a unique integer id (unique within the entire client session).

--- a/underscore.js
+++ b/underscore.js
@@ -1381,17 +1381,21 @@
 
   _.noop = function(){};
 
+  var deepGet = function(obj, path) {
+    var length = path.length;
+    for (var i = 0; i < length; i++) {
+      if (obj == null) return void 0;
+      obj = obj[path[i]];
+    }
+    return length ? obj : void 0;
+  };
+
   _.property = function(path) {
     if (!_.isArray(path)) {
       return shallowProperty(path);
     }
     return function(obj) {
-      var length = path.length;
-      for (var i = 0; i < length; i++) {
-        if (obj == null) return void 0;
-        obj = obj[path[i]];
-      }
-      return length ? obj : void 0;
+      return deepGet(obj, path);
     };
   };
 
@@ -1400,8 +1404,8 @@
     if (obj == null) {
       return function(){};
     }
-    return function(key) {
-      return _.property(key)(obj);
+    return function(path) {
+      return !_.isArray(path) ? obj[path] : deepGet(obj, path);
     };
   };
 

--- a/underscore.js
+++ b/underscore.js
@@ -1474,7 +1474,6 @@
   _.result = function(obj, path, fallback) {
     if (!_.isArray(path)) path = [path];
     var length = path.length;
-    // If path is `[]`, step through the loop once so `fallback` gets used.
     if (!length) {
       return _.isFunction(fallback) ? fallback.call(obj) : fallback;
     }

--- a/underscore.js
+++ b/underscore.js
@@ -1472,8 +1472,7 @@
     var length = path.length;
     // If path is `[]`, step through the loop once so `fallback` gets used.
     if (!length) {
-      length = 1;
-      obj = void 0;
+      return _.isFunction(fallback) ? fallback.call(obj) : fallback;
     }
     for (var i = 0; i < length; i++) {
       var prop = obj == null ? void 0 : obj[path[i]];

--- a/underscore.js
+++ b/underscore.js
@@ -147,10 +147,11 @@
     if (!isArray(path)) path = [path];
     var length = path.length;
     return function(object) {
-      for (var i = 0; object != null && i < length; i++) {
+      for (var i = 0; i < length; i++) {
+        if (object == null) return void 0;
         object = object[path[i]];
       }
-      return object == null ? void 0 : object;
+      return object;
     };
   };
 

--- a/underscore.js
+++ b/underscore.js
@@ -144,7 +144,12 @@
   };
 
   var property = function(path) {
-    if (!isArray(path)) path = [path];
+    if (!isArray(path)) {
+      // Optimized case for shallow property access.
+      return function(obj) {
+        return obj == null ? void 0 : obj[path];
+      };
+    }
     var length = path.length;
     return function(object) {
       for (var i = 0; i < length; i++) {
@@ -1351,7 +1356,9 @@
   // Shortcut function for checking if an object has a given property directly
   // on itself (in other words, not on a prototype).
   _.has = function(object, path) {
-    if (!_.isArray(path)) path = [path];
+    if (!_.isArray(path)) {
+      return object != null && hasOwnProperty.call(object, path);
+    }
     for (var i = 0, length = path.length; i < length; i++) {
       var key = path[i];
       if (object == null || !hasOwnProperty.call(object, key)) {
@@ -1390,6 +1397,9 @@
 
   // Generates a function for a given object that returns a given property.
   _.propertyOf = function(obj) {
+    if (obj == null) {
+      return function(){};
+    }
     return function(key) {
       return property(key)(obj);
     };


### PR DESCRIPTION
Replaces #2486

Inspired by underscore-contrib`'s _.getPath` and lodash's deep property access,
this adds an Array deep property access shorthand to many aspects of
Underscore, including:

* `_.property`
* `_.iteratee` and all methods that depend on it.
* `_.has`
* `_.result` (including deep evaluation)

Possible Concerns
=================

`_.property`
------------

While `_.property` does not get called in any place that would present
a performance concern, `getLength` (which is created by `_.property`) gets used
in many places which _may_ have performance ramifications.

I've placed the `isArray` call in the outer function of `_.property` in an
attempt to reduce complexity inside the generated function. This required
defining `isArray` earlier.

It's possible that this still isn't fast enough, and we should just define
`getLength` manually.

`_.has`
-------

This adds some complexity to `_.has` which underpins many methods. It's
possible that we may want to use a simpler "flat" version of `_.has`
internally.

Further work
============

We may want to expose some additional helper methods:

* `_.get`
* `_.set`
* `_.unset`

Fixes: #2372, an elegant solution to an oft requested feature: (see: #2370,
 #2268, #1169, #1266)