### PR TITLE
Update _.object and _.pairs docs to show relation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1015,7 +1015,8 @@ _.unzip([["moe", 30, true], ["larry", 40, false], ["curly", 50, false]]);
         <b class="header">object</b><code>_.object(list, [values])</code>
         <br />
         Converts arrays into objects. Pass either a single list of
-        <tt>[key, value]</tt> pairs, or a list of keys, and a list of values.
+        <tt>[key, value]</tt> pairs, or a list of keys, and a list of values. The former
+        usage is invertible through <code>_.pairs</code>.
         If duplicate keys exist, the last value wins.
       </p>
       <pre>
@@ -1424,7 +1425,8 @@ _.mapObject({start: 5, end: 12}, function(val, key) {
       <p id="pairs">
         <b class="header">pairs</b><code>_.pairs(object)</code>
         <br />
-        Convert an object into a list of <tt>[key, value]</tt> pairs.
+        Convert an object into a list of <tt>[key, value]</tt> pairs. Inverse of first
+        usage of <code>_.object</code>. 
       </p>
       <pre>
 _.pairs({one: 1, two: 2, three: 3});

--- a/index.html
+++ b/index.html
@@ -1015,9 +1015,9 @@ _.unzip([["moe", 30, true], ["larry", 40, false], ["curly", 50, false]]);
         <b class="header">object</b><code>_.object(list, [values])</code>
         <br />
         Converts arrays into objects. Pass either a single list of
-        <tt>[key, value]</tt> pairs, or a list of keys, and a list of values. The former
-        usage is invertible through <code>_.pairs</code>.
-        If duplicate keys exist, the last value wins.
+        <tt>[key, value]</tt> pairs, or a list of keys, and a list of values. Passing
+        by pairs is the reverse of <a href="#pairs">pairs</a>. If duplicate keys exist,
+        the last value wins.
       </p>
       <pre>
 _.object(['moe', 'larry', 'curly'], [30, 40, 50]);
@@ -1425,8 +1425,8 @@ _.mapObject({start: 5, end: 12}, function(val, key) {
       <p id="pairs">
         <b class="header">pairs</b><code>_.pairs(object)</code>
         <br />
-        Convert an object into a list of <tt>[key, value]</tt> pairs. Inverse of first
-        usage of <code>_.object</code>. 
+        Convert an object into a list of <tt>[key, value]</tt> pairs. The opposite
+        of <a href="#object">object</a>.
       </p>
       <pre>
 _.pairs({one: 1, two: 2, three: 3});

--- a/underscore.js
+++ b/underscore.js
@@ -612,7 +612,7 @@
 
   // Converts lists into objects. Pass either a single array of `[key, value]`
   // pairs, or two parallel arrays of the same length -- one of keys, and one of
-  // the corresponding values.
+  // the corresponding values. Passing by pairs is the reverse of _.pairs.
   _.object = function(list, values) {
     var result = {};
     for (var i = 0, length = getLength(list); i < length; i++) {
@@ -1009,6 +1009,7 @@
   };
 
   // Convert an object into a list of `[key, value]` pairs.
+  // The opposite of _.object.
   _.pairs = function(obj) {
     var keys = _.keys(obj);
     var length = keys.length;


### PR DESCRIPTION
Long time user, first time contributor. Reading through this well-documented source code, I noticed the link between _.pairs and _.object for the first time. As presented, these 2 related functions are far away from each other (with good reason), so I suggest this highlighting the connection in the annotations. Please let me know if there's a better contribution workflow, if I need to PR first to Underscore-Contrib, etc.