### PR TITLE
fix _.isNaN errors on symbols

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -844,6 +844,9 @@
     assert.notOk(_.isNaN(new Number(0)), 'wrapped 0 is not NaN');
     assert.ok(_.isNaN(NaN), 'but NaN is');
     assert.ok(_.isNaN(new Number(NaN)), 'wrapped NaN is still NaN');
+    if (typeof Symbol !== 'undefined'){
+      assert.notOk(_.isNaN(Symbol()), 'symbol is not NaN');
+    }
   });
 
   QUnit.test('isNull', function(assert) {

--- a/underscore.js
+++ b/underscore.js
@@ -1320,7 +1320,7 @@
 
   // Is the given value `NaN`?
   _.isNaN = function(obj) {
-    return isNaN(obj) && _.isNumber(obj);
+    return _.isNumber(obj) && isNaN(obj);
   };
 
   // Is a given value a boolean?


### PR DESCRIPTION
fix #2503 

when `obj = Symbol()`

```js
isNaN(obj) && _.isNumber(obj)     // Uncaught TypeError: Cannot convert a Symbol value to a number
_.isNumber(obj) && isNaN(obj)     // false 
```