### PR TITLE
safer _#toString, fix #2498

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1608,7 +1608,7 @@
   _.prototype.valueOf = _.prototype.toJSON = _.prototype.value;
 
   _.prototype.toString = function() {
-    return '' + this._wrapped;
+    return String(this._wrapped);
   };
 
   // AMD registration happens at the end for compatibility with AMD loaders


### PR DESCRIPTION
See #2498
```js
_(Symbol('a')).toString();  // Symbol(a)
```