### PR TITLE
[Documentation] Swap findWhere and where in documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -582,18 +582,6 @@ var evens = _.filter([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
 =&gt; [2, 4, 6]
 </pre>
 
-      <p id="where">
-        <b class="header">where</b><code>_.where(list, properties)</code>
-        <br />
-        Looks through each value in the <b>list</b>, returning an array of all
-        the values that contain all of the key-value pairs listed in <b>properties</b>.
-      </p>
-      <pre>
-_.where(listOfPlays, {author: "Shakespeare", year: 1611});
-=&gt; [{title: "Cymbeline", author: "Shakespeare", year: 1611},
-    {title: "The Tempest", author: "Shakespeare", year: 1611}]
-</pre>
-
       <p id="findWhere">
         <b class="header">findWhere</b><code>_.findWhere(list, properties)</code>
         <br />
@@ -610,6 +598,18 @@ _.findWhere(publicServicePulitzers, {newsroom: "The New York Times"});
   reason: "For its public service in publishing in full so many official reports,
   documents and speeches by European statesmen relating to the progress and
   conduct of the war."}
+</pre>
+
+      <p id="where">
+        <b class="header">where</b><code>_.where(list, properties)</code>
+        <br />
+        Looks through each value in the <b>list</b>, returning an array of all
+        the values that contain all of the key-value pairs listed in <b>properties</b>.
+      </p>
+      <pre>
+_.where(listOfPlays, {author: "Shakespeare", year: 1611});
+=&gt; [{title: "Cymbeline", author: "Shakespeare", year: 1611},
+    {title: "The Tempest", author: "Shakespeare", year: 1611}]
 </pre>
 
       <p id="reject">


### PR DESCRIPTION
I re-ordered findWhere and where in the documentation to make it less confusing

Fixes #1811 