### PR TITLE
Added isEq to _.isEqual for proper equality checking of 0 and -0 in sets and maps

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -559,12 +559,20 @@
     var other = {a: 1};
     assert.strictEqual(_.isEqual(new Foo, other), false, 'Objects from different constructors are not equal');
 
-
     // Tricky object cases val comparisions
-    assert.equal(_.isEqual([0], [-0]), false);
-    assert.equal(_.isEqual({a: 0}, {a: -0}), false);
-    assert.equal(_.isEqual([NaN], [NaN]), true);
-    assert.equal(_.isEqual({a: NaN}, {a: NaN}), true);
+    assert.equal(_.isEqual([0], [-0]), false, '0 and -0 are not equal as array values');
+    assert.equal(_.isEqual({a: 0}, {a: -0}), false, '0 and -0 are not equal as object values');
+    assert.equal(_.isEqual([NaN], [NaN]), true, 'NaN and NaN are equal as array values');
+    assert.equal(_.isEqual({a: NaN}, {a: NaN}), true, 'NaN and NaN are equal as object values');
+
+    // SameValueZero tests for isEq function used for sets and maps
+    var set0 = new Set().add(0);
+    var setNeg0 = new Set().add(-0);
+    var map0 = new Map().set(0, 0);
+    var mapNeg0 = new Map().set(-0, 0);
+    assert.equal(_.isEqual(set0, setNeg0), true, 'In sets 0 and -0 are equal');
+    assert.equal(_.isEqual(map0, mapNeg0), true, 'In maps keys of 0 and -0 are equal');
+
 
     if (typeof Symbol !== 'undefined') {
       var symbol = Symbol('x');

--- a/test/objects.js
+++ b/test/objects.js
@@ -566,12 +566,16 @@
     assert.equal(_.isEqual({a: NaN}, {a: NaN}), true, 'NaN and NaN are equal as object values');
 
     // SameValueZero tests for isEq function used for sets and maps
-    var set0 = new Set().add(0);
-    var setNeg0 = new Set().add(-0);
-    var map0 = new Map().set(0, 0);
-    var mapNeg0 = new Map().set(-0, 0);
-    assert.equal(_.isEqual(set0, setNeg0), true, 'In sets 0 and -0 are equal');
-    assert.equal(_.isEqual(map0, mapNeg0), true, 'In maps keys of 0 and -0 are equal');
+    if (typeof Set !== 'undefined') {
+      var set0 = new Set().add(0);
+      var setNeg0 = new Set().add(-0);
+      assert.equal(_.isEqual(set0, setNeg0), true, 'In sets 0 and -0 are equal');
+    }
+    if (typeof Map !== 'undefined') {
+      var map0 = new Map().set(0, 0);
+      var mapNeg0 = new Map().set(-0, 0);
+      assert.equal(_.isEqual(map0, mapNeg0), true, 'In maps keys of 0 and -0 are equal');
+    }
 
 
     if (typeof Symbol !== 'undefined') {

--- a/underscore.js
+++ b/underscore.js
@@ -1264,6 +1264,13 @@
     return eq(a, b);
   };
 
+  // Performs a SameValueZero comparison (http://ecma-international.org/ecma-262/6.0/#sec-samevaluezero)
+  // to check for equality between two values.
+  // Differs from _.isEqual() in that 0 and -0 are considered equal by _.eq().
+  _.isEq = function(a, b) {
+    return a === b || (a !== a && b !== b);
+  };
+
   // Is a given array, string, or object empty?
   // An "empty" object has no enumerable own-properties.
   _.isEmpty = function(obj) {


### PR DESCRIPTION
This address #2456 and #2507.
I cancelled my last pull request and moved isEq to be an internal function that is included inside of _.isEqual.  It will call deepEq to compare object values, which will continue to call eq unless it encounter a set or a map, in which case it will call isEq for proper handling of 0 and -0.
