### PR TITLE
Add linspace() to array functions.

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,6 +257,7 @@
         <li data-name="findIndex">- <a href="#findIndex">findIndex</a></li>
         <li data-name="findLastIndex">- <a href="#findLastIndex">findLastIndex</a></li>
         <li data-name="range">- <a href="#range">range</a></li>
+        <li data-name="linspace">- <a href="#linspace">linspace</a></li>
       </ul>
     </div>
 
@@ -1125,6 +1126,20 @@ _.range(0, -10, -1);
 =&gt; [0, -1, -2, -3, -4, -5, -6, -7, -8, -9]
 _.range(0);
 =&gt; []
+</pre>
+
+      <p id="linspace">
+        <b class="header">linspace</b><code>_.linspace([start], stop, [n])</code>
+        <br />
+        A function to create evenly-spaced values between <b>start</b> and
+        <b>stop</b>, inclusive. <b>start</b>, if omitted, defaults to <i>0</i>;
+        <b>n</b> defaults to <i>50</i>.
+      </p>
+      <pre>
+_.linspace(49);
+=&gt; [0, 1, 2, 3, ..., 47, 48, 49]
+_.linspace(-Math.PI, Math.PI);
+=&gt; [-3.141593, -3.013364, -2.885136, ..., 2.885136, 3.013364, 3.141593]
 </pre>
 
       <h2 id="functions">Function (uh, ahem) Functions</h2>

--- a/test/arrays.js
+++ b/test/arrays.js
@@ -545,6 +545,19 @@
     assert.deepEqual(_.range(-3), [0, -1, -2], 'negative range generates descending array');
   });
 
+  QUnit.test('linspace', function(assert) {
+    var zeros = _.linspace(0);
+    var expected = [];
+    for (var i = 0; i < 50; i++) {
+      expected.push(0);
+    }
+    assert.deepEqual(zeros, expected, 'linspace called with 0 generates 50 zeros');
+    assert.deepEqual(_.linspace(1, 5, 5), [1, 2, 3, 4, 5], 'linspace generating the numbers 1 through 5');
+    assert.deepEqual(_.linspace(5, 1, 5), [5, 4, 3, 2, 1], 'linspace generating the numbers 1 through 5 backwards');
+    assert.deepEqual(_.linspace(49), _.range(50), 'linspace generating 0 through 49 given only one arg');
+    assert.deepEqual(_.linspace(1, 50), _.range(1, 51), 'linspace generating 1 through 50 given two args');
+  });
+
   QUnit.test('chunk', function(assert) {
     assert.deepEqual(_.chunk([], 2), [], 'chunk for empty array returns an empty array');
 

--- a/underscore.js
+++ b/underscore.js
@@ -708,6 +708,27 @@
     return range;
   };
 
+  // Generate `n` evenly spaced points between `start` and `stop`.  A port of
+  // MatLab and NumPy's `linspace()` function.
+  _.linspace = function(from, to, n) {
+    if (to == null) {
+      var to = from;
+      var from = 0;
+      var n = 50;
+    }
+    if (n == null) {
+      var n = 50;
+    }
+    var num = Array(n);
+    var stepsize = (to - from) / (n - 1);
+    for (var i = 0; i < n; i++) {
+      num[i] = from + i*stepsize;
+    }
+    // Special case the last element to be exactly `to`.
+    num[n - 1] = to;
+    return num
+  }
+
   // Split an **array** into several arrays containing **count** or less elements
   // of initial array.
   _.chunk = function(array, count) {


### PR DESCRIPTION
This PR adds `linspace()` to the array functions.  It also adds tests and documentation for the function.

`linspace()` is a useful function for generating _n_ evenly-spaced numbers between two values.  It's pretty closely related to `range()`, but with range you're usually more interested in doing stuff with integers.  linspace() is especially useful when you want to generate values for plotting; if I want to plot cos(x) from 0 to 2pi, I can just do 

```
x = _.linspace(0, 2*Math.PI);
y = x.map(Math.cos);
// However you want to plot it; e.g.
Plotly.plot('myDiv', [{x: x, y: y}]);
```

`linspace()` gives a nice way of approaching this use case; and if it turns out you need more or fewer points, you just have to tweak the third parameter of linspace.

### Prior Art

[NumPy](http://docs.scipy.org/doc/numpy-1.10.0/reference/generated/numpy.linspace.html) and [MATLAB](http://www.mathworks.com/help/matlab/ref/linspace.html) both have this function.  Note that they differ on the default value for number of points; I opted to go with 50, like NumPy, but it was an arbitrary decision that I made because I like Python more than MATLAB.

P.S. I added documentation because I read CONTRIBUTING.md after I already added it, but I will rebase this PR to not include it if that works better for you.  I based the docs I added off of the _.range() function.