### PR TITLE
_.sortBy, min, max errors on symbols

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -587,6 +587,11 @@
     assert.deepEqual(_.max([0, 2], function(c){ return c * this.x; }, {x: 1}), 2, 'Iterator context');
     assert.deepEqual(_.max([[1], [2, 3], [-1, 4], [5]], 0), [5], 'Lookup falsy iterator');
     assert.deepEqual(_.max([{0: 1}, {0: 2}, {0: -1}, {a: 1}], 0), {0: 2}, 'Lookup falsy iterator');
+
+    if (typeof Symbol !== 'undefined') {
+      assert.equal(_.min([1, 2, 3, Symbol()]), 1, 'Finds correct min in array starting with num and containing a Symbol');
+      assert.equal(_.min([Symbol(), 1, 2, 3]), 1, 'Finds correct min in array starting with Symbol');
+    }
   });
 
   QUnit.test('min', function(assert) {
@@ -630,6 +635,11 @@
     assert.deepEqual(_.min([0, 2], function(c){ return c * this.x; }, {x: -1}), 2, 'Iterator context');
     assert.deepEqual(_.min([[1], [2, 3], [-1, 4], [5]], 0), [-1, 4], 'Lookup falsy iterator');
     assert.deepEqual(_.min([{0: 1}, {0: 2}, {0: -1}, {a: 1}], 0), {0: -1}, 'Lookup falsy iterator');
+
+    if (typeof Symbol !== 'undefined') {
+      assert.equal(_.min([1, 2, 3, Symbol()]), 1, 'Finds correct min in array starting with num and containing a Symbol');
+      assert.equal(_.min([Symbol(), 1, 2, 3]), 1, 'Finds correct min in array starting with Symbol');
+    }
   });
 
   QUnit.test('sortBy', function(assert) {
@@ -678,6 +688,11 @@
 
     list = ['q', 'w', 'e', 'r', 't', 'y'];
     assert.deepEqual(_.sortBy(list), ['e', 'q', 'r', 't', 'w', 'y'], 'uses _.identity if iterator is not specified');
+
+    if (typeof Symbol !== 'undefined') {
+      var sym = Symbol();
+      assert.deepEqual(_.sortBy([8, 6, sym, 4, 23]), [6, 8, sym, 4, 23], 'sortBy should work even containing a Symbol');
+    }
   });
 
   QUnit.test('groupBy', function(assert) {

--- a/underscore.js
+++ b/underscore.js
@@ -313,7 +313,7 @@
       obj = isArrayLike(obj) ? obj : _.values(obj);
       for (var i = 0, length = obj.length; i < length; i++) {
         value = obj[i];
-        if (value != null && value > result) {
+        if (value != null && !_.isSymbol(value) && value > result) {
           result = value;
         }
       }
@@ -338,7 +338,7 @@
       obj = isArrayLike(obj) ? obj : _.values(obj);
       for (var i = 0, length = obj.length; i < length; i++) {
         value = obj[i];
-        if (value != null && value < result) {
+        if (value != null && !_.isSymbol(value) && value < result) {
           result = value;
         }
       }
@@ -395,7 +395,7 @@
     }).sort(function(left, right) {
       var a = left.criteria;
       var b = right.criteria;
-      if (a !== b) {
+      if (a !== b && !_.isSymbol(a) && !_.isSymbol(b)) {
         if (a > b || a === void 0) return 1;
         if (a < b || b === void 0) return -1;
       }


### PR DESCRIPTION
fix #2501, now

``` js
_.sortBy([4, Symbol()], 3, 2);       // [4, Symbol(), 2, 3], just as sort a array contain object
_.max([Symbol(), 1, 4, 6]);          // 1
_.min([Symbol(), 1, 4, 6]);           // 6
```
