### PR TITLE
check length in _.first and _.last, fix #2495

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -15,6 +15,10 @@
     result = _.map([[1, 2, 3], [1, 2, 3]], _.first);
     assert.deepEqual(result, [1, 1], 'works well with _.map');
     assert.equal(_.first(null), void 0, 'returns undefined when called on null');
+
+    Array.prototype[0] = 'boo';
+    assert.equal(_.first([]), void 0, 'return undefined when called on a empty array');
+    delete Array.prototype[0];
   });
 
   QUnit.test('head', function(assert) {
@@ -66,6 +70,10 @@
     result = _.map([[1, 2, 3], [1, 2, 3]], _.last);
     assert.deepEqual(result, [3, 3], 'works well with _.map');
     assert.equal(_.last(null), void 0, 'returns undefined when called on null');
+
+    var arr = [];
+    arr[-1] = 'boo';
+    assert.equal(_.last(arr), void 0, 'return undefined when called on a empty array');
   });
 
   QUnit.test('compact', function(assert) {

--- a/underscore.js
+++ b/underscore.js
@@ -467,7 +467,7 @@
   // values in the array. Aliased as `head` and `take`. The **guard** check
   // allows it to work with `_.map`.
   _.first = _.head = _.take = function(array, n, guard) {
-    if (array == null) return void 0;
+    if (array == null || array.length < 1) return void 0;
     if (n == null || guard) return array[0];
     return _.initial(array, array.length - n);
   };
@@ -482,7 +482,7 @@
   // Get the last element of an array. Passing **n** will return the last N
   // values in the array.
   _.last = function(array, n, guard) {
-    if (array == null) return void 0;
+    if (array == null || array.length < 1) return void 0;
     if (n == null || guard) return array[array.length - 1];
     return _.rest(array, Math.max(0, array.length - n));
   };


### PR DESCRIPTION
Fix #2495

Now return `undefined` when use `_.first` or `_.last` on empty array.

 ```js
Array.prototype[0] = 'boo';
_.first([]) // undefined

var arr = [];
arr[-1] = 'boo'
_.last(arr); // undefined
```