### PR TITLE
fix symbol toString bug in nodejs 0.12

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1608,7 +1608,7 @@
   _.prototype.valueOf = _.prototype.toJSON = _.prototype.value;
 
   _.prototype.toString = function() {
-    return (this._wrapped).toString();
+    return _.isSymbol(this._wrapped) ? this._wrapped.toString() : String(this._wrapped);
   };
 
   // AMD registration happens at the end for compatibility with AMD loaders

--- a/underscore.js
+++ b/underscore.js
@@ -1608,7 +1608,7 @@
   _.prototype.valueOf = _.prototype.toJSON = _.prototype.value;
 
   _.prototype.toString = function() {
-    return String(this._wrapped);
+    return (this._wrapped).toString();
   };
 
   // AMD registration happens at the end for compatibility with AMD loaders


### PR DESCRIPTION
In nodejs 0.12, `String(Symbol())` got a

```
TypeError: Cannot convert a Symbol value to a string
    at String (native)
    at repl:1:8
    at REPLServer.defaultEval (repl.js:132:27)
    at bound (domain.js:291:14)
    at REPLServer.runBound [as eval] (domain.js:304:12)
    at REPLServer.<anonymous> (repl.js:279:12)
    at REPLServer.emit (events.js:107:17)
    at REPLServer.Interface._onLine (readline.js:214:10)
    at REPLServer.Interface._line (readline.js:553:8)
    at REPLServer.Interface._ttyWrite (readline.js:830:14)
```

This node 0.12 v8 bug is impossible to fix in JS-land, and is fixed in io.js and node v4.0 and later.

`Symbol().toString()` works well
