### PR TITLE
optimization in flatten function

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -505,7 +505,7 @@
     var idx = output.length;
     for (var i = 0, length = getLength(input); i < length; i++) {
       var value = input[i];
-      if (isArrayLike(value) && (_.isArray(value) || _.isArguments(value))) {
+      if ((_.isArray(value) || _.isArguments(value)) && isArrayLike(value)) {
         // Flatten current level of array or arguments object.
         if (shallow) {
           var j = 0, len = value.length;


### PR DESCRIPTION
Similarly as in [https://github.com/jashkenas/underscore/pull/2496](url), I found that  _flatten_ function can be optimized by swapping the order of checks in logical expression in line 500 (the second check is false most of the time). I provide the screenshot with the results for unit tests which performance got improved  (on V8 4.4 engine). Inputs are the same as in unit tests in the repository and performance is tested with Benchmark.js library.
![selection_012](https://cloud.githubusercontent.com/assets/7926726/14528426/958093cc-024f-11e6-885c-d63cf9f7cd61.png)

The code for tests can be download from: https://s3.eu-central-1.amazonaws.com/underscorebenchmark/benchmarks2.zip 

To run the tests, just call 

> node run.js

I am maybe wrong, but can isArrayLike(value) check be omitted here?
