### PR TITLE
Remove no-extra-parens ESLint config rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -40,7 +40,6 @@
     "no-ex-assign": 2,
     "no-extend-native": 2,
     "no-extra-boolean-cast": 2,
-    "no-extra-parens": 1,
     "no-extra-semi": 2,
     "no-fallthrough": 2,
     "no-floating-decimal": 2,


### PR DESCRIPTION
## Overview

The `no-extra-parens` ESLint rule was causing the test suite to throw warnings. But the location of the warning did not look like it had any problematic parens. This is likely a bug with ESLint. Till it is resolved, I think it makes sense to **remove this flag** to clean up the test suite logs. This will also not have any effect on the code anyway, as extra parentheses are ignored by most JS Engines

## Screenshots

<img width="694" alt="screen shot 2016-08-30 at 1 07 02 pm" src="https://cloud.githubusercontent.com/assets/1117182/18080329/b5cc4da4-6eb2-11e6-99ae-3ff63eb8f910.png">

NOTE: The code in question here is [this line](https://github.com/jashkenas/underscore/blob/master/underscore.js#L313)