### PR TITLE
Add support for maps in _.pairs method ...Closes #2517

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -82,7 +82,10 @@
     assert.deepEqual(_.pairs({one: 1, two: 2}), [['one', 1], ['two', 2]], 'can convert an object into pairs');
     assert.deepEqual(_.pairs({one: 1, two: 2, length: 3}), [['one', 1], ['two', 2], ['length', 3]], '... even when one of them is "length"');
     if (typeof Map === 'function') {
-      assert.deepEqual(_.pairs(new Map([['one', 1], ['two', 2]])), [['one', 1], ['two', 2]], '... or when object is a Map');
+      var mapObj = new Map();
+      mapObj.set('one', 1);
+      mapObj.set('two', 2);
+      assert.deepEqual(_.pairs(mapObj), [['one', 1], ['two', 2]], '... or when object is a Map');
     }
   });
 

--- a/test/objects.js
+++ b/test/objects.js
@@ -81,6 +81,9 @@
   QUnit.test('pairs', function(assert) {
     assert.deepEqual(_.pairs({one: 1, two: 2}), [['one', 1], ['two', 2]], 'can convert an object into pairs');
     assert.deepEqual(_.pairs({one: 1, two: 2, length: 3}), [['one', 1], ['two', 2], ['length', 3]], '... even when one of them is "length"');
+    if (typeof Map === 'function') {
+      assert.deepEqual(_.pairs(new Map([['one', 1], ['two', 2]])), [['one', 1], ['two', 2]], '... or when object is a Map');
+    }
   });
 
   QUnit.test('invert', function(assert) {

--- a/underscore.js
+++ b/underscore.js
@@ -435,6 +435,15 @@
     if (_.has(result, key)) result[key]++; else result[key] = 1;
   });
 
+  var mapToArray = function(map) {
+    var index = -1;
+    var result = Array(map.size);
+    map.forEach(function(value, key) {
+      result[++index] = [key, value];
+    });
+    return result;
+  };
+
   var reStrSymbol = /[^\ud800-\udfff]|[\ud800-\udbff][\udc00-\udfff]|[\ud800-\udfff]/g;
   // Safely create a real, live array from anything iterable.
   _.toArray = function(obj) {
@@ -1009,21 +1018,12 @@
 
   // Convert an object into a list of `[key, value]` pairs.
   _.pairs = function(obj) {
-    var pairs, i, length;
-    if (_.isMap(obj)) {
-      var entries = obj.entries();
-      length = obj.size;
-      pairs = Array(length);
-      for (i = 0; i < length; i++) {
-        pairs[i] = entries.next().value;
-      }
-    } else {
-      var keys = _.keys(obj);
-      length = keys.length;
-      pairs = Array(length);
-      for (i = 0; i < length; i++) {
-        pairs[i] = [keys[i], obj[keys[i]]];
-      }
+    if (_.isMap(obj)) return mapToArray(obj);
+    var keys = _.keys(obj);
+    var length = keys.length;
+    var pairs = Array(length);
+    for (var i = 0; i < length; i++) {
+      pairs[i] = [keys[i], obj[keys[i]]];
     }
     return pairs;
   };

--- a/underscore.js
+++ b/underscore.js
@@ -1009,12 +1009,21 @@
 
   // Convert an object into a list of `[key, value]` pairs.
   _.pairs = function(obj) {
-    if (_.isMap(obj)) return Array.from(obj.entries());
-    var keys = _.keys(obj);
-    var length = keys.length;
-    var pairs = Array(length);
-    for (var i = 0; i < length; i++) {
-      pairs[i] = [keys[i], obj[keys[i]]];
+    var pairs, i, length;
+    if (_.isMap(obj)) {
+      var entries = obj.entries();
+      length = obj.size;
+      pairs = Array(length);
+      for (i = 0; i < length; i++) {
+        pairs[i] = entries.next().value;
+      }
+    } else {
+      var keys = _.keys(obj);
+      length = keys.length;
+      pairs = Array(length);
+      for (i = 0; i < length; i++) {
+        pairs[i] = [keys[i], obj[keys[i]]];
+      }
     }
     return pairs;
   };

--- a/underscore.js
+++ b/underscore.js
@@ -1009,6 +1009,7 @@
 
   // Convert an object into a list of `[key, value]` pairs.
   _.pairs = function(obj) {
+    if (_.isMap(obj)) return Array.from(obj.entries());
     var keys = _.keys(obj);
     var length = keys.length;
     var pairs = Array(length);


### PR DESCRIPTION
_add support for maps within _.pairs method by returning array of map entries._

I decided to go with a different approach. Returning an array of `obj.entries()` seemed a little bit cleaner than iterating over each entry, and seemed to follow the pattern of type-check -> return in the `_.keys` method. Happy to use a loop though if it is deemed the better option. 
