### PR TITLE
Cleanup docs for methods with multiple aliases

### DIFF
--- a/index.html
+++ b/index.html
@@ -499,7 +499,7 @@ _.map([[1, 2], [3, 4]], _.first);
 
       <p id="reduce">
         <b class="header">reduce</b><code>_.reduce(list, iteratee, [memo], [context])</code>
-        <span class="alias">Aliases: <b>inject, foldl</b></span>
+        <span class="alias">Aliases: <b>inject</b>, <b>foldl</b></span>
         <br />
         Also known as <b>inject</b> and <b>foldl</b>, reduce boils down a <b>list</b> of values into a single value.
         <b>Memo</b> is the initial state of the reduction, and each successive step of it should be returned by
@@ -826,7 +826,7 @@ _.partition([0, 1, 2, 3, 4, 5], isOdd);
 
       <p id="first">
         <b class="header">first</b><code>_.first(array, [n])</code>
-        <span class="alias">Alias: <b>head</b>, <b>take</b></span>
+        <span class="alias">Aliases: <b>head</b>, <b>take</b></span>
         <br />
         Returns the first element of an <b>array</b>. Passing <b>n</b> will
         return the first <b>n</b> elements of the array.
@@ -861,7 +861,7 @@ _.last([5, 4, 3, 2, 1]);
 
       <p id="rest">
         <b class="header">rest</b><code>_.rest(array, [index])</code>
-        <span class="alias">Alias: <b>tail, drop</b></span>
+        <span class="alias">Aliases: <b>tail</b>, <b>drop</b></span>
         <br />
         Returns the <b>rest</b> of the elements in an array. Pass an <b>index</b>
         to return the values of the array from that index onward.


### PR DESCRIPTION
Our formatting was a bit inconsistent.