### PR TITLE
Optimization of _.isNaN

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1316,7 +1316,7 @@
 
   // Is the given value `NaN`?
   _.isNaN = function(obj) {
-    return _.isNumber(obj) && isNaN(obj);
+    return isNaN(obj) && _.isNumber(obj);
   };
 
   // Is a given value a boolean?


### PR DESCRIPTION
You might consider optimizing _.isNaN function  by changing the order in which checks are executed.  I run all tests and observed that isNaN(obj) is false for most of cases. By putting isNaN(obj) to be checked first, every time when it is false, the time spent in _.isNumber(obj) is saved. 

By swapping checks, I got the following performance improvements on V8 engine:
Test: isNaN - 38%
Test: indexof with NaN - 46,37% 
Test: last indexof with NaN  - 23% 
Test: includes with NaN - 61,73% 

Even though this is a simple change, it seems to improve performance without affecting the readability of the code.