### PR TITLE
improve `isElement` for precision of DOM element's type

### DIFF
--- a/index.html
+++ b/index.html
@@ -1658,11 +1658,17 @@ _.isEmpty({});
       <p id="isElement">
         <b class="header">isElement</b><code>_.isElement(object)</code>
         <br />
-        Returns <i>true</i> if <b>object</b> is a DOM element.
+        Returns <i>true</i> if <b>object</b> is a DOM element. A precision can be done
+        with a given element type's name (egg: <i>HTMLLink, HTMLDiv, SVGEllipse, ...</i>).
       </p>
       <pre>
 _.isElement(jQuery('body')[0]);
 =&gt; true
+_.isElement(document.createElement('a'), 'html-anchor');
+=&gt; true
+// given type precision can also be in camelCase following DOM naming's spec.
+_.isElement(document.body, 'HTMLScript');
+=&gt; false
 </pre>
 
       <p id="isArray">

--- a/underscore.js
+++ b/underscore.js
@@ -1273,7 +1273,16 @@
   };
 
   // Is a given value a DOM element?
-  _.isElement = function(obj) {
+  _.isElement = function(obj, eltName) {
+    if (_.isString(eltName)) {
+      if (_.indexOf(eltName, '-') !== -1) {
+        // nomalize the element's name according to the DOM's naming spec (egg: 'HTMLHeadElement')
+        eltName = eltName.toUpperCase().split('-') ;
+        eltName = eltName[0] + (eltName[1][0] ? eltName[1][0] + eltName[1].substring(1).toLowerCase() : '');
+      }
+      var eltnUp = eltName.toUpperCase();
+      return _.indexOf(['HTML', 'SVG'], eltnUp) !== -1 ? obj instanceof root[eltnUp + 'Element'] : toString.call(obj) === '[object ' + eltName + 'Element]' ;
+    }
     return !!(obj && obj.nodeType === 1);
   };
 


### PR DESCRIPTION
A precision can be now done with a given element type's name (egg: *HTMLLink, HTMLDiv, SVGEllipse, ...*).

*examples* 
```js
_.isElement(jQuery('body')[0]);
//=> true
_.isElement(document.createElement('a'), 'html-anchor');
//=> true
// given type precision can also be in camelCase following DOM naming's spec.
_.isElement(document.body, 'HTMLScript');
//=> false
```