### PR TITLE
Return self after using mixin()

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1573,6 +1573,7 @@
         return chainResult(this, func.apply(_, args));
       };
     });
+    return _;
   };
 
   // Add all of the Underscore functions to the wrapper object.


### PR DESCRIPTION
Will allow user to chain mixin(), and most importantly use mixin() in the dependency section of the file, and only there.

**The Motivation**

I'm currently extending underscore like this:
```
var s = require('underscore.string');
var _ = require('underscore');
    _ = _.mixin(s.exports()) || _; // Ohhh this is nasty
```

But I'd rather use it like this:
```
var s = require('underscore.string');
var _ = require('underscore').mixin(s.exports());
```

Or even:
```
var _ = require('underscore')
        .mixin(require('underscore.string').exports())
        .mixin([another module]);
```