### PR TITLE
Improve readability of underscorejs.org TOC

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,12 +46,11 @@
         font-weight: normal;
       }
     ul.toc_section {
-      font-size: 11px;
-      line-height: 14px;
+      font-size: 14px;
+      line-height: 16px;
       margin: 5px 0 0 0;
       padding-left: 0px;
       list-style-type: none;
-      font-family: Lucida Grande;
     }
       .toc_section li {
         cursor: pointer;


### PR DESCRIPTION
The TOC section has the following CSS:

```
ul.toc_section {
    font-size: 11px;
    line-height: 14px;
    margin: 5px 0 0 0;
    padding-left: 0px;
    list-style-type: none;
    font-family: Lucida Grande;
}
```

Since Lucida Grande is/might be missing on default installs, the result is a tiny serif font being used. It is also superfluous as it is already declared with a proper fall-back, here:

```
.interface {
    font-family: "Lucida Grande", "Lucida Sans Unicode", Helvetica, Arial, sans-serif !important;
}
```

### Example:
![screenshot-underscorejs org 2016-07-14 22-55-55](https://cloud.githubusercontent.com/assets/1453735/16856142/e623aef2-4a18-11e6-94f6-7c463c7fd3b0.png)


Simply removing `font-family` from that block would solve the issue, though I've increased the font-size slightly since 11px is tiny no matter what font is used.
