### PR TITLE
Remove Simplified Chinese link

### DIFF
--- a/index.html
+++ b/index.html
@@ -2189,11 +2189,6 @@ _.chain([1, 2, 3]).reverse().value();
       <h2 id="links">Links &amp; Suggested Reading</h2>
 
       <p>
-        The Underscore documentation is also available in
-        <a href="http://learning.github.io/underscore/">Simplified Chinese</a>.
-      </p>
-
-      <p>
         <a href="http://mirven.github.io/underscore.lua/">Underscore.lua</a>,
         a Lua port of the functions that are applicable in both languages.
         Includes OOP-wrapping and chaining.


### PR DESCRIPTION
It's not available now.

It redirect to <http://learningcn.com/legacy> and is full of ads.