### PR TITLE
Use the irregular id when jumping to `functions`

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,7 +294,7 @@
         <li data-name="pairs">- <a href="#pairs">pairs</a></li>
         <li data-name="invert">- <a href="#invert">invert</a></li>
         <li data-name="create">- <a href="#create">create</a></li>
-        <li data-name="functions" data-aliases="methods">- <a href="#object-functions">functions</a></li>
+        <li data-name="object-functions" data-aliases="methods">- <a href="#object-functions">functions</a></li>
         <li data-name="findKey">- <a href="#findKey">findKey</a></li>
         <li data-name="extend">- <a href="#extend">extend</a></li>
         <li data-name="extendOwn" data-aliases="assign">- <a href="#extendOwn">extendOwn</a></li>


### PR DESCRIPTION
Because the "Functions" section heading already uses `#functions` the
individual method uses an irregular id. I missed this in #2514.