### PR TITLE
added deep merge functionality

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -171,6 +171,10 @@
     assert.strictEqual(_.collect, _.map, 'is an alias for map');
   });
 
+  QUnit.test('deep Merge', function(assert){
+    assert.deepEqual(_.deepMerge({a: {b: 1, c: 3}}, {a: {b: 2, d: 3}}).a, {b: 2, c: 3, d: 3}, 'deep Merge nexted hash.' );
+  });
+
   QUnit.test('reduce', function(assert) {
     var sum = _.reduce([1, 2, 3], function(memo, num){ return memo + num; }, 0);
     assert.equal(sum, 6, 'can sum up an array');

--- a/test/collections.js
+++ b/test/collections.js
@@ -171,10 +171,6 @@
     assert.strictEqual(_.collect, _.map, 'is an alias for map');
   });
 
-  QUnit.test('deep Merge', function(assert){
-    assert.deepEqual(_.deepMerge({a: {b: 1, c: 3}}, {a: {b: 2, d: 3}}).a, {b: 2, c: 3, d: 3}, 'deep Merge nexted hash.' );
-  });
-
   QUnit.test('reduce', function(assert) {
     var sum = _.reduce([1, 2, 3], function(memo, num){ return memo + num; }, 0);
     assert.equal(sum, 6, 'can sum up an array');

--- a/test/objects.js
+++ b/test/objects.js
@@ -110,7 +110,10 @@
     assert.equal(_.extend({}, {a: 'b'}).a, 'b', 'can extend an object with the attributes of another');
     assert.equal(_.extend({a: 'x'}, {a: 'b'}).a, 'b', 'properties in source override destination');
     assert.equal(_.extend({x: 'x'}, {a: 'b'}).x, 'x', "properties not in source don't get overriden");
+    assert.deepEqual(_.extend({a: {b: 1, c: 3}}, {a: {b: 2, d: 3}}, 'deepMerge').a, {b: 2, c: 3, d: 3}, 'Deep Merge nested hash.');
+
     result = _.extend({x: 'x'}, {a: 'a'}, {b: 'b'});
+
     assert.deepEqual(result, {x: 'x', a: 'a', b: 'b'}, 'can extend from multiple source objects');
     result = _.extend({x: 'x'}, {a: 'a', x: 2}, {a: 'b'});
     assert.deepEqual(result, {x: 2, a: 'b'}, 'extending from multiple source objects last property trumps');

--- a/underscore.js
+++ b/underscore.js
@@ -240,6 +240,19 @@
     return results;
   };
 
+  // merge two object at deep level.
+  _.deepMerge = function(hash1, hash2){
+    var hash = hash1;
+    _.each(hash2, function(value, key){
+      if ( value instanceof Object  && hash[key] instanceof Object) {
+        hash[key] = _.deepMerge(hash[key], value);
+      } else {
+        hash[key] = value;
+      }
+    });
+    return hash;
+  };
+
   // Return all the elements for which a truth test fails.
   _.reject = function(obj, predicate, context) {
     return _.filter(obj, _.negate(cb(predicate)), context);
@@ -359,6 +372,8 @@
   _.shuffle = function(obj) {
     return _.sample(obj, Infinity);
   };
+
+
 
   // Sample **n** random values from a collection using the modern version of the
   // [Fisher-Yates shuffle](http://en.wikipedia.org/wiki/Fisher–Yates_shuffle).

--- a/underscore.js
+++ b/underscore.js
@@ -240,19 +240,6 @@
     return results;
   };
 
-  // merge two object at deep level.
-  _.deepMerge = function(hash1, hash2){
-    var hash = hash1;
-    _.each(hash2, function(value, key){
-      if ( value instanceof Object  && hash[key] instanceof Object) {
-        hash[key] = _.deepMerge(hash[key], value);
-      } else {
-        hash[key] = value;
-      }
-    });
-    return hash;
-  };
-
   // Return all the elements for which a truth test fails.
   _.reject = function(obj, predicate, context) {
     return _.filter(obj, _.negate(cb(predicate)), context);
@@ -1056,6 +1043,12 @@
   // An internal function for creating assigner functions.
   var createAssigner = function(keysFunc, defaults) {
     return function(obj) {
+      var deepMerge = false;
+      arguments = _.reject(arguments, function(x){
+        if (x === 'deepMerge') deepMerge = true ;
+        return (x === 'deepMerge');
+      });
+
       var length = arguments.length;
       if (defaults) obj = Object(obj);
       if (length < 2 || obj == null) return obj;
@@ -1065,7 +1058,11 @@
             l = keys.length;
         for (var i = 0; i < l; i++) {
           var key = keys[i];
-          if (!defaults || obj[key] === void 0) obj[key] = source[key];
+          if (deepMerge && obj[key] instanceof Object && source[key] instanceof Object){
+            obj[key] = _.extend(obj[key], source[key], 'deepMerge');
+          } else if (!defaults || obj[key] === void 0){
+            obj[key] = source[key];
+          }
         }
       }
       return obj;


### PR DESCRIPTION
I have given deep merger functionality,
_.deepMerge({a: {b: 1}, c: [1, 2]} {a: {c: 2}, c: [3, 1]})
=> {a: {b: 1 c: 2}, c: [3, 1]} 