### PR TITLE
Add support for isSafeInteger

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -864,6 +864,18 @@
     assert.ok(_.isUndefined(void 0), 'undefined is undefined');
   });
 
+  QUnit.test('isSafeInteger', function(assert) {
+    assert.notOk(_.isSafeInteger('1'), 'strings are not safe integers');
+    assert.notOk(_.isSafeInteger(null), 'null is not a safe integer');
+    assert.notOk(_.isSafeInteger(false), 'false is not a safe integer');
+    assert.notOk(_.isSafeInteger(NaN), 'NaN is not a safe integer');
+    assert.notOk(_.isSafeInteger(void 0), 'undefined is not a safe integer');
+    assert.notOk(_.isSafeInteger(10.01), 'floats are not safe integers');
+    assert.notOk(_.isSafeInteger(), 'nothing is not safe integers');
+    assert.ok(_.isSafeInteger(1), 'numbers are safe integers');
+    assert.ok(_.isSafeInteger(-10), 'integers are safe integers');
+  });
+
   QUnit.test('isError', function(assert) {
     assert.notOk(_.isError(1), 'numbers are not Errors');
     assert.notOk(_.isError(null), 'null is not an Error');

--- a/underscore.js
+++ b/underscore.js
@@ -1344,6 +1344,10 @@
     return obj != null && hasOwnProperty.call(obj, key);
   };
 
+  _.isSafeInteger = function(obj) {
+    return _.isNumber(obj) && _.isFinite(obj) && toString.call(parseInt(obj, 10)) === '[object Number]' && Math.floor(obj) === obj;
+  };
+
   // Utility Functions
   // -----------------
 


### PR DESCRIPTION
Include [isSafeInteger](http://www.ecma-international.org/ecma-262/6.0/#sec-number.issafeinteger) as referenced in [issue 2455](https://github.com/jashkenas/underscore/issues/2455) by @jdalton.

The conditions are:
1. If Type(number) is not Number, return false.
2. If number is NaN, +∞, or −∞, return false.
3. Let integer be ToInteger(number).
4. If integer is not equal to number, return false.
5. Otherwise, return true.
