### PR TITLE
default data support for _.template()

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1488,7 +1488,7 @@
   // Underscore templating handles arbitrary delimiters, preserves whitespace,
   // and correctly escapes quotes within interpolated code.
   // NB: `oldSettings` only exists for backwards compatibility.
-  _.template = function(text, settings, oldSettings) {
+  _.template = function(text, settings, oldSettings, defaultData) {
     if (!settings && oldSettings) settings = oldSettings;
     settings = _.defaults({}, settings, _.templateSettings);
 
@@ -1534,9 +1534,18 @@
       throw e;
     }
 
-    var template = function(data) {
-      return render.call(this, data, _);
-    };
+    var template;
+    if(!defaultData) {
+      template = function(data) {
+        return render.call(this, data, _);
+      };
+    } else {
+      template = function(data) {
+        var merged = _.clone(defaultData);
+        _.extend(merged, data);
+        return render.call(this, merged, _);
+      };
+    }
 
     // Provide the compiled source as a convenience for precompilation.
     var argument = settings.variable || 'obj';


### PR DESCRIPTION
I've added default data support for the template() method. It makes it possible to

* add default data
* adding helper functions

Example:

```javascript
var tpl = '<%= greet(name) %>';

var hello = function(name){
  return 'Hello '+name+'!';
};

var hey = function(name){
  return 'Hey '+name+'!';
};

var defaultData = {
  greet: hello,
  name: 'Jack'
};

var settings = _.templateSettings;
var compiled = _.template(tpl,settings,settings,defaultData);
console.log(compiled());
// => "Hello Jack!"
console.log(compiled({name:'Bill'}));
// => "Hello Bill!"
console.log(compiled({greet:hey}));
// => "Hey Jack!"
```