### PR TITLE
Add tests and docs for `_.mixin` chaining

### DIFF
--- a/index.html
+++ b/index.html
@@ -1886,8 +1886,8 @@ _.random(0, 100);
         <br />
         Allows you to extend Underscore with your own utility functions. Pass
         a hash of <tt>{name: function}</tt> definitions to have your functions
-        added to the Underscore object, as well as the OOP wrapper.
-      </p>
+        added to the Underscore object, as well as the OOP wrapper. Returns the
+        Underscore object to facilitate chaining.</p>
       <pre>
 _.mixin({
   capitalize: function(string) {

--- a/test/utility.js
+++ b/test/utility.js
@@ -137,11 +137,12 @@
   });
 
   QUnit.test('mixin', function(assert) {
-    _.mixin({
+    var ret = _.mixin({
       myReverse: function(string) {
         return string.split('').reverse().join('');
       }
     });
+    assert.equal(ret, _, 'returns the _ object to facilitate chaining');
     assert.equal(_.myReverse('panacea'), 'aecanap', 'mixed in a function to _');
     assert.equal(_('champ').myReverse(), 'pmahc', 'mixed in a function to the OOP wrapper');
   });


### PR DESCRIPTION
This change was introduced in #2502 without tests or docs. This commit adds
those two missing pieces.