### PR TITLE
Tried to add the ability to generate arithmetic ranges using _.range (i.e. factorials)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,7 @@
     "key-spacing": 1,
     "linebreak-style": 2,
     "max-depth": [1, 4],
-    "max-params": [1, 5],
+    "max-params": [1, 6],
     "new-cap": 2,
     "no-alert": 2,
     "no-caller": 2,

--- a/docs/underscore.html
+++ b/docs/underscore.html
@@ -29,13 +29,13 @@
               </div>
               <pre><code>Underscore.js <span class="hljs-number">1.8</span><span class="hljs-number">.3</span>
 http:<span class="hljs-comment">//underscorejs.org</span>
-(c) <span class="hljs-number">2009</span>-<span class="hljs-number">2015</span> Jeremy Ashkenas, DocumentCloud and Investigative Reporters &amp; Editors
+(c) <span class="hljs-number">2009</span><span class="hljs-number">-2015</span> Jeremy Ashkenas, DocumentCloud and Investigative Reporters &amp; Editors
 Underscore may be freely distributed under the MIT license.
 </code></pre>
             </div>
             
             <div class="content"><div class='highlight'><pre>
-(<span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{</pre></div></div>
+(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{</pre></div></div>
             
         </li>
         
@@ -71,11 +71,15 @@ Underscore may be freely distributed under the MIT license.
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-4">&#182;</a>
               </div>
-              <p>Establish the root object, <code>window</code> in the browser, or <code>exports</code> on the server.</p>
+              <p>Establish the root object, <code>window</code> (<code>self</code>) in the browser, <code>global</code>
+on the server, or <code>this</code> in some virtual machines. We use <code>self</code>
+instead of <code>window</code> for <code>WebWorker</code> support.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> root = <span class="hljs-keyword">this</span>;</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> root = <span class="hljs-keyword">typeof</span> self == <span class="hljs-string">'object'</span> &amp;&amp; self.self === self &amp;&amp; self ||
+            <span class="hljs-keyword">typeof</span> global == <span class="hljs-string">'object'</span> &amp;&amp; global.global === global &amp;&amp; global ||
+            <span class="hljs-keyword">this</span>;</pre></div></div>
             
         </li>
         
@@ -105,7 +109,7 @@ Underscore may be freely distributed under the MIT license.
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> ArrayProto = <span class="hljs-built_in">Array</span>.prototype, ObjProto = <span class="hljs-built_in">Object</span>.prototype, FuncProto = <span class="hljs-built_in">Function</span>.prototype;</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> ArrayProto = <span class="hljs-built_in">Array</span>.prototype, ObjProto = <span class="hljs-built_in">Object</span>.prototype;</pre></div></div>
             
         </li>
         
@@ -121,10 +125,10 @@ Underscore may be freely distributed under the MIT license.
             </div>
             
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span>
-    push             = ArrayProto.push,
-    slice            = ArrayProto.slice,
-    toString         = ObjProto.toString,
-    hasOwnProperty   = ObjProto.hasOwnProperty;</pre></div></div>
+    push = ArrayProto.push,
+    slice = ArrayProto.slice,
+    toString = ObjProto.toString,
+    hasOwnProperty = ObjProto.hasOwnProperty;</pre></div></div>
             
         </li>
         
@@ -141,10 +145,9 @@ are declared here.</p>
             </div>
             
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span>
-    nativeIsArray      = <span class="hljs-built_in">Array</span>.isArray,
-    nativeKeys         = <span class="hljs-built_in">Object</span>.keys,
-    nativeBind         = FuncProto.bind,
-    nativeCreate       = <span class="hljs-built_in">Object</span>.create;</pre></div></div>
+    nativeIsArray = <span class="hljs-built_in">Array</span>.isArray,
+    nativeKeys = <span class="hljs-built_in">Object</span>.keys,
+    nativeCreate = <span class="hljs-built_in">Object</span>.create;</pre></div></div>
             
         </li>
         
@@ -159,7 +162,7 @@ are declared here.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> Ctor = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span></span>{};</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> Ctor = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>)</span>{};</pre></div></div>
             
         </li>
         
@@ -174,7 +177,7 @@ are declared here.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> _ = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> _ = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
     <span class="hljs-keyword">if</span> (obj <span class="hljs-keyword">instanceof</span> _) <span class="hljs-keyword">return</span> obj;
     <span class="hljs-keyword">if</span> (!(<span class="hljs-keyword">this</span> <span class="hljs-keyword">instanceof</span> _)) <span class="hljs-keyword">return</span> <span class="hljs-keyword">new</span> _(obj);
     <span class="hljs-keyword">this</span>._wrapped = obj;
@@ -190,13 +193,15 @@ are declared here.</p>
                 <a class="pilcrow" href="#section-11">&#182;</a>
               </div>
               <p>Export the Underscore object for <strong>Node.js</strong>, with
-backwards-compatibility for the old <code>require()</code> API. If we’re in
-the browser, add <code>_</code> as a global object.</p>
+backwards-compatibility for their old module API. If we’re in
+the browser, add <code>_</code> as a global object.
+(<code>nodeType</code> is checked to ensure that <code>module</code>
+and <code>exports</code> are not HTML elements.)</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">if</span> (<span class="hljs-keyword">typeof</span> exports !== <span class="hljs-string">'undefined'</span>) {
-    <span class="hljs-keyword">if</span> (<span class="hljs-keyword">typeof</span> <span class="hljs-built_in">module</span> !== <span class="hljs-string">'undefined'</span> &amp;&amp; <span class="hljs-built_in">module</span>.exports) {
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">if</span> (<span class="hljs-keyword">typeof</span> exports != <span class="hljs-string">'undefined'</span> &amp;&amp; !exports.nodeType) {
+    <span class="hljs-keyword">if</span> (<span class="hljs-keyword">typeof</span> <span class="hljs-built_in">module</span> != <span class="hljs-string">'undefined'</span> &amp;&amp; !<span class="hljs-built_in">module</span>.nodeType &amp;&amp; <span class="hljs-built_in">module</span>.exports) {
       exports = <span class="hljs-built_in">module</span>.exports = _;
     }
     exports._ = _;
@@ -234,26 +239,12 @@ functions.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> optimizeCb = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(func, context, argCount)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> optimizeCb = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">func, context, argCount</span>) </span>{
     <span class="hljs-keyword">if</span> (context === <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>) <span class="hljs-keyword">return</span> func;
     <span class="hljs-keyword">switch</span> (argCount == <span class="hljs-literal">null</span> ? <span class="hljs-number">3</span> : argCount) {
-      <span class="hljs-keyword">case</span> <span class="hljs-number">1</span>: <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value)</span> </span>{
+      <span class="hljs-keyword">case</span> <span class="hljs-number">1</span>: <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">value</span>) </span>{
         <span class="hljs-keyword">return</span> func.call(context, value);
-      };
-      <span class="hljs-keyword">case</span> <span class="hljs-number">2</span>: <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value, other)</span> </span>{
-        <span class="hljs-keyword">return</span> func.call(context, value, other);
-      };
-      <span class="hljs-keyword">case</span> <span class="hljs-number">3</span>: <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value, index, collection)</span> </span>{
-        <span class="hljs-keyword">return</span> func.call(context, value, index, collection);
-      };
-      <span class="hljs-keyword">case</span> <span class="hljs-number">4</span>: <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(accumulator, value, index, collection)</span> </span>{
-        <span class="hljs-keyword">return</span> func.call(context, accumulator, value, index, collection);
-      };
-    }
-    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">return</span> func.apply(context, <span class="hljs-built_in">arguments</span>);
-    };
-  };</pre></div></div>
+      };</pre></div></div>
             
         </li>
         
@@ -264,20 +255,21 @@ functions.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-14">&#182;</a>
               </div>
-              <p>A mostly-internal function to generate callbacks that can be applied
-to each element in a collection, returning the desired result — either
-identity, an arbitrary callback, a property matcher, or a property accessor.</p>
+              <p>The 2-parameter case has been omitted only because no current consumers
+made use of it.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> cb = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value, context, argCount)</span> </span>{
-    <span class="hljs-keyword">if</span> (value == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> _.identity;
-    <span class="hljs-keyword">if</span> (_.isFunction(value)) <span class="hljs-keyword">return</span> optimizeCb(value, context, argCount);
-    <span class="hljs-keyword">if</span> (_.isObject(value)) <span class="hljs-keyword">return</span> _.matcher(value);
-    <span class="hljs-keyword">return</span> _.property(value);
-  };
-  _.iteratee = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value, context)</span> </span>{
-    <span class="hljs-keyword">return</span> cb(value, context, <span class="hljs-literal">Infinity</span>);
+            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">case</span> <span class="hljs-number">3</span>: <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">value, index, collection</span>) </span>{
+        <span class="hljs-keyword">return</span> func.call(context, value, index, collection);
+      };
+      <span class="hljs-keyword">case</span> <span class="hljs-number">4</span>: <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">accumulator, value, index, collection</span>) </span>{
+        <span class="hljs-keyword">return</span> func.call(context, accumulator, value, index, collection);
+      };
+    }
+    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+      <span class="hljs-keyword">return</span> func.apply(context, <span class="hljs-built_in">arguments</span>);
+    };
   };</pre></div></div>
             
         </li>
@@ -289,25 +281,21 @@ identity, an arbitrary callback, a property matcher, or a property accessor.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-15">&#182;</a>
               </div>
-              <p>An internal function for creating assigner functions.</p>
+              <p>A mostly-internal function to generate callbacks that can be applied
+to each element in a collection, returning the desired result — either
+<code>identity</code>, an arbitrary callback, a property matcher, or a property accessor.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> createAssigner = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(keysFunc, undefinedOnly)</span> </span>{
-    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-      <span class="hljs-keyword">var</span> length = <span class="hljs-built_in">arguments</span>.length;
-      <span class="hljs-keyword">if</span> (length &lt; <span class="hljs-number">2</span> || obj == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> obj;
-      <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> index = <span class="hljs-number">1</span>; index &lt; length; index++) {
-        <span class="hljs-keyword">var</span> source = <span class="hljs-built_in">arguments</span>[index],
-            keys = keysFunc(source),
-            l = keys.length;
-        <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>; i &lt; l; i++) {
-          <span class="hljs-keyword">var</span> key = keys[i];
-          <span class="hljs-keyword">if</span> (!undefinedOnly || obj[key] === <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>) obj[key] = source[key];
-        }
-      }
-      <span class="hljs-keyword">return</span> obj;
-    };
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> cb = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">value, context, argCount</span>) </span>{
+    <span class="hljs-keyword">if</span> (value == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> _.identity;
+    <span class="hljs-keyword">if</span> (_.isFunction(value)) <span class="hljs-keyword">return</span> optimizeCb(value, context, argCount);
+    <span class="hljs-keyword">if</span> (_.isObject(value)) <span class="hljs-keyword">return</span> _.matcher(value);
+    <span class="hljs-keyword">return</span> _.property(value);
+  };
+
+  _.iteratee = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">value, context</span>) </span>{
+    <span class="hljs-keyword">return</span> cb(value, context, <span class="hljs-literal">Infinity</span>);
   };</pre></div></div>
             
         </li>
@@ -319,22 +307,30 @@ identity, an arbitrary callback, a property matcher, or a property accessor.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-16">&#182;</a>
               </div>
-              <p>An internal function for creating a new object that inherits from another.</p>
+              <p>Similar to ES6’s rest param (<a href="http://ariya.ofilabs.com/2013/03/es6-and-rest-parameter.html">http://ariya.ofilabs.com/2013/03/es6-and-rest-parameter.html</a>)
+This accumulates the arguments passed into an array, after a given index.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> baseCreate = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(prototype)</span> </span>{
-    <span class="hljs-keyword">if</span> (!_.isObject(prototype)) <span class="hljs-keyword">return</span> {};
-    <span class="hljs-keyword">if</span> (nativeCreate) <span class="hljs-keyword">return</span> nativeCreate(prototype);
-    Ctor.prototype = prototype;
-    <span class="hljs-keyword">var</span> result = <span class="hljs-keyword">new</span> Ctor;
-    Ctor.prototype = <span class="hljs-literal">null</span>;
-    <span class="hljs-keyword">return</span> result;
-  };
-
-  <span class="hljs-keyword">var</span> property = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(key)</span> </span>{
-    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-      <span class="hljs-keyword">return</span> obj == <span class="hljs-literal">null</span> ? <span class="hljs-keyword">void</span> <span class="hljs-number">0</span> : obj[key];
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> restArgs = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">func, startIndex</span>) </span>{
+    startIndex = startIndex == <span class="hljs-literal">null</span> ? func.length - <span class="hljs-number">1</span> : +startIndex;
+    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+      <span class="hljs-keyword">var</span> length = <span class="hljs-built_in">Math</span>.max(<span class="hljs-built_in">arguments</span>.length - startIndex, <span class="hljs-number">0</span>);
+      <span class="hljs-keyword">var</span> rest = <span class="hljs-built_in">Array</span>(length), index;
+      <span class="hljs-keyword">for</span> (index = <span class="hljs-number">0</span>; index &lt; length; index++) {
+        rest[index] = <span class="hljs-built_in">arguments</span>[index + startIndex];
+      }
+      <span class="hljs-keyword">switch</span> (startIndex) {
+        <span class="hljs-keyword">case</span> <span class="hljs-number">0</span>: <span class="hljs-keyword">return</span> func.call(<span class="hljs-keyword">this</span>, rest);
+        <span class="hljs-keyword">case</span> <span class="hljs-number">1</span>: <span class="hljs-keyword">return</span> func.call(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>[<span class="hljs-number">0</span>], rest);
+        <span class="hljs-keyword">case</span> <span class="hljs-number">2</span>: <span class="hljs-keyword">return</span> func.call(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>[<span class="hljs-number">0</span>], <span class="hljs-built_in">arguments</span>[<span class="hljs-number">1</span>], rest);
+      }
+      <span class="hljs-keyword">var</span> args = <span class="hljs-built_in">Array</span>(startIndex + <span class="hljs-number">1</span>);
+      <span class="hljs-keyword">for</span> (index = <span class="hljs-number">0</span>; index &lt; startIndex; index++) {
+        args[index] = <span class="hljs-built_in">arguments</span>[index];
+      }
+      args[startIndex] = rest;
+      <span class="hljs-keyword">return</span> func.apply(<span class="hljs-keyword">this</span>, args);
     };
   };</pre></div></div>
             
@@ -347,18 +343,23 @@ identity, an arbitrary callback, a property matcher, or a property accessor.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-17">&#182;</a>
               </div>
-              <p>Helper for collection methods to determine whether a collection
-should be iterated as an array or as an object
-Related: <a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tolength">http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tolength</a>
-Avoids a very nasty iOS 8 JIT bug on ARM-64. #2094</p>
+              <p>An internal function for creating a new object that inherits from another.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> MAX_ARRAY_INDEX = <span class="hljs-built_in">Math</span>.pow(<span class="hljs-number">2</span>, <span class="hljs-number">53</span>) - <span class="hljs-number">1</span>;
-  <span class="hljs-keyword">var</span> getLength = property(<span class="hljs-string">'length'</span>);
-  <span class="hljs-keyword">var</span> isArrayLike = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(collection)</span> </span>{
-    <span class="hljs-keyword">var</span> length = getLength(collection);
-    <span class="hljs-keyword">return</span> <span class="hljs-keyword">typeof</span> length == <span class="hljs-string">'number'</span> &amp;&amp; length &gt;= <span class="hljs-number">0</span> &amp;&amp; length &lt;= MAX_ARRAY_INDEX;
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> baseCreate = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">prototype</span>) </span>{
+    <span class="hljs-keyword">if</span> (!_.isObject(prototype)) <span class="hljs-keyword">return</span> {};
+    <span class="hljs-keyword">if</span> (nativeCreate) <span class="hljs-keyword">return</span> nativeCreate(prototype);
+    Ctor.prototype = prototype;
+    <span class="hljs-keyword">var</span> result = <span class="hljs-keyword">new</span> Ctor;
+    Ctor.prototype = <span class="hljs-literal">null</span>;
+    <span class="hljs-keyword">return</span> result;
+  };
+
+  <span class="hljs-keyword">var</span> property = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">key</span>) </span>{
+    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+      <span class="hljs-keyword">return</span> obj == <span class="hljs-literal">null</span> ? <span class="hljs-keyword">void</span> <span class="hljs-number">0</span> : obj[key];
+    };
   };</pre></div></div>
             
         </li>
@@ -370,9 +371,19 @@ Avoids a very nasty iOS 8 JIT bug on ARM-64. #2094</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-18">&#182;</a>
               </div>
-              <h2 id="collection-functions">Collection Functions</h2>
+              <p>Helper for collection methods to determine whether a collection
+should be iterated as an array or as an object.
+Related: <a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tolength">http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tolength</a>
+Avoids a very nasty iOS 8 JIT bug on ARM-64. #2094</p>
 
             </div>
+            
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> MAX_ARRAY_INDEX = <span class="hljs-built_in">Math</span>.pow(<span class="hljs-number">2</span>, <span class="hljs-number">53</span>) - <span class="hljs-number">1</span>;
+  <span class="hljs-keyword">var</span> getLength = property(<span class="hljs-string">'length'</span>);
+  <span class="hljs-keyword">var</span> isArrayLike = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">collection</span>) </span>{
+    <span class="hljs-keyword">var</span> length = getLength(collection);
+    <span class="hljs-keyword">return</span> <span class="hljs-keyword">typeof</span> length == <span class="hljs-string">'number'</span> &amp;&amp; length &gt;= <span class="hljs-number">0</span> &amp;&amp; length &lt;= MAX_ARRAY_INDEX;
+  };</pre></div></div>
             
         </li>
         
@@ -383,7 +394,8 @@ Avoids a very nasty iOS 8 JIT bug on ARM-64. #2094</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-19">&#182;</a>
               </div>
-              
+              <h2 id="collection-functions">Collection Functions</h2>
+
             </div>
             
         </li>
@@ -395,13 +407,25 @@ Avoids a very nasty iOS 8 JIT bug on ARM-64. #2094</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-20">&#182;</a>
               </div>
+              
+            </div>
+            
+        </li>
+        
+        
+        <li id="section-21">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-21">&#182;</a>
+              </div>
               <p>The cornerstone, an <code>each</code> implementation, aka <code>forEach</code>.
 Handles raw objects in addition to array-likes. Treats all
 sparse array-likes as if they were dense.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.each = _.forEach = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, iteratee, context)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.each = _.forEach = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, iteratee, context</span>) </span>{
     iteratee = optimizeCb(iteratee, context);
     <span class="hljs-keyword">var</span> i, length;
     <span class="hljs-keyword">if</span> (isArrayLike(obj)) {
@@ -420,17 +444,17 @@ sparse array-likes as if they were dense.</p>
         </li>
         
         
-        <li id="section-21">
+        <li id="section-22">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-21">&#182;</a>
+                <a class="pilcrow" href="#section-22">&#182;</a>
               </div>
               <p>Return the results of applying the iteratee to each element.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.map = _.collect = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, iteratee, context)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.map = _.collect = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, iteratee, context</span>) </span>{
     iteratee = cb(iteratee, context);
     <span class="hljs-keyword">var</span> keys = !isArrayLike(obj) &amp;&amp; _.keys(obj),
         length = (keys || obj).length,
@@ -445,45 +469,17 @@ sparse array-likes as if they were dense.</p>
         </li>
         
         
-        <li id="section-22">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-22">&#182;</a>
-              </div>
-              <p>Create a reducing function iterating left or right.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">createReduce</span><span class="hljs-params">(dir)</span> </span>{</pre></div></div>
-            
-        </li>
-        
-        
         <li id="section-23">
             <div class="annotation">
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-23">&#182;</a>
               </div>
-              <p>Optimized iterator function as using arguments.length
-in the main function will deoptimize the, see #1991.</p>
+              <p>Create a reducing function iterating left or right.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>    <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">iterator</span><span class="hljs-params">(obj, iteratee, memo, keys, index, length)</span> </span>{
-      <span class="hljs-keyword">for</span> (; index &gt;= <span class="hljs-number">0</span> &amp;&amp; index &lt; length; index += dir) {
-        <span class="hljs-keyword">var</span> currentKey = keys ? keys[index] : index;
-        memo = iteratee(memo, obj[currentKey], currentKey, obj);
-      }
-      <span class="hljs-keyword">return</span> memo;
-    }
-
-    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, iteratee, memo, context)</span> </span>{
-      iteratee = optimizeCb(iteratee, context, <span class="hljs-number">4</span>);
-      <span class="hljs-keyword">var</span> keys = !isArrayLike(obj) &amp;&amp; _.keys(obj),
-          length = (keys || obj).length,
-          index = dir &gt; <span class="hljs-number">0</span> ? <span class="hljs-number">0</span> : length - <span class="hljs-number">1</span>;</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> createReduce = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">dir</span>) </span>{</pre></div></div>
             
         </li>
         
@@ -494,17 +490,31 @@ in the main function will deoptimize the, see #1991.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-24">&#182;</a>
               </div>
-              <p>Determine the initial value if none is provided.</p>
+              <p>Optimized iterator function as using arguments.length
+in the main function will deoptimize the, see #1991.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (<span class="hljs-built_in">arguments</span>.length &lt; <span class="hljs-number">3</span>) {
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">var</span> reducer = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, iteratee, memo, initial</span>) </span>{
+      <span class="hljs-keyword">var</span> keys = !isArrayLike(obj) &amp;&amp; _.keys(obj),
+          length = (keys || obj).length,
+          index = dir &gt; <span class="hljs-number">0</span> ? <span class="hljs-number">0</span> : length - <span class="hljs-number">1</span>;
+      <span class="hljs-keyword">if</span> (!initial) {
         memo = obj[keys ? keys[index] : index];
         index += dir;
       }
-      <span class="hljs-keyword">return</span> iterator(obj, iteratee, memo, keys, index, length);
+      <span class="hljs-keyword">for</span> (; index &gt;= <span class="hljs-number">0</span> &amp;&amp; index &lt; length; index += dir) {
+        <span class="hljs-keyword">var</span> currentKey = keys ? keys[index] : index;
+        memo = iteratee(memo, obj[currentKey], currentKey, obj);
+      }
+      <span class="hljs-keyword">return</span> memo;
     };
-  }</pre></div></div>
+
+    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, iteratee, memo, context</span>) </span>{
+      <span class="hljs-keyword">var</span> initial = <span class="hljs-built_in">arguments</span>.length &gt;= <span class="hljs-number">3</span>;
+      <span class="hljs-keyword">return</span> reducer(obj, optimizeCb(iteratee, context, <span class="hljs-number">4</span>), memo, initial);
+    };
+  };</pre></div></div>
             
         </li>
         
@@ -535,7 +545,7 @@ or <code>foldl</code>.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.reduceRight = _.foldr = createReduce(-<span class="hljs-number">1</span>);</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  _.reduceRight = _.foldr = createReduce(<span class="hljs-number">-1</span>);</pre></div></div>
             
         </li>
         
@@ -550,14 +560,14 @@ or <code>foldl</code>.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.find = _.detect = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, predicate, context)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.find = _.detect = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, predicate, context</span>) </span>{
     <span class="hljs-keyword">var</span> key;
     <span class="hljs-keyword">if</span> (isArrayLike(obj)) {
       key = _.findIndex(obj, predicate, context);
     } <span class="hljs-keyword">else</span> {
       key = _.findKey(obj, predicate, context);
     }
-    <span class="hljs-keyword">if</span> (key !== <span class="hljs-keyword">void</span> <span class="hljs-number">0</span> &amp;&amp; key !== -<span class="hljs-number">1</span>) <span class="hljs-keyword">return</span> obj[key];
+    <span class="hljs-keyword">if</span> (key !== <span class="hljs-keyword">void</span> <span class="hljs-number">0</span> &amp;&amp; key !== <span class="hljs-number">-1</span>) <span class="hljs-keyword">return</span> obj[key];
   };</pre></div></div>
             
         </li>
@@ -574,10 +584,10 @@ Aliased as <code>select</code>.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.filter = _.select = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, predicate, context)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.filter = _.select = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, predicate, context</span>) </span>{
     <span class="hljs-keyword">var</span> results = [];
     predicate = cb(predicate, context);
-    _.each(obj, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value, index, list)</span> </span>{
+    _.each(obj, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">value, index, list</span>) </span>{
       <span class="hljs-keyword">if</span> (predicate(value, index, list)) results.push(value);
     });
     <span class="hljs-keyword">return</span> results;
@@ -596,7 +606,7 @@ Aliased as <code>select</code>.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.reject = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, predicate, context)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.reject = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, predicate, context</span>) </span>{
     <span class="hljs-keyword">return</span> _.filter(obj, _.negate(cb(predicate)), context);
   };</pre></div></div>
             
@@ -614,7 +624,7 @@ Aliased as <code>all</code>.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.every = _.all = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, predicate, context)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.every = _.all = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, predicate, context</span>) </span>{
     predicate = cb(predicate, context);
     <span class="hljs-keyword">var</span> keys = !isArrayLike(obj) &amp;&amp; _.keys(obj),
         length = (keys || obj).length;
@@ -639,7 +649,7 @@ Aliased as <code>any</code>.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.some = _.any = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, predicate, context)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.some = _.any = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, predicate, context</span>) </span>{
     predicate = cb(predicate, context);
     <span class="hljs-keyword">var</span> keys = !isArrayLike(obj) &amp;&amp; _.keys(obj),
         length = (keys || obj).length;
@@ -664,7 +674,7 @@ Aliased as <code>includes</code> and <code>include</code>.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.contains = _.includes = _.include = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, item, fromIndex, guard)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.contains = _.includes = _.include = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, item, fromIndex, guard</span>) </span>{
     <span class="hljs-keyword">if</span> (!isArrayLike(obj)) obj = _.values(obj);
     <span class="hljs-keyword">if</span> (<span class="hljs-keyword">typeof</span> fromIndex != <span class="hljs-string">'number'</span> || guard) fromIndex = <span class="hljs-number">0</span>;
     <span class="hljs-keyword">return</span> _.indexOf(obj, item, fromIndex) &gt;= <span class="hljs-number">0</span>;
@@ -683,14 +693,13 @@ Aliased as <code>includes</code> and <code>include</code>.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.invoke = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, method)</span> </span>{
-    <span class="hljs-keyword">var</span> args = slice.call(<span class="hljs-built_in">arguments</span>, <span class="hljs-number">2</span>);
+            <div class="content"><div class='highlight'><pre>  _.invoke = restArgs(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, method, args</span>) </span>{
     <span class="hljs-keyword">var</span> isFunc = _.isFunction(method);
-    <span class="hljs-keyword">return</span> _.map(obj, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value)</span> </span>{
+    <span class="hljs-keyword">return</span> _.map(obj, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">value</span>) </span>{
       <span class="hljs-keyword">var</span> func = isFunc ? method : value[method];
       <span class="hljs-keyword">return</span> func == <span class="hljs-literal">null</span> ? func : func.apply(value, args);
     });
-  };</pre></div></div>
+  });</pre></div></div>
             
         </li>
         
@@ -705,7 +714,7 @@ Aliased as <code>includes</code> and <code>include</code>.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.pluck = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, key)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.pluck = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, key</span>) </span>{
     <span class="hljs-keyword">return</span> _.map(obj, _.property(key));
   };</pre></div></div>
             
@@ -723,7 +732,7 @@ containing specific <code>key:value</code> pairs.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.where = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, attrs)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.where = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, attrs</span>) </span>{
     <span class="hljs-keyword">return</span> _.filter(obj, _.matcher(attrs));
   };</pre></div></div>
             
@@ -741,7 +750,7 @@ containing specific <code>key:value</code> pairs.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.findWhere = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, attrs)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.findWhere = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, attrs</span>) </span>{
     <span class="hljs-keyword">return</span> _.find(obj, _.matcher(attrs));
   };</pre></div></div>
             
@@ -758,23 +767,23 @@ containing specific <code>key:value</code> pairs.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.max = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, iteratee, context)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.max = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, iteratee, context</span>) </span>{
     <span class="hljs-keyword">var</span> result = -<span class="hljs-literal">Infinity</span>, lastComputed = -<span class="hljs-literal">Infinity</span>,
         value, computed;
-    <span class="hljs-keyword">if</span> (iteratee == <span class="hljs-literal">null</span> &amp;&amp; obj != <span class="hljs-literal">null</span>) {
+    <span class="hljs-keyword">if</span> (iteratee == <span class="hljs-literal">null</span> || (<span class="hljs-keyword">typeof</span> iteratee == <span class="hljs-string">'number'</span> &amp;&amp; <span class="hljs-keyword">typeof</span> obj[<span class="hljs-number">0</span>] != <span class="hljs-string">'object'</span>) &amp;&amp; obj != <span class="hljs-literal">null</span>) {
       obj = isArrayLike(obj) ? obj : _.values(obj);
       <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = obj.length; i &lt; length; i++) {
         value = obj[i];
-        <span class="hljs-keyword">if</span> (value &gt; result) {
+        <span class="hljs-keyword">if</span> (value != <span class="hljs-literal">null</span> &amp;&amp; value &gt; result) {
           result = value;
         }
       }
     } <span class="hljs-keyword">else</span> {
       iteratee = cb(iteratee, context);
-      _.each(obj, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value, index, list)</span> </span>{
-        computed = iteratee(value, index, list);
+      _.each(obj, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">v, index, list</span>) </span>{
+        computed = iteratee(v, index, list);
         <span class="hljs-keyword">if</span> (computed &gt; lastComputed || computed === -<span class="hljs-literal">Infinity</span> &amp;&amp; result === -<span class="hljs-literal">Infinity</span>) {
-          result = value;
+          result = v;
           lastComputed = computed;
         }
       });
@@ -795,23 +804,23 @@ containing specific <code>key:value</code> pairs.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.min = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, iteratee, context)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.min = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, iteratee, context</span>) </span>{
     <span class="hljs-keyword">var</span> result = <span class="hljs-literal">Infinity</span>, lastComputed = <span class="hljs-literal">Infinity</span>,
         value, computed;
-    <span class="hljs-keyword">if</span> (iteratee == <span class="hljs-literal">null</span> &amp;&amp; obj != <span class="hljs-literal">null</span>) {
+    <span class="hljs-keyword">if</span> (iteratee == <span class="hljs-literal">null</span> || (<span class="hljs-keyword">typeof</span> iteratee == <span class="hljs-string">'number'</span> &amp;&amp; <span class="hljs-keyword">typeof</span> obj[<span class="hljs-number">0</span>] != <span class="hljs-string">'object'</span>) &amp;&amp; obj != <span class="hljs-literal">null</span>) {
       obj = isArrayLike(obj) ? obj : _.values(obj);
       <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = obj.length; i &lt; length; i++) {
         value = obj[i];
-        <span class="hljs-keyword">if</span> (value &lt; result) {
+        <span class="hljs-keyword">if</span> (value != <span class="hljs-literal">null</span> &amp;&amp; value &lt; result) {
           result = value;
         }
       }
     } <span class="hljs-keyword">else</span> {
       iteratee = cb(iteratee, context);
-      _.each(obj, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value, index, list)</span> </span>{
-        computed = iteratee(value, index, list);
+      _.each(obj, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">v, index, list</span>) </span>{
+        computed = iteratee(v, index, list);
         <span class="hljs-keyword">if</span> (computed &lt; lastComputed || computed === <span class="hljs-literal">Infinity</span> &amp;&amp; result === <span class="hljs-literal">Infinity</span>) {
-          result = value;
+          result = v;
           lastComputed = computed;
         }
       });
@@ -828,21 +837,12 @@ containing specific <code>key:value</code> pairs.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-39">&#182;</a>
               </div>
-              <p>Shuffle a collection, using the modern version of the
-<a href="http://en.wikipedia.org/wiki/Fisher–Yates_shuffle">Fisher-Yates shuffle</a>.</p>
+              <p>Shuffle a collection.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.shuffle = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-    <span class="hljs-keyword">var</span> set = isArrayLike(obj) ? obj : _.values(obj);
-    <span class="hljs-keyword">var</span> length = set.length;
-    <span class="hljs-keyword">var</span> shuffled = <span class="hljs-built_in">Array</span>(length);
-    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> index = <span class="hljs-number">0</span>, rand; index &lt; length; index++) {
-      rand = _.random(<span class="hljs-number">0</span>, index);
-      <span class="hljs-keyword">if</span> (rand !== index) shuffled[index] = shuffled[rand];
-      shuffled[rand] = set[index];
-    }
-    <span class="hljs-keyword">return</span> shuffled;
+            <div class="content"><div class='highlight'><pre>  _.shuffle = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+    <span class="hljs-keyword">return</span> _.sample(obj, <span class="hljs-literal">Infinity</span>);
   };</pre></div></div>
             
         </li>
@@ -854,18 +854,29 @@ containing specific <code>key:value</code> pairs.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-40">&#182;</a>
               </div>
-              <p>Sample <strong>n</strong> random values from a collection.
+              <p>Sample <strong>n</strong> random values from a collection using the modern version of the
+<a href="http://en.wikipedia.org/wiki/Fisher–Yates_shuffle">Fisher-Yates shuffle</a>.
 If <strong>n</strong> is not specified, returns a single random element.
 The internal <code>guard</code> argument allows it to work with <code>map</code>.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.sample = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, n, guard)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.sample = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, n, guard</span>) </span>{
     <span class="hljs-keyword">if</span> (n == <span class="hljs-literal">null</span> || guard) {
       <span class="hljs-keyword">if</span> (!isArrayLike(obj)) obj = _.values(obj);
       <span class="hljs-keyword">return</span> obj[_.random(obj.length - <span class="hljs-number">1</span>)];
     }
-    <span class="hljs-keyword">return</span> _.shuffle(obj).slice(<span class="hljs-number">0</span>, <span class="hljs-built_in">Math</span>.max(<span class="hljs-number">0</span>, n));
+    <span class="hljs-keyword">var</span> sample = isArrayLike(obj) ? _.clone(obj) : _.values(obj);
+    <span class="hljs-keyword">var</span> length = getLength(sample);
+    n = <span class="hljs-built_in">Math</span>.max(<span class="hljs-built_in">Math</span>.min(n, length), <span class="hljs-number">0</span>);
+    <span class="hljs-keyword">var</span> last = length - <span class="hljs-number">1</span>;
+    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> index = <span class="hljs-number">0</span>; index &lt; n; index++) {
+      <span class="hljs-keyword">var</span> rand = _.random(index, last);
+      <span class="hljs-keyword">var</span> temp = sample[index];
+      sample[index] = sample[rand];
+      sample[rand] = temp;
+    }
+    <span class="hljs-keyword">return</span> sample.slice(<span class="hljs-number">0</span>, n);
   };</pre></div></div>
             
         </li>
@@ -881,20 +892,21 @@ The internal <code>guard</code> argument allows it to work with <code>map</code>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.sortBy = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, iteratee, context)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.sortBy = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, iteratee, context</span>) </span>{
+    <span class="hljs-keyword">var</span> index = <span class="hljs-number">0</span>;
     iteratee = cb(iteratee, context);
-    <span class="hljs-keyword">return</span> _.pluck(_.map(obj, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value, index, list)</span> </span>{
+    <span class="hljs-keyword">return</span> _.pluck(_.map(obj, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">value, key, list</span>) </span>{
       <span class="hljs-keyword">return</span> {
         value: value,
-        index: index,
-        criteria: iteratee(value, index, list)
+        index: index++,
+        criteria: iteratee(value, key, list)
       };
-    }).sort(<span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(left, right)</span> </span>{
+    }).sort(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">left, right</span>) </span>{
       <span class="hljs-keyword">var</span> a = left.criteria;
       <span class="hljs-keyword">var</span> b = right.criteria;
       <span class="hljs-keyword">if</span> (a !== b) {
         <span class="hljs-keyword">if</span> (a &gt; b || a === <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>) <span class="hljs-keyword">return</span> <span class="hljs-number">1</span>;
-        <span class="hljs-keyword">if</span> (a &lt; b || b === <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>) <span class="hljs-keyword">return</span> -<span class="hljs-number">1</span>;
+        <span class="hljs-keyword">if</span> (a &lt; b || b === <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>) <span class="hljs-keyword">return</span> <span class="hljs-number">-1</span>;
       }
       <span class="hljs-keyword">return</span> left.index - right.index;
     }), <span class="hljs-string">'value'</span>);
@@ -913,11 +925,11 @@ The internal <code>guard</code> argument allows it to work with <code>map</code>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> group = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(behavior)</span> </span>{
-    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, iteratee, context)</span> </span>{
-      <span class="hljs-keyword">var</span> result = {};
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> group = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">behavior, partition</span>) </span>{
+    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, iteratee, context</span>) </span>{
+      <span class="hljs-keyword">var</span> result = partition ? [[], []] : {};
       iteratee = cb(iteratee, context);
-      _.each(obj, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value, index)</span> </span>{
+      _.each(obj, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">value, index</span>) </span>{
         <span class="hljs-keyword">var</span> key = iteratee(value, index, obj);
         behavior(result, value, key);
       });
@@ -939,7 +951,7 @@ to group by, or a function that returns the criterion.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.groupBy = group(<span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(result, value, key)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.groupBy = group(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">result, value, key</span>) </span>{
     <span class="hljs-keyword">if</span> (_.has(result, key)) result[key].push(value); <span class="hljs-keyword">else</span> result[key] = [value];
   });</pre></div></div>
             
@@ -957,7 +969,7 @@ when you know that your index values will be unique.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.indexBy = group(<span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(result, value, key)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.indexBy = group(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">result, value, key</span>) </span>{
     result[key] = value;
   });</pre></div></div>
             
@@ -976,9 +988,11 @@ criterion.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.countBy = group(<span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(result, value, key)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.countBy = group(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">result, value, key</span>) </span>{
     <span class="hljs-keyword">if</span> (_.has(result, key)) result[key]++; <span class="hljs-keyword">else</span> result[key] = <span class="hljs-number">1</span>;
-  });</pre></div></div>
+  });
+
+  <span class="hljs-keyword">var</span> reStrSymbol = <span class="hljs-regexp">/[^\ud800-\udfff]|[\ud800-\udbff][\udc00-\udfff]|[\ud800-\udfff]/g</span>;</pre></div></div>
             
         </li>
         
@@ -993,12 +1007,10 @@ criterion.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.toArray = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.toArray = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
     <span class="hljs-keyword">if</span> (!obj) <span class="hljs-keyword">return</span> [];
     <span class="hljs-keyword">if</span> (_.isArray(obj)) <span class="hljs-keyword">return</span> slice.call(obj);
-    <span class="hljs-keyword">if</span> (isArrayLike(obj)) <span class="hljs-keyword">return</span> _.map(obj, _.identity);
-    <span class="hljs-keyword">return</span> _.values(obj);
-  };</pre></div></div>
+    <span class="hljs-keyword">if</span> (_.isString(obj)) {</pre></div></div>
             
         </li>
         
@@ -1009,13 +1021,14 @@ criterion.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-47">&#182;</a>
               </div>
-              <p>Return the number of elements in an object.</p>
+              <p>Keep surrogate pair characters together</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.size = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-    <span class="hljs-keyword">if</span> (obj == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> <span class="hljs-number">0</span>;
-    <span class="hljs-keyword">return</span> isArrayLike(obj) ? obj.length : _.keys(obj).length;
+            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">return</span> obj ? obj.match(reStrSymbol) : [];
+    }
+    <span class="hljs-keyword">if</span> (isArrayLike(obj)) <span class="hljs-keyword">return</span> _.map(obj, _.identity);
+    <span class="hljs-keyword">return</span> _.values(obj);
   };</pre></div></div>
             
         </li>
@@ -1027,18 +1040,13 @@ criterion.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-48">&#182;</a>
               </div>
-              <p>Split a collection into two arrays: one whose elements all satisfy the given
-predicate, and one whose elements all do not satisfy the predicate.</p>
+              <p>Return the number of elements in an object.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.partition = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, predicate, context)</span> </span>{
-    predicate = cb(predicate, context);
-    <span class="hljs-keyword">var</span> pass = [], fail = [];
-    _.each(obj, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value, key, obj)</span> </span>{
-      (predicate(value, key, obj) ? pass : fail).push(value);
-    });
-    <span class="hljs-keyword">return</span> [pass, fail];
+            <div class="content"><div class='highlight'><pre>  _.size = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+    <span class="hljs-keyword">if</span> (obj == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> <span class="hljs-number">0</span>;
+    <span class="hljs-keyword">return</span> isArrayLike(obj) ? obj.length : _.keys(obj).length;
   };</pre></div></div>
             
         </li>
@@ -1050,9 +1058,14 @@ predicate, and one whose elements all do not satisfy the predicate.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-49">&#182;</a>
               </div>
-              <h2 id="array-functions">Array Functions</h2>
+              <p>Split a collection into two arrays: one whose elements all satisfy the given
+predicate, and one whose elements all do not satisfy the predicate.</p>
 
             </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.partition = group(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">result, value, pass</span>) </span>{
+    result[pass ? <span class="hljs-number">0</span> : <span class="hljs-number">1</span>].push(value);
+  }, <span class="hljs-literal">true</span>);</pre></div></div>
             
         </li>
         
@@ -1063,7 +1076,8 @@ predicate, and one whose elements all do not satisfy the predicate.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-50">&#182;</a>
               </div>
-              
+              <h2 id="array-functions">Array Functions</h2>
+
             </div>
             
         </li>
@@ -1075,17 +1089,8 @@ predicate, and one whose elements all do not satisfy the predicate.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-51">&#182;</a>
               </div>
-              <p>Get the first element of an array. Passing <strong>n</strong> will return the first N
-values in the array. Aliased as <code>head</code> and <code>take</code>. The <strong>guard</strong> check
-allows it to work with <code>_.map</code>.</p>
-
+              
             </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.first = _.head = _.take = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(array, n, guard)</span> </span>{
-    <span class="hljs-keyword">if</span> (array == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>;
-    <span class="hljs-keyword">if</span> (n == <span class="hljs-literal">null</span> || guard) <span class="hljs-keyword">return</span> array[<span class="hljs-number">0</span>];
-    <span class="hljs-keyword">return</span> _.initial(array, array.length - n);
-  };</pre></div></div>
             
         </li>
         
@@ -1096,14 +1101,16 @@ allows it to work with <code>_.map</code>.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-52">&#182;</a>
               </div>
-              <p>Returns everything but the last entry of the array. Especially useful on
-the arguments object. Passing <strong>n</strong> will return all the values in
-the array, excluding the last N.</p>
+              <p>Get the first element of an array. Passing <strong>n</strong> will return the first N
+values in the array. Aliased as <code>head</code> and <code>take</code>. The <strong>guard</strong> check
+allows it to work with <code>_.map</code>.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.initial = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(array, n, guard)</span> </span>{
-    <span class="hljs-keyword">return</span> slice.call(array, <span class="hljs-number">0</span>, <span class="hljs-built_in">Math</span>.max(<span class="hljs-number">0</span>, array.length - (n == <span class="hljs-literal">null</span> || guard ? <span class="hljs-number">1</span> : n)));
+            <div class="content"><div class='highlight'><pre>  _.first = _.head = _.take = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">array, n, guard</span>) </span>{
+    <span class="hljs-keyword">if</span> (array == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>;
+    <span class="hljs-keyword">if</span> (n == <span class="hljs-literal">null</span> || guard) <span class="hljs-keyword">return</span> array[<span class="hljs-number">0</span>];
+    <span class="hljs-keyword">return</span> _.initial(array, array.length - n);
   };</pre></div></div>
             
         </li>
@@ -1115,15 +1122,14 @@ the array, excluding the last N.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-53">&#182;</a>
               </div>
-              <p>Get the last element of an array. Passing <strong>n</strong> will return the last N
-values in the array.</p>
+              <p>Returns everything but the last entry of the array. Especially useful on
+the arguments object. Passing <strong>n</strong> will return all the values in
+the array, excluding the last N.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.last = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(array, n, guard)</span> </span>{
-    <span class="hljs-keyword">if</span> (array == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>;
-    <span class="hljs-keyword">if</span> (n == <span class="hljs-literal">null</span> || guard) <span class="hljs-keyword">return</span> array[array.length - <span class="hljs-number">1</span>];
-    <span class="hljs-keyword">return</span> _.rest(array, <span class="hljs-built_in">Math</span>.max(<span class="hljs-number">0</span>, array.length - n));
+            <div class="content"><div class='highlight'><pre>  _.initial = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">array, n, guard</span>) </span>{
+    <span class="hljs-keyword">return</span> slice.call(array, <span class="hljs-number">0</span>, <span class="hljs-built_in">Math</span>.max(<span class="hljs-number">0</span>, array.length - (n == <span class="hljs-literal">null</span> || guard ? <span class="hljs-number">1</span> : n)));
   };</pre></div></div>
             
         </li>
@@ -1135,14 +1141,15 @@ values in the array.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-54">&#182;</a>
               </div>
-              <p>Returns everything but the first entry of the array. Aliased as <code>tail</code> and <code>drop</code>.
-Especially useful on the arguments object. Passing an <strong>n</strong> will return
-the rest N values in the array.</p>
+              <p>Get the last element of an array. Passing <strong>n</strong> will return the last N
+values in the array.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.rest = _.tail = _.drop = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(array, n, guard)</span> </span>{
-    <span class="hljs-keyword">return</span> slice.call(array, n == <span class="hljs-literal">null</span> || guard ? <span class="hljs-number">1</span> : n);
+            <div class="content"><div class='highlight'><pre>  _.last = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">array, n, guard</span>) </span>{
+    <span class="hljs-keyword">if</span> (array == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>;
+    <span class="hljs-keyword">if</span> (n == <span class="hljs-literal">null</span> || guard) <span class="hljs-keyword">return</span> array[array.length - <span class="hljs-number">1</span>];
+    <span class="hljs-keyword">return</span> _.rest(array, <span class="hljs-built_in">Math</span>.max(<span class="hljs-number">0</span>, array.length - n));
   };</pre></div></div>
             
         </li>
@@ -1154,12 +1161,14 @@ the rest N values in the array.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-55">&#182;</a>
               </div>
-              <p>Trim out all falsy values from an array.</p>
+              <p>Returns everything but the first entry of the array. Aliased as <code>tail</code> and <code>drop</code>.
+Especially useful on the arguments object. Passing an <strong>n</strong> will return
+the rest N values in the array.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.compact = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(array)</span> </span>{
-    <span class="hljs-keyword">return</span> _.filter(array, _.identity);
+            <div class="content"><div class='highlight'><pre>  _.rest = _.tail = _.drop = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">array, n, guard</span>) </span>{
+    <span class="hljs-keyword">return</span> slice.call(array, n == <span class="hljs-literal">null</span> || guard ? <span class="hljs-number">1</span> : n);
   };</pre></div></div>
             
         </li>
@@ -1171,15 +1180,13 @@ the rest N values in the array.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-56">&#182;</a>
               </div>
-              <p>Internal implementation of a recursive <code>flatten</code> function.</p>
+              <p>Trim out all falsy values from an array.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> flatten = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(input, shallow, strict, startIndex)</span> </span>{
-    <span class="hljs-keyword">var</span> output = [], idx = <span class="hljs-number">0</span>;
-    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = startIndex || <span class="hljs-number">0</span>, length = getLength(input); i &lt; length; i++) {
-      <span class="hljs-keyword">var</span> value = input[i];
-      <span class="hljs-keyword">if</span> (isArrayLike(value) &amp;&amp; (_.isArray(value) || _.isArguments(value))) {</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  _.compact = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">array</span>) </span>{
+    <span class="hljs-keyword">return</span> _.filter(array, _.identity);
+  };</pre></div></div>
             
         </li>
         
@@ -1190,15 +1197,36 @@ the rest N values in the array.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-57">&#182;</a>
               </div>
-              <p>flatten current level of array or arguments object</p>
+              <p>Internal implementation of a recursive <code>flatten</code> function.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>        <span class="hljs-keyword">if</span> (!shallow) value = flatten(value, shallow, strict);
-        <span class="hljs-keyword">var</span> j = <span class="hljs-number">0</span>, len = value.length;
-        output.length += len;
-        <span class="hljs-keyword">while</span> (j &lt; len) {
-          output[idx++] = value[j++];
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> flatten = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">input, shallow, strict, output</span>) </span>{
+    output = output || [];
+    <span class="hljs-keyword">var</span> idx = output.length;
+    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = getLength(input); i &lt; length; i++) {
+      <span class="hljs-keyword">var</span> value = input[i];
+      <span class="hljs-keyword">if</span> (isArrayLike(value) &amp;&amp; (_.isArray(value) || _.isArguments(value))) {</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-58">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-58">&#182;</a>
+              </div>
+              <p>Flatten current level of array or arguments object</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        <span class="hljs-keyword">if</span> (shallow) {
+          <span class="hljs-keyword">var</span> j = <span class="hljs-number">0</span>, len = value.length;
+          <span class="hljs-keyword">while</span> (j &lt; len) output[idx++] = value[j++];
+        } <span class="hljs-keyword">else</span> {
+          flatten(value, shallow, strict, output);
+          idx = output.length;
         }
       } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (!strict) {
         output[idx++] = value;
@@ -1210,35 +1238,18 @@ the rest N values in the array.</p>
         </li>
         
         
-        <li id="section-58">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-58">&#182;</a>
-              </div>
-              <p>Flatten out an array, either recursively (by default), or just one level.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.flatten = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(array, shallow)</span> </span>{
-    <span class="hljs-keyword">return</span> flatten(array, shallow, <span class="hljs-literal">false</span>);
-  };</pre></div></div>
-            
-        </li>
-        
-        
         <li id="section-59">
             <div class="annotation">
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-59">&#182;</a>
               </div>
-              <p>Return a version of the array that does not contain the specified value(s).</p>
+              <p>Flatten out an array, either recursively (by default), or just one level.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.without = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(array)</span> </span>{
-    <span class="hljs-keyword">return</span> _.difference(array, slice.call(<span class="hljs-built_in">arguments</span>, <span class="hljs-number">1</span>));
+            <div class="content"><div class='highlight'><pre>  _.flatten = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">array, shallow</span>) </span>{
+    <span class="hljs-keyword">return</span> flatten(array, shallow, <span class="hljs-literal">false</span>);
   };</pre></div></div>
             
         </li>
@@ -1250,13 +1261,30 @@ the rest N values in the array.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-60">&#182;</a>
               </div>
+              <p>Return a version of the array that does not contain the specified value(s).</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.without = restArgs(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">array, otherArrays</span>) </span>{
+    <span class="hljs-keyword">return</span> _.difference(array, otherArrays);
+  });</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-61">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-61">&#182;</a>
+              </div>
               <p>Produce a duplicate-free version of the array. If the array has already
 been sorted, you have the option of using a faster algorithm.
 Aliased as <code>unique</code>.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.uniq = _.unique = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(array, isSorted, iteratee, context)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.uniq = _.unique = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">array, isSorted, iteratee, context</span>) </span>{
     <span class="hljs-keyword">if</span> (!_.isBoolean(isSorted)) {
       context = iteratee;
       iteratee = isSorted;
@@ -1286,48 +1314,20 @@ Aliased as <code>unique</code>.</p>
         </li>
         
         
-        <li id="section-61">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-61">&#182;</a>
-              </div>
-              <p>Produce an array that contains the union: each distinct element from all of
-the passed-in arrays.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.union = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-    <span class="hljs-keyword">return</span> _.uniq(flatten(<span class="hljs-built_in">arguments</span>, <span class="hljs-literal">true</span>, <span class="hljs-literal">true</span>));
-  };</pre></div></div>
-            
-        </li>
-        
-        
         <li id="section-62">
             <div class="annotation">
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-62">&#182;</a>
               </div>
-              <p>Produce an array that contains every item shared between all the
-passed-in arrays.</p>
+              <p>Produce an array that contains the union: each distinct element from all of
+the passed-in arrays.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.intersection = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(array)</span> </span>{
-    <span class="hljs-keyword">var</span> result = [];
-    <span class="hljs-keyword">var</span> argsLength = <span class="hljs-built_in">arguments</span>.length;
-    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = getLength(array); i &lt; length; i++) {
-      <span class="hljs-keyword">var</span> item = array[i];
-      <span class="hljs-keyword">if</span> (_.contains(result, item)) <span class="hljs-keyword">continue</span>;
-      <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> j = <span class="hljs-number">1</span>; j &lt; argsLength; j++) {
-        <span class="hljs-keyword">if</span> (!_.contains(<span class="hljs-built_in">arguments</span>[j], item)) <span class="hljs-keyword">break</span>;
-      }
-      <span class="hljs-keyword">if</span> (j === argsLength) result.push(item);
-    }
-    <span class="hljs-keyword">return</span> result;
-  };</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  _.union = restArgs(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">arrays</span>) </span>{
+    <span class="hljs-keyword">return</span> _.uniq(flatten(arrays, <span class="hljs-literal">true</span>, <span class="hljs-literal">true</span>));
+  });</pre></div></div>
             
         </li>
         
@@ -1338,16 +1338,24 @@ passed-in arrays.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-63">&#182;</a>
               </div>
-              <p>Take the difference between one array and a number of other arrays.
-Only the elements present in just the first array will remain.</p>
+              <p>Produce an array that contains every item shared between all the
+passed-in arrays.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.difference = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(array)</span> </span>{
-    <span class="hljs-keyword">var</span> rest = flatten(<span class="hljs-built_in">arguments</span>, <span class="hljs-literal">true</span>, <span class="hljs-literal">true</span>, <span class="hljs-number">1</span>);
-    <span class="hljs-keyword">return</span> _.filter(array, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value)</span></span>{
-      <span class="hljs-keyword">return</span> !_.contains(rest, value);
-    });
+            <div class="content"><div class='highlight'><pre>  _.intersection = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">array</span>) </span>{
+    <span class="hljs-keyword">var</span> result = [];
+    <span class="hljs-keyword">var</span> argsLength = <span class="hljs-built_in">arguments</span>.length;
+    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = getLength(array); i &lt; length; i++) {
+      <span class="hljs-keyword">var</span> item = array[i];
+      <span class="hljs-keyword">if</span> (_.contains(result, item)) <span class="hljs-keyword">continue</span>;
+      <span class="hljs-keyword">var</span> j;
+      <span class="hljs-keyword">for</span> (j = <span class="hljs-number">1</span>; j &lt; argsLength; j++) {
+        <span class="hljs-keyword">if</span> (!_.contains(<span class="hljs-built_in">arguments</span>[j], item)) <span class="hljs-keyword">break</span>;
+      }
+      <span class="hljs-keyword">if</span> (j === argsLength) result.push(item);
+    }
+    <span class="hljs-keyword">return</span> result;
   };</pre></div></div>
             
         </li>
@@ -1359,14 +1367,17 @@ Only the elements present in just the first array will remain.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-64">&#182;</a>
               </div>
-              <p>Zip together multiple lists into a single array — elements that share
-an index go together.</p>
+              <p>Take the difference between one array and a number of other arrays.
+Only the elements present in just the first array will remain.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.zip = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-    <span class="hljs-keyword">return</span> _.unzip(<span class="hljs-built_in">arguments</span>);
-  };</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  _.difference = restArgs(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">array, rest</span>) </span>{
+    rest = flatten(rest, <span class="hljs-literal">true</span>, <span class="hljs-literal">true</span>);
+    <span class="hljs-keyword">return</span> _.filter(array, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">value</span>)</span>{
+      <span class="hljs-keyword">return</span> !_.contains(rest, value);
+    });
+  });</pre></div></div>
             
         </li>
         
@@ -1382,7 +1393,7 @@ each array’s elements on shared indices</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.unzip = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(array)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.unzip = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">array</span>) </span>{
     <span class="hljs-keyword">var</span> length = array &amp;&amp; _.max(array, getLength).length || <span class="hljs-number">0</span>;
     <span class="hljs-keyword">var</span> result = <span class="hljs-built_in">Array</span>(length);
 
@@ -1401,13 +1412,29 @@ each array’s elements on shared indices</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-66">&#182;</a>
               </div>
+              <p>Zip together multiple lists into a single array – elements that share
+an index go together.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.zip = restArgs(_.unzip);</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-67">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-67">&#182;</a>
+              </div>
               <p>Converts lists into objects. Pass either a single array of <code>[key, value]</code>
-pairs, or two parallel arrays of the same length — one of keys, and one of
+pairs, or two parallel arrays of the same length – one of keys, and one of
 the corresponding values.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.object = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(list, values)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.object = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">list, values</span>) </span>{
     <span class="hljs-keyword">var</span> result = {};
     <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = getLength(list); i &lt; length; i++) {
       <span class="hljs-keyword">if</span> (values) {
@@ -1422,43 +1449,27 @@ the corresponding values.</p>
         </li>
         
         
-        <li id="section-67">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-67">&#182;</a>
-              </div>
-              <p>Generator function to create the findIndex and findLastIndex functions</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">createPredicateIndexFinder</span><span class="hljs-params">(dir)</span> </span>{
-    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(array, predicate, context)</span> </span>{
-      predicate = cb(predicate, context);
-      <span class="hljs-keyword">var</span> length = getLength(array);
-      <span class="hljs-keyword">var</span> index = dir &gt; <span class="hljs-number">0</span> ? <span class="hljs-number">0</span> : length - <span class="hljs-number">1</span>;
-      <span class="hljs-keyword">for</span> (; index &gt;= <span class="hljs-number">0</span> &amp;&amp; index &lt; length; index += dir) {
-        <span class="hljs-keyword">if</span> (predicate(array[index], index, array)) <span class="hljs-keyword">return</span> index;
-      }
-      <span class="hljs-keyword">return</span> -<span class="hljs-number">1</span>;
-    };
-  }</pre></div></div>
-            
-        </li>
-        
-        
         <li id="section-68">
             <div class="annotation">
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-68">&#182;</a>
               </div>
-              <p>Returns the first index on an array-like that passes a predicate test</p>
+              <p>Generator function to create the findIndex and findLastIndex functions</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.findIndex = createPredicateIndexFinder(<span class="hljs-number">1</span>);
-  _.findLastIndex = createPredicateIndexFinder(-<span class="hljs-number">1</span>);</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> createPredicateIndexFinder = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">dir</span>) </span>{
+    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">array, predicate, context</span>) </span>{
+      predicate = cb(predicate, context);
+      <span class="hljs-keyword">var</span> length = getLength(array);
+      <span class="hljs-keyword">var</span> index = dir &gt; <span class="hljs-number">0</span> ? <span class="hljs-number">0</span> : length - <span class="hljs-number">1</span>;
+      <span class="hljs-keyword">for</span> (; index &gt;= <span class="hljs-number">0</span> &amp;&amp; index &lt; length; index += dir) {
+        <span class="hljs-keyword">if</span> (predicate(array[index], index, array)) <span class="hljs-keyword">return</span> index;
+      }
+      <span class="hljs-keyword">return</span> <span class="hljs-number">-1</span>;
+    };
+  };</pre></div></div>
             
         </li>
         
@@ -1469,12 +1480,28 @@ the corresponding values.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-69">&#182;</a>
               </div>
+              <p>Returns the first index on an array-like that passes a predicate test</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.findIndex = createPredicateIndexFinder(<span class="hljs-number">1</span>);
+  _.findLastIndex = createPredicateIndexFinder(<span class="hljs-number">-1</span>);</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-70">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-70">&#182;</a>
+              </div>
               <p>Use a comparator function to figure out the smallest index at which
 an object should be inserted so as to maintain order. Uses binary search.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.sortedIndex = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(array, obj, iteratee, context)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.sortedIndex = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">array, obj, iteratee, context</span>) </span>{
     iteratee = cb(iteratee, context, <span class="hljs-number">1</span>);
     <span class="hljs-keyword">var</span> value = iteratee(obj);
     <span class="hljs-keyword">var</span> low = <span class="hljs-number">0</span>, high = getLength(array);
@@ -1488,58 +1515,39 @@ an object should be inserted so as to maintain order. Uses binary search.</p>
         </li>
         
         
-        <li id="section-70">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-70">&#182;</a>
-              </div>
-              <p>Generator function to create the indexOf and lastIndexOf functions</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">createIndexFinder</span><span class="hljs-params">(dir, predicateFind, sortedIndex)</span> </span>{
-    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(array, item, idx)</span> </span>{
-      <span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = getLength(array);
-      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">typeof</span> idx == <span class="hljs-string">'number'</span>) {
-        <span class="hljs-keyword">if</span> (dir &gt; <span class="hljs-number">0</span>) {
-            i = idx &gt;= <span class="hljs-number">0</span> ? idx : <span class="hljs-built_in">Math</span>.max(idx + length, i);
-        } <span class="hljs-keyword">else</span> {
-            length = idx &gt;= <span class="hljs-number">0</span> ? <span class="hljs-built_in">Math</span>.min(idx + <span class="hljs-number">1</span>, length) : idx + length + <span class="hljs-number">1</span>;
-        }
-      } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (sortedIndex &amp;&amp; idx &amp;&amp; length) {
-        idx = sortedIndex(array, item);
-        <span class="hljs-keyword">return</span> array[idx] === item ? idx : -<span class="hljs-number">1</span>;
-      }
-      <span class="hljs-keyword">if</span> (item !== item) {
-        idx = predicateFind(slice.call(array, i, length), _.isNaN);
-        <span class="hljs-keyword">return</span> idx &gt;= <span class="hljs-number">0</span> ? idx + i : -<span class="hljs-number">1</span>;
-      }
-      <span class="hljs-keyword">for</span> (idx = dir &gt; <span class="hljs-number">0</span> ? i : length - <span class="hljs-number">1</span>; idx &gt;= <span class="hljs-number">0</span> &amp;&amp; idx &lt; length; idx += dir) {
-        <span class="hljs-keyword">if</span> (array[idx] === item) <span class="hljs-keyword">return</span> idx;
-      }
-      <span class="hljs-keyword">return</span> -<span class="hljs-number">1</span>;
-    };
-  }</pre></div></div>
-            
-        </li>
-        
-        
         <li id="section-71">
             <div class="annotation">
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-71">&#182;</a>
               </div>
-              <p>Return the position of the first occurrence of an item in an array,
-or -1 if the item is not included in the array.
-If the array is large and already in sort order, pass <code>true</code>
-for <strong>isSorted</strong> to use binary search.</p>
+              <p>Generator function to create the indexOf and lastIndexOf functions</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.indexOf = createIndexFinder(<span class="hljs-number">1</span>, _.findIndex, _.sortedIndex);
-  _.lastIndexOf = createIndexFinder(-<span class="hljs-number">1</span>, _.findLastIndex);</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> createIndexFinder = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">dir, predicateFind, sortedIndex</span>) </span>{
+    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">array, item, idx</span>) </span>{
+      <span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = getLength(array);
+      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">typeof</span> idx == <span class="hljs-string">'number'</span>) {
+        <span class="hljs-keyword">if</span> (dir &gt; <span class="hljs-number">0</span>) {
+          i = idx &gt;= <span class="hljs-number">0</span> ? idx : <span class="hljs-built_in">Math</span>.max(idx + length, i);
+        } <span class="hljs-keyword">else</span> {
+          length = idx &gt;= <span class="hljs-number">0</span> ? <span class="hljs-built_in">Math</span>.min(idx + <span class="hljs-number">1</span>, length) : idx + length + <span class="hljs-number">1</span>;
+        }
+      } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (sortedIndex &amp;&amp; idx &amp;&amp; length) {
+        idx = sortedIndex(array, item);
+        <span class="hljs-keyword">return</span> array[idx] === item ? idx : <span class="hljs-number">-1</span>;
+      }
+      <span class="hljs-keyword">if</span> (item !== item) {
+        idx = predicateFind(slice.call(array, i, length), _.isNaN);
+        <span class="hljs-keyword">return</span> idx &gt;= <span class="hljs-number">0</span> ? idx + i : <span class="hljs-number">-1</span>;
+      }
+      <span class="hljs-keyword">for</span> (idx = dir &gt; <span class="hljs-number">0</span> ? i : length - <span class="hljs-number">1</span>; idx &gt;= <span class="hljs-number">0</span> &amp;&amp; idx &lt; length; idx += dir) {
+        <span class="hljs-keyword">if</span> (array[idx] === item) <span class="hljs-keyword">return</span> idx;
+      }
+      <span class="hljs-keyword">return</span> <span class="hljs-number">-1</span>;
+    };
+  };</pre></div></div>
             
         </li>
         
@@ -1550,28 +1558,15 @@ for <strong>isSorted</strong> to use binary search.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-72">&#182;</a>
               </div>
-              <p>Generate an integer Array containing an arithmetic progression. A port of
-the native Python <code>range()</code> function. See
-<a href="http://docs.python.org/library/functions.html#range">the Python documentation</a>.</p>
+              <p>Return the position of the first occurrence of an item in an array,
+or -1 if the item is not included in the array.
+If the array is large and already in sort order, pass <code>true</code>
+for <strong>isSorted</strong> to use binary search.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.range = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(start, stop, step)</span> </span>{
-    <span class="hljs-keyword">if</span> (stop == <span class="hljs-literal">null</span>) {
-      stop = start || <span class="hljs-number">0</span>;
-      start = <span class="hljs-number">0</span>;
-    }
-    step = step || <span class="hljs-number">1</span>;
-
-    <span class="hljs-keyword">var</span> length = <span class="hljs-built_in">Math</span>.max(<span class="hljs-built_in">Math</span>.ceil((stop - start) / step), <span class="hljs-number">0</span>);
-    <span class="hljs-keyword">var</span> range = <span class="hljs-built_in">Array</span>(length);
-
-    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> idx = <span class="hljs-number">0</span>; idx &lt; length; idx++, start += step) {
-      range[idx] = start;
-    }
-
-    <span class="hljs-keyword">return</span> range;
-  };</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  _.indexOf = createIndexFinder(<span class="hljs-number">1</span>, _.findIndex, _.sortedIndex);
+  _.lastIndexOf = createIndexFinder(<span class="hljs-number">-1</span>, _.findLastIndex);</pre></div></div>
             
         </li>
         
@@ -1582,9 +1577,39 @@ the native Python <code>range()</code> function. See
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-73">&#182;</a>
               </div>
-              <h2 id="function-ahem-functions">Function (ahem) Functions</h2>
+              <p>Generate an integer Array containing an arithmetic progression. A port of
+the native Python <code>range()</code> function. See
+<a href="http://docs.python.org/library/functions.html#range">the Python documentation</a>.</p>
 
             </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.range = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">start, stop, step, iteratee, toBind, providedArgs</span>) </span>{
+    <span class="hljs-keyword">if</span> (stop == <span class="hljs-literal">null</span>) {
+      stop = start || <span class="hljs-number">0</span>;
+      start = <span class="hljs-number">0</span>;
+    }
+
+    step = step || <span class="hljs-number">1</span>;
+
+    <span class="hljs-keyword">var</span> isFunc;
+    <span class="hljs-keyword">if</span> ( _.isFunction( iteratee ) ) {
+      isFunc = <span class="hljs-literal">true</span>;
+    }
+    <span class="hljs-keyword">var</span> length = <span class="hljs-built_in">Math</span>.max(<span class="hljs-built_in">Math</span>.ceil((stop - start) / step ), <span class="hljs-number">0</span>);
+    <span class="hljs-keyword">var</span> range = <span class="hljs-built_in">Array</span>(length);
+
+    <span class="hljs-keyword">var</span> increment = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">index</span>) </span>{
+      <span class="hljs-keyword">var</span> args = providedArgs.slice(<span class="hljs-number">0</span>);
+      args.unshift( index );
+      <span class="hljs-keyword">return</span> iteratee.apply( toBind, args );
+    };
+
+    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> idx = <span class="hljs-number">0</span>; idx &lt; length; start += step, idx++ ) {
+      range[idx] = isFunc ? increment(start) : start;
+    }
+
+    <span class="hljs-keyword">return</span> range;
+  };</pre></div></div>
             
         </li>
         
@@ -1595,8 +1620,21 @@ the native Python <code>range()</code> function. See
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-74">&#182;</a>
               </div>
-              
+              <p>Split an <strong>array</strong> into several arrays containing <strong>count</strong> or less elements
+of initial array</p>
+
             </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.chunk = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">array, count</span>) </span>{
+    <span class="hljs-keyword">if</span> (count == <span class="hljs-literal">null</span> || count &lt; <span class="hljs-number">1</span>) <span class="hljs-keyword">return</span> [];
+
+    <span class="hljs-keyword">var</span> result = [];
+    <span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = array.length;
+    <span class="hljs-keyword">while</span> (i &lt; length) {
+      result.push(slice.call(array, i, i += count));
+    }
+    <span class="hljs-keyword">return</span> result;
+  };</pre></div></div>
             
         </li>
         
@@ -1607,18 +1645,9 @@ the native Python <code>range()</code> function. See
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-75">&#182;</a>
               </div>
-              <p>Determines whether to execute a function as a constructor
-or a normal function with the provided arguments</p>
+              <h2 id="function-ahem-functions">Function (ahem) Functions</h2>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> executeBound = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(sourceFunc, boundFunc, context, callingContext, args)</span> </span>{
-    <span class="hljs-keyword">if</span> (!(callingContext <span class="hljs-keyword">instanceof</span> boundFunc)) <span class="hljs-keyword">return</span> sourceFunc.apply(context, args);
-    <span class="hljs-keyword">var</span> self = baseCreate(sourceFunc.prototype);
-    <span class="hljs-keyword">var</span> result = sourceFunc.apply(self, args);
-    <span class="hljs-keyword">if</span> (_.isObject(result)) <span class="hljs-keyword">return</span> result;
-    <span class="hljs-keyword">return</span> self;
-  };</pre></div></div>
             
         </li>
         
@@ -1629,21 +1658,8 @@ or a normal function with the provided arguments</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-76">&#182;</a>
               </div>
-              <p>Create a function bound to a given object (assigning <code>this</code>, and arguments,
-optionally). Delegates to <strong>ECMAScript 5</strong>‘s native <code>Function.bind</code> if
-available.</p>
-
+              
             </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.bind = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(func, context)</span> </span>{
-    <span class="hljs-keyword">if</span> (nativeBind &amp;&amp; func.bind === nativeBind) <span class="hljs-keyword">return</span> nativeBind.apply(func, slice.call(<span class="hljs-built_in">arguments</span>, <span class="hljs-number">1</span>));
-    <span class="hljs-keyword">if</span> (!_.isFunction(func)) <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">TypeError</span>(<span class="hljs-string">'Bind must be called on a function'</span>);
-    <span class="hljs-keyword">var</span> args = slice.call(<span class="hljs-built_in">arguments</span>, <span class="hljs-number">2</span>);
-    <span class="hljs-keyword">var</span> bound = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">return</span> executeBound(func, bound, context, <span class="hljs-keyword">this</span>, args.concat(slice.call(<span class="hljs-built_in">arguments</span>)));
-    };
-    <span class="hljs-keyword">return</span> bound;
-  };</pre></div></div>
             
         </li>
         
@@ -1654,24 +1670,17 @@ available.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-77">&#182;</a>
               </div>
-              <p>Partially apply a function by creating a version that has had some of its
-arguments pre-filled, without changing its dynamic <code>this</code> context. _ acts
-as a placeholder, allowing any combination of arguments to be pre-filled.</p>
+              <p>Determines whether to execute a function as a constructor
+or a normal function with the provided arguments</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.partial = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(func)</span> </span>{
-    <span class="hljs-keyword">var</span> boundArgs = slice.call(<span class="hljs-built_in">arguments</span>, <span class="hljs-number">1</span>);
-    <span class="hljs-keyword">var</span> bound = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">var</span> position = <span class="hljs-number">0</span>, length = boundArgs.length;
-      <span class="hljs-keyword">var</span> args = <span class="hljs-built_in">Array</span>(length);
-      <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>; i &lt; length; i++) {
-        args[i] = boundArgs[i] === _ ? <span class="hljs-built_in">arguments</span>[position++] : boundArgs[i];
-      }
-      <span class="hljs-keyword">while</span> (position &lt; <span class="hljs-built_in">arguments</span>.length) args.push(<span class="hljs-built_in">arguments</span>[position++]);
-      <span class="hljs-keyword">return</span> executeBound(func, bound, <span class="hljs-keyword">this</span>, <span class="hljs-keyword">this</span>, args);
-    };
-    <span class="hljs-keyword">return</span> bound;
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> executeBound = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">sourceFunc, boundFunc, context, callingContext, args</span>) </span>{
+    <span class="hljs-keyword">if</span> (!(callingContext <span class="hljs-keyword">instanceof</span> boundFunc)) <span class="hljs-keyword">return</span> sourceFunc.apply(context, args);
+    <span class="hljs-keyword">var</span> self = baseCreate(sourceFunc.prototype);
+    <span class="hljs-keyword">var</span> result = sourceFunc.apply(self, args);
+    <span class="hljs-keyword">if</span> (_.isObject(result)) <span class="hljs-keyword">return</span> result;
+    <span class="hljs-keyword">return</span> self;
   };</pre></div></div>
             
         </li>
@@ -1683,21 +1692,19 @@ as a placeholder, allowing any combination of arguments to be pre-filled.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-78">&#182;</a>
               </div>
-              <p>Bind a number of an object’s methods to that object. Remaining arguments
-are the method names to be bound. Useful for ensuring that all callbacks
-defined on an object belong to it.</p>
+              <p>Create a function bound to a given object (assigning <code>this</code>, and arguments,
+optionally). Delegates to <strong>ECMAScript 5</strong>‘s native <code>Function.bind</code> if
+available.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.bindAll = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-    <span class="hljs-keyword">var</span> i, length = <span class="hljs-built_in">arguments</span>.length, key;
-    <span class="hljs-keyword">if</span> (length &lt;= <span class="hljs-number">1</span>) <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">'bindAll must be passed function names'</span>);
-    <span class="hljs-keyword">for</span> (i = <span class="hljs-number">1</span>; i &lt; length; i++) {
-      key = <span class="hljs-built_in">arguments</span>[i];
-      obj[key] = _.bind(obj[key], obj);
-    }
-    <span class="hljs-keyword">return</span> obj;
-  };</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  _.bind = restArgs(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">func, context, args</span>) </span>{
+    <span class="hljs-keyword">if</span> (!_.isFunction(func)) <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">TypeError</span>(<span class="hljs-string">'Bind must be called on a function'</span>);
+    <span class="hljs-keyword">var</span> bound = restArgs(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">callArgs</span>) </span>{
+      <span class="hljs-keyword">return</span> executeBound(func, bound, context, <span class="hljs-keyword">this</span>, args.concat(callArgs));
+    });
+    <span class="hljs-keyword">return</span> bound;
+  });</pre></div></div>
             
         </li>
         
@@ -1708,12 +1715,69 @@ defined on an object belong to it.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-79">&#182;</a>
               </div>
+              <p>Partially apply a function by creating a version that has had some of its
+arguments pre-filled, without changing its dynamic <code>this</code> context. <em> acts
+as a placeholder by default, allowing any combination of arguments to be
+pre-filled. Set `</em>.partial.placeholder` for a custom placeholder argument.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.partial = restArgs(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">func, boundArgs</span>) </span>{
+    <span class="hljs-keyword">var</span> placeholder = _.partial.placeholder;
+    <span class="hljs-keyword">var</span> bound = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+      <span class="hljs-keyword">var</span> position = <span class="hljs-number">0</span>, length = boundArgs.length;
+      <span class="hljs-keyword">var</span> args = <span class="hljs-built_in">Array</span>(length);
+      <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>; i &lt; length; i++) {
+        args[i] = boundArgs[i] === placeholder ? <span class="hljs-built_in">arguments</span>[position++] : boundArgs[i];
+      }
+      <span class="hljs-keyword">while</span> (position &lt; <span class="hljs-built_in">arguments</span>.length) args.push(<span class="hljs-built_in">arguments</span>[position++]);
+      <span class="hljs-keyword">return</span> executeBound(func, bound, <span class="hljs-keyword">this</span>, <span class="hljs-keyword">this</span>, args);
+    };
+    <span class="hljs-keyword">return</span> bound;
+  });
+
+  _.partial.placeholder = _;</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-80">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-80">&#182;</a>
+              </div>
+              <p>Bind a number of an object’s methods to that object. Remaining arguments
+are the method names to be bound. Useful for ensuring that all callbacks
+defined on an object belong to it.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.bindAll = restArgs(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, keys</span>) </span>{
+    keys = flatten(keys, <span class="hljs-literal">false</span>, <span class="hljs-literal">false</span>);
+    <span class="hljs-keyword">var</span> index = keys.length;
+    <span class="hljs-keyword">if</span> (index &lt; <span class="hljs-number">1</span>) <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">'bindAll must be passed function names'</span>);
+    <span class="hljs-keyword">while</span> (index--) {
+      <span class="hljs-keyword">var</span> key = keys[index];
+      obj[key] = _.bind(obj[key], obj);
+    }
+  });</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-81">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-81">&#182;</a>
+              </div>
               <p>Memoize an expensive function by storing its results.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.memoize = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(func, hasher)</span> </span>{
-    <span class="hljs-keyword">var</span> memoize = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(key)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.memoize = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">func, hasher</span>) </span>{
+    <span class="hljs-keyword">var</span> memoize = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">key</span>) </span>{
       <span class="hljs-keyword">var</span> cache = memoize.cache;
       <span class="hljs-keyword">var</span> address = <span class="hljs-string">''</span> + (hasher ? hasher.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>) : key);
       <span class="hljs-keyword">if</span> (!_.has(cache, address)) cache[address] = func.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
@@ -1726,32 +1790,31 @@ defined on an object belong to it.</p>
         </li>
         
         
-        <li id="section-80">
+        <li id="section-82">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-80">&#182;</a>
+                <a class="pilcrow" href="#section-82">&#182;</a>
               </div>
               <p>Delays a function for the given number of milliseconds, and then calls
 it with the arguments supplied.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.delay = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(func, wait)</span> </span>{
-    <span class="hljs-keyword">var</span> args = slice.call(<span class="hljs-built_in">arguments</span>, <span class="hljs-number">2</span>);
-    <span class="hljs-keyword">return</span> setTimeout(<span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span></span>{
+            <div class="content"><div class='highlight'><pre>  _.delay = restArgs(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">func, wait, args</span>) </span>{
+    <span class="hljs-keyword">return</span> setTimeout(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
       <span class="hljs-keyword">return</span> func.apply(<span class="hljs-literal">null</span>, args);
     }, wait);
-  };</pre></div></div>
+  });</pre></div></div>
             
         </li>
         
         
-        <li id="section-81">
+        <li id="section-83">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-81">&#182;</a>
+                <a class="pilcrow" href="#section-83">&#182;</a>
               </div>
               <p>Defers a function, scheduling it to run after the current call stack has
 cleared.</p>
@@ -1763,11 +1826,11 @@ cleared.</p>
         </li>
         
         
-        <li id="section-82">
+        <li id="section-84">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-82">&#182;</a>
+                <a class="pilcrow" href="#section-84">&#182;</a>
               </div>
               <p>Returns a function, that, when invoked, will only be triggered at most once
 during a given window of time. Normally, the throttled function will run
@@ -1777,18 +1840,19 @@ but if you’d like to disable the execution on the leading edge, pass
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.throttle = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(func, wait, options)</span> </span>{
-    <span class="hljs-keyword">var</span> context, args, result;
-    <span class="hljs-keyword">var</span> timeout = <span class="hljs-literal">null</span>;
+            <div class="content"><div class='highlight'><pre>  _.throttle = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">func, wait, options</span>) </span>{
+    <span class="hljs-keyword">var</span> timeout, context, args, result;
     <span class="hljs-keyword">var</span> previous = <span class="hljs-number">0</span>;
     <span class="hljs-keyword">if</span> (!options) options = {};
-    <span class="hljs-keyword">var</span> later = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+
+    <span class="hljs-keyword">var</span> later = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
       previous = options.leading === <span class="hljs-literal">false</span> ? <span class="hljs-number">0</span> : _.now();
       timeout = <span class="hljs-literal">null</span>;
       result = func.apply(context, args);
       <span class="hljs-keyword">if</span> (!timeout) context = args = <span class="hljs-literal">null</span>;
     };
-    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+
+    <span class="hljs-keyword">var</span> throttled = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
       <span class="hljs-keyword">var</span> now = _.now();
       <span class="hljs-keyword">if</span> (!previous &amp;&amp; options.leading === <span class="hljs-literal">false</span>) previous = now;
       <span class="hljs-keyword">var</span> remaining = wait - (now - previous);
@@ -1807,73 +1871,14 @@ but if you’d like to disable the execution on the leading edge, pass
       }
       <span class="hljs-keyword">return</span> result;
     };
-  };</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-83">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-83">&#182;</a>
-              </div>
-              <p>Returns a function, that, as long as it continues to be invoked, will not
-be triggered. The function will be called after it stops being called for
-N milliseconds. If <code>immediate</code> is passed, trigger the function on the
-leading edge, instead of the trailing.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.debounce = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(func, wait, immediate)</span> </span>{
-    <span class="hljs-keyword">var</span> timeout, args, context, timestamp, result;
-
-    <span class="hljs-keyword">var</span> later = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">var</span> last = _.now() - timestamp;
-
-      <span class="hljs-keyword">if</span> (last &lt; wait &amp;&amp; last &gt;= <span class="hljs-number">0</span>) {
-        timeout = setTimeout(later, wait - last);
-      } <span class="hljs-keyword">else</span> {
-        timeout = <span class="hljs-literal">null</span>;
-        <span class="hljs-keyword">if</span> (!immediate) {
-          result = func.apply(context, args);
-          <span class="hljs-keyword">if</span> (!timeout) context = args = <span class="hljs-literal">null</span>;
-        }
-      }
+    throttled.clear = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+      clearTimeout(timeout);
+      previous = <span class="hljs-number">0</span>;
+      timeout = context = args = <span class="hljs-literal">null</span>;
     };
 
-    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      context = <span class="hljs-keyword">this</span>;
-      args = <span class="hljs-built_in">arguments</span>;
-      timestamp = _.now();
-      <span class="hljs-keyword">var</span> callNow = immediate &amp;&amp; !timeout;
-      <span class="hljs-keyword">if</span> (!timeout) timeout = setTimeout(later, wait);
-      <span class="hljs-keyword">if</span> (callNow) {
-        result = func.apply(context, args);
-        context = args = <span class="hljs-literal">null</span>;
-      }
-
-      <span class="hljs-keyword">return</span> result;
-    };
-  };</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-84">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-84">&#182;</a>
-              </div>
-              <p>Returns the first function passed as an argument to the second,
-allowing you to adjust arguments, run code before and after, and
-conditionally execute the original function.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.wrap = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(func, wrapper)</span> </span>{
-    <span class="hljs-keyword">return</span> _.partial(wrapper, func);
+    <span class="hljs-keyword">return</span> throttled;
   };</pre></div></div>
             
         </li>
@@ -1885,14 +1890,40 @@ conditionally execute the original function.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-85">&#182;</a>
               </div>
-              <p>Returns a negated version of the passed-in predicate.</p>
+              <p>Returns a function, that, as long as it continues to be invoked, will not
+be triggered. The function will be called after it stops being called for
+N milliseconds. If <code>immediate</code> is passed, trigger the function on the
+leading edge, instead of the trailing.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.negate = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(predicate)</span> </span>{
-    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">return</span> !predicate.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
+            <div class="content"><div class='highlight'><pre>  _.debounce = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">func, wait, immediate</span>) </span>{
+    <span class="hljs-keyword">var</span> timeout, result;
+
+    <span class="hljs-keyword">var</span> later = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">context, args</span>) </span>{
+      timeout = <span class="hljs-literal">null</span>;
+      <span class="hljs-keyword">if</span> (args) result = func.apply(context, args);
     };
+
+    <span class="hljs-keyword">var</span> debounced = restArgs(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">args</span>) </span>{
+      <span class="hljs-keyword">var</span> callNow = immediate &amp;&amp; !timeout;
+      <span class="hljs-keyword">if</span> (timeout) clearTimeout(timeout);
+      <span class="hljs-keyword">if</span> (callNow) {
+        timeout = setTimeout(later, wait);
+        result = func.apply(<span class="hljs-keyword">this</span>, args);
+      } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (!immediate) {
+        timeout = _.delay(later, wait, <span class="hljs-keyword">this</span>, args);
+      }
+
+      <span class="hljs-keyword">return</span> result;
+    });
+
+    debounced.clear = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+      clearTimeout(timeout);
+      timeout = <span class="hljs-literal">null</span>;
+    };
+
+    <span class="hljs-keyword">return</span> debounced;
   };</pre></div></div>
             
         </li>
@@ -1904,20 +1935,14 @@ conditionally execute the original function.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-86">&#182;</a>
               </div>
-              <p>Returns a function that is the composition of a list of functions, each
-consuming the return value of the function that follows.</p>
+              <p>Returns the first function passed as an argument to the second,
+allowing you to adjust arguments, run code before and after, and
+conditionally execute the original function.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.compose = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-    <span class="hljs-keyword">var</span> args = <span class="hljs-built_in">arguments</span>;
-    <span class="hljs-keyword">var</span> start = args.length - <span class="hljs-number">1</span>;
-    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">var</span> i = start;
-      <span class="hljs-keyword">var</span> result = args[start].apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
-      <span class="hljs-keyword">while</span> (i--) result = args[i].call(<span class="hljs-keyword">this</span>, result);
-      <span class="hljs-keyword">return</span> result;
-    };
+            <div class="content"><div class='highlight'><pre>  _.wrap = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">func, wrapper</span>) </span>{
+    <span class="hljs-keyword">return</span> _.partial(wrapper, func);
   };</pre></div></div>
             
         </li>
@@ -1929,15 +1954,13 @@ consuming the return value of the function that follows.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-87">&#182;</a>
               </div>
-              <p>Returns a function that will only be executed on and after the Nth call.</p>
+              <p>Returns a negated version of the passed-in predicate.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.after = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(times, func)</span> </span>{
-    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">if</span> (--times &lt; <span class="hljs-number">1</span>) {
-        <span class="hljs-keyword">return</span> func.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
-      }
+            <div class="content"><div class='highlight'><pre>  _.negate = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">predicate</span>) </span>{
+    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+      <span class="hljs-keyword">return</span> !predicate.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
     };
   };</pre></div></div>
             
@@ -1950,18 +1973,19 @@ consuming the return value of the function that follows.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-88">&#182;</a>
               </div>
-              <p>Returns a function that will only be executed up to (but not including) the Nth call.</p>
+              <p>Returns a function that is the composition of a list of functions, each
+consuming the return value of the function that follows.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.before = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(times, func)</span> </span>{
-    <span class="hljs-keyword">var</span> memo;
-    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">if</span> (--times &gt; <span class="hljs-number">0</span>) {
-        memo = func.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
-      }
-      <span class="hljs-keyword">if</span> (times &lt;= <span class="hljs-number">1</span>) func = <span class="hljs-literal">null</span>;
-      <span class="hljs-keyword">return</span> memo;
+            <div class="content"><div class='highlight'><pre>  _.compose = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+    <span class="hljs-keyword">var</span> args = <span class="hljs-built_in">arguments</span>;
+    <span class="hljs-keyword">var</span> start = args.length - <span class="hljs-number">1</span>;
+    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+      <span class="hljs-keyword">var</span> i = start;
+      <span class="hljs-keyword">var</span> result = args[start].apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
+      <span class="hljs-keyword">while</span> (i--) result = args[i].call(<span class="hljs-keyword">this</span>, result);
+      <span class="hljs-keyword">return</span> result;
     };
   };</pre></div></div>
             
@@ -1974,12 +1998,17 @@ consuming the return value of the function that follows.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-89">&#182;</a>
               </div>
-              <p>Returns a function that will be executed at most one time, no matter how
-often you call it. Useful for lazy initialization.</p>
+              <p>Returns a function that will only be executed on and after the Nth call.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.once = _.partial(_.before, <span class="hljs-number">2</span>);</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  _.after = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">times, func</span>) </span>{
+    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+      <span class="hljs-keyword">if</span> (--times &lt; <span class="hljs-number">1</span>) {
+        <span class="hljs-keyword">return</span> func.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
+      }
+    };
+  };</pre></div></div>
             
         </li>
         
@@ -1990,9 +2019,20 @@ often you call it. Useful for lazy initialization.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-90">&#182;</a>
               </div>
-              <h2 id="object-functions">Object Functions</h2>
+              <p>Returns a function that will only be executed up to (but not including) the Nth call.</p>
 
             </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.before = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">times, func</span>) </span>{
+    <span class="hljs-keyword">var</span> memo;
+    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+      <span class="hljs-keyword">if</span> (--times &gt; <span class="hljs-number">0</span>) {
+        memo = func.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
+      }
+      <span class="hljs-keyword">if</span> (times &lt;= <span class="hljs-number">1</span>) func = <span class="hljs-literal">null</span>;
+      <span class="hljs-keyword">return</span> memo;
+    };
+  };</pre></div></div>
             
         </li>
         
@@ -2003,8 +2043,14 @@ often you call it. Useful for lazy initialization.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-91">&#182;</a>
               </div>
-              
+              <p>Returns a function that will be executed at most one time, no matter how
+often you call it. Useful for lazy initialization.</p>
+
             </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.once = _.partial(_.before, <span class="hljs-number">2</span>);
+
+  _.restArgs = restArgs;</pre></div></div>
             
         </li>
         
@@ -2015,18 +2061,9 @@ often you call it. Useful for lazy initialization.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-92">&#182;</a>
               </div>
-              <p>Keys in IE &lt; 9 that won’t be iterated by <code>for key in ...</code> and thus missed.</p>
+              <h2 id="object-functions">Object Functions</h2>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> hasEnumBug = !{toString: <span class="hljs-literal">null</span>}.propertyIsEnumerable(<span class="hljs-string">'toString'</span>);
-  <span class="hljs-keyword">var</span> nonEnumerableProps = [<span class="hljs-string">'valueOf'</span>, <span class="hljs-string">'isPrototypeOf'</span>, <span class="hljs-string">'toString'</span>,
-                      <span class="hljs-string">'propertyIsEnumerable'</span>, <span class="hljs-string">'hasOwnProperty'</span>, <span class="hljs-string">'toLocaleString'</span>];
-
-  <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">collectNonEnumProps</span><span class="hljs-params">(obj, keys)</span> </span>{
-    <span class="hljs-keyword">var</span> nonEnumIdx = nonEnumerableProps.length;
-    <span class="hljs-keyword">var</span> constructor = obj.constructor;
-    <span class="hljs-keyword">var</span> proto = (_.isFunction(constructor) &amp;&amp; constructor.prototype) || ObjProto;</pre></div></div>
             
         </li>
         
@@ -2036,6 +2073,40 @@ often you call it. Useful for lazy initialization.</p>
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-93">&#182;</a>
+              </div>
+              
+            </div>
+            
+        </li>
+        
+        
+        <li id="section-94">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-94">&#182;</a>
+              </div>
+              <p>Keys in IE &lt; 9 that won’t be iterated by <code>for key in ...</code> and thus missed.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> hasEnumBug = !{toString: <span class="hljs-literal">null</span>}.propertyIsEnumerable(<span class="hljs-string">'toString'</span>);
+  <span class="hljs-keyword">var</span> nonEnumerableProps = [<span class="hljs-string">'valueOf'</span>, <span class="hljs-string">'isPrototypeOf'</span>, <span class="hljs-string">'toString'</span>,
+                      <span class="hljs-string">'propertyIsEnumerable'</span>, <span class="hljs-string">'hasOwnProperty'</span>, <span class="hljs-string">'toLocaleString'</span>];
+
+  <span class="hljs-keyword">var</span> collectNonEnumProps = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, keys</span>) </span>{
+    <span class="hljs-keyword">var</span> nonEnumIdx = nonEnumerableProps.length;
+    <span class="hljs-keyword">var</span> <span class="hljs-keyword">constructor</span> = obj.<span class="hljs-keyword">constructor</span>;
+    var proto = _.isFunction(<span class="hljs-keyword">constructor</span>) &amp;&amp; <span class="hljs-keyword">constructor</span>.prototype || ObjProto;</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-95">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-95">&#182;</a>
               </div>
               <p>Constructor is a special case.</p>
 
@@ -2050,43 +2121,6 @@ often you call it. Useful for lazy initialization.</p>
         keys.push(prop);
       }
     }
-  }</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-94">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-94">&#182;</a>
-              </div>
-              <p>Retrieve the names of an object’s own properties.
-Delegates to <strong>ECMAScript 5</strong>‘s native <code>Object.keys</code></p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.keys = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-    <span class="hljs-keyword">if</span> (!_.isObject(obj)) <span class="hljs-keyword">return</span> [];
-    <span class="hljs-keyword">if</span> (nativeKeys) <span class="hljs-keyword">return</span> nativeKeys(obj);
-    <span class="hljs-keyword">var</span> keys = [];
-    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> key <span class="hljs-keyword">in</span> obj) <span class="hljs-keyword">if</span> (_.has(obj, key)) keys.push(key);</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-95">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-95">&#182;</a>
-              </div>
-              <p>Ahem, IE &lt; 9.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">if</span> (hasEnumBug) collectNonEnumProps(obj, keys);
-    <span class="hljs-keyword">return</span> keys;
   };</pre></div></div>
             
         </li>
@@ -2098,14 +2132,16 @@ Delegates to <strong>ECMAScript 5</strong>‘s native <code>Object.keys</code></
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-96">&#182;</a>
               </div>
-              <p>Retrieve all the property names of an object.</p>
+              <p>Retrieve the names of an object’s own properties.
+Delegates to <strong>ECMAScript 5</strong>‘s native <code>Object.keys</code></p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.allKeys = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.keys = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
     <span class="hljs-keyword">if</span> (!_.isObject(obj)) <span class="hljs-keyword">return</span> [];
+    <span class="hljs-keyword">if</span> (nativeKeys) <span class="hljs-keyword">return</span> nativeKeys(obj);
     <span class="hljs-keyword">var</span> keys = [];
-    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> key <span class="hljs-keyword">in</span> obj) keys.push(key);</pre></div></div>
+    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> key <span class="hljs-keyword">in</span> obj) <span class="hljs-keyword">if</span> (_.has(obj, key)) keys.push(key);</pre></div></div>
             
         </li>
         
@@ -2133,11 +2169,46 @@ Delegates to <strong>ECMAScript 5</strong>‘s native <code>Object.keys</code></
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-98">&#182;</a>
               </div>
+              <p>Retrieve all the property names of an object.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.allKeys = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+    <span class="hljs-keyword">if</span> (!_.isObject(obj)) <span class="hljs-keyword">return</span> [];
+    <span class="hljs-keyword">var</span> keys = [];
+    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> key <span class="hljs-keyword">in</span> obj) keys.push(key);</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-99">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-99">&#182;</a>
+              </div>
+              <p>Ahem, IE &lt; 9.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">if</span> (hasEnumBug) collectNonEnumProps(obj, keys);
+    <span class="hljs-keyword">return</span> keys;
+  };</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-100">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-100">&#182;</a>
+              </div>
               <p>Retrieve the values of an object’s properties.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.values = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.values = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
     <span class="hljs-keyword">var</span> keys = _.keys(obj);
     <span class="hljs-keyword">var</span> length = keys.length;
     <span class="hljs-keyword">var</span> values = <span class="hljs-built_in">Array</span>(length);
@@ -2150,44 +2221,43 @@ Delegates to <strong>ECMAScript 5</strong>‘s native <code>Object.keys</code></
         </li>
         
         
-        <li id="section-99">
+        <li id="section-101">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-99">&#182;</a>
+                <a class="pilcrow" href="#section-101">&#182;</a>
               </div>
               <p>Returns the results of applying the iteratee to each element of the object
 In contrast to _.map it returns an object</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.mapObject = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, iteratee, context)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.mapObject = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, iteratee, context</span>) </span>{
     iteratee = cb(iteratee, context);
-    <span class="hljs-keyword">var</span> keys =  _.keys(obj),
-          length = keys.length,
-          results = {},
-          currentKey;
-      <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> index = <span class="hljs-number">0</span>; index &lt; length; index++) {
-        currentKey = keys[index];
-        results[currentKey] = iteratee(obj[currentKey], currentKey, obj);
-      }
-      <span class="hljs-keyword">return</span> results;
+    <span class="hljs-keyword">var</span> keys = _.keys(obj),
+      length = keys.length,
+      results = {};
+    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> index = <span class="hljs-number">0</span>; index &lt; length; index++) {
+      <span class="hljs-keyword">var</span> currentKey = keys[index];
+      results[currentKey] = iteratee(obj[currentKey], currentKey, obj);
+    }
+    <span class="hljs-keyword">return</span> results;
   };</pre></div></div>
             
         </li>
         
         
-        <li id="section-100">
+        <li id="section-102">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-100">&#182;</a>
+                <a class="pilcrow" href="#section-102">&#182;</a>
               </div>
               <p>Convert an object into a list of <code>[key, value]</code> pairs.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.pairs = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.pairs = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
     <span class="hljs-keyword">var</span> keys = _.keys(obj);
     <span class="hljs-keyword">var</span> length = keys.length;
     <span class="hljs-keyword">var</span> pairs = <span class="hljs-built_in">Array</span>(length);
@@ -2200,17 +2270,17 @@ In contrast to _.map it returns an object</p>
         </li>
         
         
-        <li id="section-101">
+        <li id="section-103">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-101">&#182;</a>
+                <a class="pilcrow" href="#section-103">&#182;</a>
               </div>
               <p>Invert the keys and values of an object. The values must be serializable.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.invert = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.invert = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
     <span class="hljs-keyword">var</span> result = {};
     <span class="hljs-keyword">var</span> keys = _.keys(obj);
     <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = keys.length; i &lt; length; i++) {
@@ -2222,18 +2292,18 @@ In contrast to _.map it returns an object</p>
         </li>
         
         
-        <li id="section-102">
+        <li id="section-104">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-102">&#182;</a>
+                <a class="pilcrow" href="#section-104">&#182;</a>
               </div>
               <p>Return a sorted list of the function names available on the object.
 Aliased as <code>methods</code></p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.functions = _.methods = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.functions = _.methods = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
     <span class="hljs-keyword">var</span> names = [];
     <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> key <span class="hljs-keyword">in</span> obj) {
       <span class="hljs-keyword">if</span> (_.isFunction(obj[key])) names.push(key);
@@ -2244,54 +2314,32 @@ Aliased as <code>methods</code></p>
         </li>
         
         
-        <li id="section-103">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-103">&#182;</a>
-              </div>
-              <p>Extend a given object with all the properties in passed-in object(s).</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.extend = createAssigner(_.allKeys);</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-104">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-104">&#182;</a>
-              </div>
-              <p>Assigns a given object with all the own properties in the passed-in object(s)
-(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/assign">https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/assign</a>)</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.extendOwn = _.assign = createAssigner(_.keys);</pre></div></div>
-            
-        </li>
-        
-        
         <li id="section-105">
             <div class="annotation">
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-105">&#182;</a>
               </div>
-              <p>Returns the first key on an object that passes a predicate test</p>
+              <p>An internal function for creating assigner functions.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.findKey = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, predicate, context)</span> </span>{
-    predicate = cb(predicate, context);
-    <span class="hljs-keyword">var</span> keys = _.keys(obj), key;
-    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = keys.length; i &lt; length; i++) {
-      key = keys[i];
-      <span class="hljs-keyword">if</span> (predicate(obj[key], key, obj)) <span class="hljs-keyword">return</span> key;
-    }
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> createAssigner = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">keysFunc, defaults</span>) </span>{
+    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+      <span class="hljs-keyword">var</span> length = <span class="hljs-built_in">arguments</span>.length;
+      <span class="hljs-keyword">if</span> (defaults) obj = <span class="hljs-built_in">Object</span>(obj);
+      <span class="hljs-keyword">if</span> (length &lt; <span class="hljs-number">2</span> || obj == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> obj;
+      <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> index = <span class="hljs-number">1</span>; index &lt; length; index++) {
+        <span class="hljs-keyword">var</span> source = <span class="hljs-built_in">arguments</span>[index],
+            keys = keysFunc(source),
+            l = keys.length;
+        <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>; i &lt; l; i++) {
+          <span class="hljs-keyword">var</span> key = keys[i];
+          <span class="hljs-keyword">if</span> (!defaults || obj[key] === <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>) obj[key] = source[key];
+        }
+      }
+      <span class="hljs-keyword">return</span> obj;
+    };
   };</pre></div></div>
             
         </li>
@@ -2303,28 +2351,11 @@ Aliased as <code>methods</code></p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-106">&#182;</a>
               </div>
-              <p>Return a copy of the object only containing the whitelisted properties.</p>
+              <p>Extend a given object with all the properties in passed-in object(s).</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.pick = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(object, oiteratee, context)</span> </span>{
-    <span class="hljs-keyword">var</span> result = {}, obj = object, iteratee, keys;
-    <span class="hljs-keyword">if</span> (obj == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> result;
-    <span class="hljs-keyword">if</span> (_.isFunction(oiteratee)) {
-      keys = _.allKeys(obj);
-      iteratee = optimizeCb(oiteratee, context);
-    } <span class="hljs-keyword">else</span> {
-      keys = flatten(<span class="hljs-built_in">arguments</span>, <span class="hljs-literal">false</span>, <span class="hljs-literal">false</span>, <span class="hljs-number">1</span>);
-      iteratee = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value, key, obj)</span> </span>{ <span class="hljs-keyword">return</span> key <span class="hljs-keyword">in</span> obj; };
-      obj = <span class="hljs-built_in">Object</span>(obj);
-    }
-    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = keys.length; i &lt; length; i++) {
-      <span class="hljs-keyword">var</span> key = keys[i];
-      <span class="hljs-keyword">var</span> value = obj[key];
-      <span class="hljs-keyword">if</span> (iteratee(value, key, obj)) result[key] = value;
-    }
-    <span class="hljs-keyword">return</span> result;
-  };</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  _.extend = createAssigner(_.allKeys);</pre></div></div>
             
         </li>
         
@@ -2335,21 +2366,12 @@ Aliased as <code>methods</code></p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-107">&#182;</a>
               </div>
-              <p>Return a copy of the object without the blacklisted properties.</p>
+              <p>Assigns a given object with all the own properties in the passed-in object(s)
+(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/assign">https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/assign</a>)</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.omit = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, iteratee, context)</span> </span>{
-    <span class="hljs-keyword">if</span> (_.isFunction(iteratee)) {
-      iteratee = _.negate(iteratee);
-    } <span class="hljs-keyword">else</span> {
-      <span class="hljs-keyword">var</span> keys = _.map(flatten(<span class="hljs-built_in">arguments</span>, <span class="hljs-literal">false</span>, <span class="hljs-literal">false</span>, <span class="hljs-number">1</span>), <span class="hljs-built_in">String</span>);
-      iteratee = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value, key)</span> </span>{
-        <span class="hljs-keyword">return</span> !_.contains(keys, key);
-      };
-    }
-    <span class="hljs-keyword">return</span> _.pick(obj, iteratee, context);
-  };</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  _.extendOwn = _.assign = createAssigner(_.keys);</pre></div></div>
             
         </li>
         
@@ -2360,11 +2382,18 @@ Aliased as <code>methods</code></p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-108">&#182;</a>
               </div>
-              <p>Fill in a given object with default properties.</p>
+              <p>Returns the first key on an object that passes a predicate test</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.defaults = createAssigner(_.allKeys, <span class="hljs-literal">true</span>);</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  _.findKey = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, predicate, context</span>) </span>{
+    predicate = cb(predicate, context);
+    <span class="hljs-keyword">var</span> keys = _.keys(obj), key;
+    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = keys.length; i &lt; length; i++) {
+      key = keys[i];
+      <span class="hljs-keyword">if</span> (predicate(obj[key], key, obj)) <span class="hljs-keyword">return</span> key;
+    }
+  };</pre></div></div>
             
         </li>
         
@@ -2375,16 +2404,12 @@ Aliased as <code>methods</code></p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-109">&#182;</a>
               </div>
-              <p>Creates an object that inherits from the given prototype object.
-If additional properties are provided then they will be added to the
-created object.</p>
+              <p>Internal pick helper function to determine if <code>obj</code> has key <code>key</code>.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.create = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(prototype, props)</span> </span>{
-    <span class="hljs-keyword">var</span> result = baseCreate(prototype);
-    <span class="hljs-keyword">if</span> (props) _.extendOwn(result, props);
-    <span class="hljs-keyword">return</span> result;
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> keyInObj = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">value, key, obj</span>) </span>{
+    <span class="hljs-keyword">return</span> key <span class="hljs-keyword">in</span> obj;
   };</pre></div></div>
             
         </li>
@@ -2396,14 +2421,28 @@ created object.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-110">&#182;</a>
               </div>
-              <p>Create a (shallow-cloned) duplicate of an object.</p>
+              <p>Return a copy of the object only containing the whitelisted properties.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.clone = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-    <span class="hljs-keyword">if</span> (!_.isObject(obj)) <span class="hljs-keyword">return</span> obj;
-    <span class="hljs-keyword">return</span> _.isArray(obj) ? obj.slice() : _.extend({}, obj);
-  };</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  _.pick = restArgs(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, keys</span>) </span>{
+    <span class="hljs-keyword">var</span> result = {}, iteratee = keys[<span class="hljs-number">0</span>];
+    <span class="hljs-keyword">if</span> (obj == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> result;
+    <span class="hljs-keyword">if</span> (_.isFunction(iteratee)) {
+      <span class="hljs-keyword">if</span> (keys.length &gt; <span class="hljs-number">1</span>) iteratee = optimizeCb(iteratee, keys[<span class="hljs-number">1</span>]);
+      keys = _.allKeys(obj);
+    } <span class="hljs-keyword">else</span> {
+      iteratee = keyInObj;
+      keys = flatten(keys, <span class="hljs-literal">false</span>, <span class="hljs-literal">false</span>);
+      obj = <span class="hljs-built_in">Object</span>(obj);
+    }
+    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = keys.length; i &lt; length; i++) {
+      <span class="hljs-keyword">var</span> key = keys[i];
+      <span class="hljs-keyword">var</span> value = obj[key];
+      <span class="hljs-keyword">if</span> (iteratee(value, key, obj)) result[key] = value;
+    }
+    <span class="hljs-keyword">return</span> result;
+  });</pre></div></div>
             
         </li>
         
@@ -2414,16 +2453,23 @@ created object.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-111">&#182;</a>
               </div>
-              <p>Invokes interceptor with the obj, and then returns obj.
-The primary purpose of this method is to “tap into” a method chain, in
-order to perform operations on intermediate results within the chain.</p>
+              <p>Return a copy of the object without the blacklisted properties.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.tap = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, interceptor)</span> </span>{
-    interceptor(obj);
-    <span class="hljs-keyword">return</span> obj;
-  };</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  _.omit = restArgs(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, keys</span>) </span>{
+    <span class="hljs-keyword">var</span> iteratee = keys[<span class="hljs-number">0</span>], context;
+    <span class="hljs-keyword">if</span> (_.isFunction(iteratee)) {
+      iteratee = _.negate(iteratee);
+      <span class="hljs-keyword">if</span> (keys.length &gt; <span class="hljs-number">1</span>) context = keys[<span class="hljs-number">1</span>];
+    } <span class="hljs-keyword">else</span> {
+      keys = _.map(flatten(keys, <span class="hljs-literal">false</span>, <span class="hljs-literal">false</span>), <span class="hljs-built_in">String</span>);
+      iteratee = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">value, key</span>) </span>{
+        <span class="hljs-keyword">return</span> !_.contains(keys, key);
+      };
+    }
+    <span class="hljs-keyword">return</span> _.pick(obj, iteratee, context);
+  });</pre></div></div>
             
         </li>
         
@@ -2434,11 +2480,85 @@ order to perform operations on intermediate results within the chain.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-112">&#182;</a>
               </div>
+              <p>Fill in a given object with default properties.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.defaults = createAssigner(_.allKeys, <span class="hljs-literal">true</span>);</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-113">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-113">&#182;</a>
+              </div>
+              <p>Creates an object that inherits from the given prototype object.
+If additional properties are provided then they will be added to the
+created object.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.create = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">prototype, props</span>) </span>{
+    <span class="hljs-keyword">var</span> result = baseCreate(prototype);
+    <span class="hljs-keyword">if</span> (props) _.extendOwn(result, props);
+    <span class="hljs-keyword">return</span> result;
+  };</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-114">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-114">&#182;</a>
+              </div>
+              <p>Create a (shallow-cloned) duplicate of an object.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.clone = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+    <span class="hljs-keyword">if</span> (!_.isObject(obj)) <span class="hljs-keyword">return</span> obj;
+    <span class="hljs-keyword">return</span> _.isArray(obj) ? obj.slice() : _.extend({}, obj);
+  };</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-115">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-115">&#182;</a>
+              </div>
+              <p>Invokes interceptor with the obj, and then returns obj.
+The primary purpose of this method is to “tap into” a method chain, in
+order to perform operations on intermediate results within the chain.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.tap = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, interceptor</span>) </span>{
+    interceptor(obj);
+    <span class="hljs-keyword">return</span> obj;
+  };</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-116">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-116">&#182;</a>
+              </div>
               <p>Returns whether an object has a given set of <code>key:value</code> pairs.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.isMatch = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(object, attrs)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.isMatch = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">object, attrs</span>) </span>{
     <span class="hljs-keyword">var</span> keys = _.keys(attrs), length = keys.length;
     <span class="hljs-keyword">if</span> (object == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> !length;
     <span class="hljs-keyword">var</span> obj = <span class="hljs-built_in">Object</span>(object);
@@ -2452,26 +2572,27 @@ order to perform operations on intermediate results within the chain.</p>
         </li>
         
         
-        <li id="section-113">
+        <li id="section-117">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-113">&#182;</a>
+                <a class="pilcrow" href="#section-117">&#182;</a>
               </div>
               <p>Internal recursive comparison function for <code>isEqual</code>.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> eq = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(a, b, aStack, bStack)</span> </span>{</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> eq, deepEq;
+  eq = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b, aStack, bStack</span>) </span>{</pre></div></div>
             
         </li>
         
         
-        <li id="section-114">
+        <li id="section-118">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-114">&#182;</a>
+                <a class="pilcrow" href="#section-118">&#182;</a>
               </div>
               <p>Identical objects are equal. <code>0 === -0</code>, but they aren’t identical.
 See the <a href="http://wiki.ecmascript.org/doku.php?id=harmony:egal">Harmony <code>egal</code> proposal</a>.</p>
@@ -2483,11 +2604,11 @@ See the <a href="http://wiki.ecmascript.org/doku.php?id=harmony:egal">Harmony <c
         </li>
         
         
-        <li id="section-115">
+        <li id="section-119">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-115">&#182;</a>
+                <a class="pilcrow" href="#section-119">&#182;</a>
               </div>
               <p>A strict comparison is necessary because <code>null == undefined</code>.</p>
 
@@ -2498,11 +2619,59 @@ See the <a href="http://wiki.ecmascript.org/doku.php?id=harmony:egal">Harmony <c
         </li>
         
         
-        <li id="section-116">
+        <li id="section-120">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-116">&#182;</a>
+                <a class="pilcrow" href="#section-120">&#182;</a>
+              </div>
+              <p><code>NaN</code>s are equivalent, but non-reflexive.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">if</span> (a !== a) <span class="hljs-keyword">return</span> b !== b;</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-121">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-121">&#182;</a>
+              </div>
+              <p>Exhaust primitive checks</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">var</span> type = <span class="hljs-keyword">typeof</span> a;
+    <span class="hljs-keyword">if</span> (type !== <span class="hljs-string">'function'</span> &amp;&amp; type !== <span class="hljs-string">'object'</span> &amp;&amp; <span class="hljs-keyword">typeof</span> b != <span class="hljs-string">'object'</span>) <span class="hljs-keyword">return</span> <span class="hljs-literal">false</span>;
+    <span class="hljs-keyword">return</span> deepEq(a, b, aStack, bStack);
+  };</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-122">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-122">&#182;</a>
+              </div>
+              <p>Internal recursive comparison function for <code>isEqual</code>.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  deepEq = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b, aStack, bStack</span>) </span>{</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-123">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-123">&#182;</a>
               </div>
               <p>Unwrap any wrapped objects.</p>
 
@@ -2514,11 +2683,11 @@ See the <a href="http://wiki.ecmascript.org/doku.php?id=harmony:egal">Harmony <c
         </li>
         
         
-        <li id="section-117">
+        <li id="section-124">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-117">&#182;</a>
+                <a class="pilcrow" href="#section-124">&#182;</a>
               </div>
               <p>Compare <code>[[Class]]</code> names.</p>
 
@@ -2531,11 +2700,11 @@ See the <a href="http://wiki.ecmascript.org/doku.php?id=harmony:egal">Harmony <c
         </li>
         
         
-        <li id="section-118">
+        <li id="section-125">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-118">&#182;</a>
+                <a class="pilcrow" href="#section-125">&#182;</a>
               </div>
               <p>Strings, numbers, regular expressions, dates, and booleans are compared by value.</p>
 
@@ -2546,11 +2715,11 @@ See the <a href="http://wiki.ecmascript.org/doku.php?id=harmony:egal">Harmony <c
         </li>
         
         
-        <li id="section-119">
+        <li id="section-126">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-119">&#182;</a>
+                <a class="pilcrow" href="#section-126">&#182;</a>
               </div>
               <p>RegExps are coerced to strings for comparison (Note: ‘’ + /a/i === ‘/a/i’)</p>
 
@@ -2561,11 +2730,11 @@ See the <a href="http://wiki.ecmascript.org/doku.php?id=harmony:egal">Harmony <c
         </li>
         
         
-        <li id="section-120">
+        <li id="section-127">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-120">&#182;</a>
+                <a class="pilcrow" href="#section-127">&#182;</a>
               </div>
               <p>Primitives and their corresponding object wrappers are equivalent; thus, <code>&quot;5&quot;</code> is
 equivalent to <code>new String(&quot;5&quot;)</code>.</p>
@@ -2578,11 +2747,11 @@ equivalent to <code>new String(&quot;5&quot;)</code>.</p>
         </li>
         
         
-        <li id="section-121">
+        <li id="section-128">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-121">&#182;</a>
+                <a class="pilcrow" href="#section-128">&#182;</a>
               </div>
               <p><code>NaN</code>s are equivalent, but non-reflexive.
 Object(NaN) is equivalent to NaN</p>
@@ -2594,11 +2763,11 @@ Object(NaN) is equivalent to NaN</p>
         </li>
         
         
-        <li id="section-122">
+        <li id="section-129">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-122">&#182;</a>
+                <a class="pilcrow" href="#section-129">&#182;</a>
               </div>
               <p>An <code>egal</code> comparison is performed for other numeric values.</p>
 
@@ -2611,11 +2780,11 @@ Object(NaN) is equivalent to NaN</p>
         </li>
         
         
-        <li id="section-123">
+        <li id="section-130">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-123">&#182;</a>
+                <a class="pilcrow" href="#section-130">&#182;</a>
               </div>
               <p>Coerce dates and booleans to numeric primitive values. Dates are compared by their
 millisecond representations. Note that invalid dates with millisecond representations
@@ -2633,11 +2802,11 @@ of <code>NaN</code> are not equivalent.</p>
         </li>
         
         
-        <li id="section-124">
+        <li id="section-131">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-124">&#182;</a>
+                <a class="pilcrow" href="#section-131">&#182;</a>
               </div>
               <p>Objects with different constructors are not equivalent, but <code>Object</code>s or <code>Array</code>s
 from different frames are.</p>
@@ -2655,11 +2824,11 @@ from different frames are.</p>
         </li>
         
         
-        <li id="section-125">
+        <li id="section-132">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-125">&#182;</a>
+                <a class="pilcrow" href="#section-132">&#182;</a>
               </div>
               <p>Assume equality for cyclic structures. The algorithm for detecting cyclic
 structures is adapted from ES 5.1 section 15.12.3, abstract operation <code>JO</code>.</p>
@@ -2669,11 +2838,11 @@ structures is adapted from ES 5.1 section 15.12.3, abstract operation <code>JO</
         </li>
         
         
-        <li id="section-126">
+        <li id="section-133">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-126">&#182;</a>
+                <a class="pilcrow" href="#section-133">&#182;</a>
               </div>
               <p>Initializing stack of traversed objects.
 It’s done here since we only need them for objects and arrays comparison.</p>
@@ -2688,11 +2857,11 @@ It’s done here since we only need them for objects and arrays comparison.</p>
         </li>
         
         
-        <li id="section-127">
+        <li id="section-134">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-127">&#182;</a>
+                <a class="pilcrow" href="#section-134">&#182;</a>
               </div>
               <p>Linear search. Performance is inversely proportional to the number of
 unique nested structures.</p>
@@ -2705,11 +2874,11 @@ unique nested structures.</p>
         </li>
         
         
-        <li id="section-128">
+        <li id="section-135">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-128">&#182;</a>
+                <a class="pilcrow" href="#section-135">&#182;</a>
               </div>
               <p>Add the first object to the stack of traversed objects.</p>
 
@@ -2721,11 +2890,11 @@ unique nested structures.</p>
         </li>
         
         
-        <li id="section-129">
+        <li id="section-136">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-129">&#182;</a>
+                <a class="pilcrow" href="#section-136">&#182;</a>
               </div>
               <p>Recursively compare objects and arrays.</p>
 
@@ -2736,11 +2905,11 @@ unique nested structures.</p>
         </li>
         
         
-        <li id="section-130">
+        <li id="section-137">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-130">&#182;</a>
+                <a class="pilcrow" href="#section-137">&#182;</a>
               </div>
               <p>Compare array lengths to determine if a deep comparison is necessary.</p>
 
@@ -2752,11 +2921,11 @@ unique nested structures.</p>
         </li>
         
         
-        <li id="section-131">
+        <li id="section-138">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-131">&#182;</a>
+                <a class="pilcrow" href="#section-138">&#182;</a>
               </div>
               <p>Deep compare the contents, ignoring non-numeric properties.</p>
 
@@ -2770,11 +2939,11 @@ unique nested structures.</p>
         </li>
         
         
-        <li id="section-132">
+        <li id="section-139">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-132">&#182;</a>
+                <a class="pilcrow" href="#section-139">&#182;</a>
               </div>
               <p>Deep compare objects.</p>
 
@@ -2786,11 +2955,11 @@ unique nested structures.</p>
         </li>
         
         
-        <li id="section-133">
+        <li id="section-140">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-133">&#182;</a>
+                <a class="pilcrow" href="#section-140">&#182;</a>
               </div>
               <p>Ensure that both objects contain the same number of properties before comparing deep equality.</p>
 
@@ -2802,11 +2971,11 @@ unique nested structures.</p>
         </li>
         
         
-        <li id="section-134">
+        <li id="section-141">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-134">&#182;</a>
+                <a class="pilcrow" href="#section-141">&#182;</a>
               </div>
               <p>Deep compare each member</p>
 
@@ -2820,11 +2989,11 @@ unique nested structures.</p>
         </li>
         
         
-        <li id="section-135">
+        <li id="section-142">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-135">&#182;</a>
+                <a class="pilcrow" href="#section-142">&#182;</a>
               </div>
               <p>Remove the first object from the stack of traversed objects.</p>
 
@@ -2838,151 +3007,19 @@ unique nested structures.</p>
         </li>
         
         
-        <li id="section-136">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-136">&#182;</a>
-              </div>
-              <p>Perform a deep comparison to check if two objects are equal.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.isEqual = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(a, b)</span> </span>{
-    <span class="hljs-keyword">return</span> eq(a, b);
-  };</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-137">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-137">&#182;</a>
-              </div>
-              <p>Is a given array, string, or object empty?
-An “empty” object has no enumerable own-properties.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.isEmpty = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-    <span class="hljs-keyword">if</span> (obj == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> <span class="hljs-literal">true</span>;
-    <span class="hljs-keyword">if</span> (isArrayLike(obj) &amp;&amp; (_.isArray(obj) || _.isString(obj) || _.isArguments(obj))) <span class="hljs-keyword">return</span> obj.length === <span class="hljs-number">0</span>;
-    <span class="hljs-keyword">return</span> _.keys(obj).length === <span class="hljs-number">0</span>;
-  };</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-138">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-138">&#182;</a>
-              </div>
-              <p>Is a given value a DOM element?</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.isElement = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-    <span class="hljs-keyword">return</span> !!(obj &amp;&amp; obj.nodeType === <span class="hljs-number">1</span>);
-  };</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-139">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-139">&#182;</a>
-              </div>
-              <p>Is a given value an array?
-Delegates to ECMA5’s native Array.isArray</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.isArray = nativeIsArray || <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-    <span class="hljs-keyword">return</span> toString.call(obj) === <span class="hljs-string">'[object Array]'</span>;
-  };</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-140">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-140">&#182;</a>
-              </div>
-              <p>Is a given variable an object?</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.isObject = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-    <span class="hljs-keyword">var</span> type = <span class="hljs-keyword">typeof</span> obj;
-    <span class="hljs-keyword">return</span> type === <span class="hljs-string">'function'</span> || type === <span class="hljs-string">'object'</span> &amp;&amp; !!obj;
-  };</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-141">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-141">&#182;</a>
-              </div>
-              <p>Add some isType methods: isArguments, isFunction, isString, isNumber, isDate, isRegExp, isError.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.each([<span class="hljs-string">'Arguments'</span>, <span class="hljs-string">'Function'</span>, <span class="hljs-string">'String'</span>, <span class="hljs-string">'Number'</span>, <span class="hljs-string">'Date'</span>, <span class="hljs-string">'RegExp'</span>, <span class="hljs-string">'Error'</span>], <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(name)</span> </span>{
-    _[<span class="hljs-string">'is'</span> + name] = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-      <span class="hljs-keyword">return</span> toString.call(obj) === <span class="hljs-string">'[object '</span> + name + <span class="hljs-string">']'</span>;
-    };
-  });</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-142">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-142">&#182;</a>
-              </div>
-              <p>Define a fallback version of the method in browsers (ahem, IE &lt; 9), where
-there isn’t any inspectable “Arguments” type.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">if</span> (!_.isArguments(<span class="hljs-built_in">arguments</span>)) {
-    _.isArguments = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-      <span class="hljs-keyword">return</span> _.has(obj, <span class="hljs-string">'callee'</span>);
-    };
-  }</pre></div></div>
-            
-        </li>
-        
-        
         <li id="section-143">
             <div class="annotation">
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-143">&#182;</a>
               </div>
-              <p>Optimize <code>isFunction</code> if appropriate. Work around some typeof bugs in old v8,
-IE 11 (#1621), and in Safari 8 (#1929).</p>
+              <p>Perform a deep comparison to check if two objects are equal.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">if</span> (<span class="hljs-keyword">typeof</span> /./ != <span class="hljs-string">'function'</span> &amp;&amp; <span class="hljs-keyword">typeof</span> <span class="hljs-built_in">Int8Array</span> != <span class="hljs-string">'object'</span>) {
-    _.isFunction = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-      <span class="hljs-keyword">return</span> <span class="hljs-keyword">typeof</span> obj == <span class="hljs-string">'function'</span> || <span class="hljs-literal">false</span>;
-    };
-  }</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  _.isEqual = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">a, b</span>) </span>{
+    <span class="hljs-keyword">return</span> eq(a, b);
+  };</pre></div></div>
             
         </li>
         
@@ -2993,12 +3030,15 @@ IE 11 (#1621), and in Safari 8 (#1929).</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-144">&#182;</a>
               </div>
-              <p>Is a given object a finite number?</p>
+              <p>Is a given array, string, or object empty?
+An “empty” object has no enumerable own-properties.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.isFinite = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-    <span class="hljs-keyword">return</span> <span class="hljs-built_in">isFinite</span>(obj) &amp;&amp; !<span class="hljs-built_in">isNaN</span>(<span class="hljs-built_in">parseFloat</span>(obj));
+            <div class="content"><div class='highlight'><pre>  _.isEmpty = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+    <span class="hljs-keyword">if</span> (obj == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> <span class="hljs-literal">true</span>;
+    <span class="hljs-keyword">if</span> (isArrayLike(obj) &amp;&amp; (_.isArray(obj) || _.isString(obj) || _.isArguments(obj))) <span class="hljs-keyword">return</span> obj.length === <span class="hljs-number">0</span>;
+    <span class="hljs-keyword">return</span> _.keys(obj).length === <span class="hljs-number">0</span>;
   };</pre></div></div>
             
         </li>
@@ -3010,12 +3050,12 @@ IE 11 (#1621), and in Safari 8 (#1929).</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-145">&#182;</a>
               </div>
-              <p>Is the given value <code>NaN</code>? (NaN is the only number which does not equal itself).</p>
+              <p>Is a given value a DOM element?</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.isNaN = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-    <span class="hljs-keyword">return</span> _.isNumber(obj) &amp;&amp; obj !== +obj;
+            <div class="content"><div class='highlight'><pre>  _.isElement = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+    <span class="hljs-keyword">return</span> !!(obj &amp;&amp; obj.nodeType === <span class="hljs-number">1</span>);
   };</pre></div></div>
             
         </li>
@@ -3027,12 +3067,13 @@ IE 11 (#1621), and in Safari 8 (#1929).</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-146">&#182;</a>
               </div>
-              <p>Is a given value a boolean?</p>
+              <p>Is a given value an array?
+Delegates to ECMA5’s native Array.isArray</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.isBoolean = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-    <span class="hljs-keyword">return</span> obj === <span class="hljs-literal">true</span> || obj === <span class="hljs-literal">false</span> || toString.call(obj) === <span class="hljs-string">'[object Boolean]'</span>;
+            <div class="content"><div class='highlight'><pre>  _.isArray = nativeIsArray || <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+    <span class="hljs-keyword">return</span> toString.call(obj) === <span class="hljs-string">'[object Array]'</span>;
   };</pre></div></div>
             
         </li>
@@ -3044,12 +3085,13 @@ IE 11 (#1621), and in Safari 8 (#1929).</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-147">&#182;</a>
               </div>
-              <p>Is a given value equal to null?</p>
+              <p>Is a given variable an object?</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.isNull = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-    <span class="hljs-keyword">return</span> obj === <span class="hljs-literal">null</span>;
+            <div class="content"><div class='highlight'><pre>  _.isObject = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+    <span class="hljs-keyword">var</span> type = <span class="hljs-keyword">typeof</span> obj;
+    <span class="hljs-keyword">return</span> type === <span class="hljs-string">'function'</span> || type === <span class="hljs-string">'object'</span> &amp;&amp; !!obj;
   };</pre></div></div>
             
         </li>
@@ -3061,13 +3103,15 @@ IE 11 (#1621), and in Safari 8 (#1929).</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-148">&#182;</a>
               </div>
-              <p>Is a given variable undefined?</p>
+              <p>Add some isType methods: isArguments, isFunction, isString, isNumber, isDate, isRegExp, isError.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.isUndefined = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-    <span class="hljs-keyword">return</span> obj === <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>;
-  };</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  _.each([<span class="hljs-string">'Arguments'</span>, <span class="hljs-string">'Function'</span>, <span class="hljs-string">'String'</span>, <span class="hljs-string">'Number'</span>, <span class="hljs-string">'Date'</span>, <span class="hljs-string">'RegExp'</span>, <span class="hljs-string">'Error'</span>], <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">name</span>) </span>{
+    _[<span class="hljs-string">'is'</span> + name] = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+      <span class="hljs-keyword">return</span> toString.call(obj) === <span class="hljs-string">'[object '</span> + name + <span class="hljs-string">']'</span>;
+    };
+  });</pre></div></div>
             
         </li>
         
@@ -3078,14 +3122,16 @@ IE 11 (#1621), and in Safari 8 (#1929).</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-149">&#182;</a>
               </div>
-              <p>Shortcut function for checking if an object has a given property directly
-on itself (in other words, not on a prototype).</p>
+              <p>Define a fallback version of the method in browsers (ahem, IE &lt; 9), where
+there isn’t any inspectable “Arguments” type.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.has = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, key)</span> </span>{
-    <span class="hljs-keyword">return</span> obj != <span class="hljs-literal">null</span> &amp;&amp; hasOwnProperty.call(obj, key);
-  };</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">if</span> (!_.isArguments(<span class="hljs-built_in">arguments</span>)) {
+    _.isArguments = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+      <span class="hljs-keyword">return</span> _.has(obj, <span class="hljs-string">'callee'</span>);
+    };
+  }</pre></div></div>
             
         </li>
         
@@ -3096,9 +3142,17 @@ on itself (in other words, not on a prototype).</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-150">&#182;</a>
               </div>
-              <h2 id="utility-functions">Utility Functions</h2>
+              <p>Optimize <code>isFunction</code> if appropriate. Work around some typeof bugs in old v8,
+IE 11 (#1621), Safari 8 (#1929), and PhantomJS (#2236).</p>
 
             </div>
+            
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> nodelist = root.document &amp;&amp; root.document.childNodes;
+  <span class="hljs-keyword">if</span> (<span class="hljs-keyword">typeof</span> /./ != <span class="hljs-string">'function'</span> &amp;&amp; <span class="hljs-keyword">typeof</span> <span class="hljs-built_in">Int8Array</span> != <span class="hljs-string">'object'</span> &amp;&amp; <span class="hljs-keyword">typeof</span> nodelist != <span class="hljs-string">'function'</span>) {
+    _.isFunction = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+      <span class="hljs-keyword">return</span> <span class="hljs-keyword">typeof</span> obj == <span class="hljs-string">'function'</span> || <span class="hljs-literal">false</span>;
+    };
+  }</pre></div></div>
             
         </li>
         
@@ -3109,8 +3163,13 @@ on itself (in other words, not on a prototype).</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-151">&#182;</a>
               </div>
-              
+              <p>Is a given object a finite number?</p>
+
             </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.isFinite = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+    <span class="hljs-keyword">return</span> <span class="hljs-built_in">isFinite</span>(obj) &amp;&amp; !<span class="hljs-built_in">isNaN</span>(<span class="hljs-built_in">parseFloat</span>(obj));
+  };</pre></div></div>
             
         </li>
         
@@ -3121,14 +3180,12 @@ on itself (in other words, not on a prototype).</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-152">&#182;</a>
               </div>
-              <p>Run Underscore.js in <em>noConflict</em> mode, returning the <code>_</code> variable to its
-previous owner. Returns a reference to the Underscore object.</p>
+              <p>Is the given value <code>NaN</code>?</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.noConflict = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-    root._ = previousUnderscore;
-    <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
+            <div class="content"><div class='highlight'><pre>  _.isNaN = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+    <span class="hljs-keyword">return</span> _.isNumber(obj) &amp;&amp; <span class="hljs-built_in">isNaN</span>(obj);
   };</pre></div></div>
             
         </li>
@@ -3140,12 +3197,12 @@ previous owner. Returns a reference to the Underscore object.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-153">&#182;</a>
               </div>
-              <p>Keep the identity function around for default iteratees.</p>
+              <p>Is a given value a boolean?</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.identity = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value)</span> </span>{
-    <span class="hljs-keyword">return</span> value;
+            <div class="content"><div class='highlight'><pre>  _.isBoolean = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+    <span class="hljs-keyword">return</span> obj === <span class="hljs-literal">true</span> || obj === <span class="hljs-literal">false</span> || toString.call(obj) === <span class="hljs-string">'[object Boolean]'</span>;
   };</pre></div></div>
             
         </li>
@@ -3157,19 +3214,13 @@ previous owner. Returns a reference to the Underscore object.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-154">&#182;</a>
               </div>
-              <p>Predicate-generating functions. Often useful outside of Underscore.</p>
+              <p>Is a given value equal to null?</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.constant = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value)</span> </span>{
-    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">return</span> value;
-    };
-  };
-
-  _.noop = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span></span>{};
-
-  _.property = property;</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  _.isNull = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+    <span class="hljs-keyword">return</span> obj === <span class="hljs-literal">null</span>;
+  };</pre></div></div>
             
         </li>
         
@@ -3180,14 +3231,12 @@ previous owner. Returns a reference to the Underscore object.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-155">&#182;</a>
               </div>
-              <p>Generates a function for a given object that returns a given property.</p>
+              <p>Is a given variable undefined?</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.propertyOf = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-    <span class="hljs-keyword">return</span> obj == <span class="hljs-literal">null</span> ? <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span></span>{} : <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(key)</span> </span>{
-      <span class="hljs-keyword">return</span> obj[key];
-    };
+            <div class="content"><div class='highlight'><pre>  _.isUndefined = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+    <span class="hljs-keyword">return</span> obj === <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>;
   };</pre></div></div>
             
         </li>
@@ -3199,16 +3248,13 @@ previous owner. Returns a reference to the Underscore object.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-156">&#182;</a>
               </div>
-              <p>Returns a predicate for checking whether an object has a given set of
-<code>key:value</code> pairs.</p>
+              <p>Shortcut function for checking if an object has a given property directly
+on itself (in other words, not on a prototype).</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.matcher = _.matches = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(attrs)</span> </span>{
-    attrs = _.extendOwn({}, attrs);
-    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-      <span class="hljs-keyword">return</span> _.isMatch(obj, attrs);
-    };
+            <div class="content"><div class='highlight'><pre>  _.has = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj, key</span>) </span>{
+    <span class="hljs-keyword">return</span> obj != <span class="hljs-literal">null</span> &amp;&amp; hasOwnProperty.call(obj, key);
   };</pre></div></div>
             
         </li>
@@ -3220,16 +3266,9 @@ previous owner. Returns a reference to the Underscore object.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-157">&#182;</a>
               </div>
-              <p>Run a function <strong>n</strong> times.</p>
+              <h2 id="utility-functions">Utility Functions</h2>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.times = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(n, iteratee, context)</span> </span>{
-    <span class="hljs-keyword">var</span> accum = <span class="hljs-built_in">Array</span>(<span class="hljs-built_in">Math</span>.max(<span class="hljs-number">0</span>, n));
-    iteratee = optimizeCb(iteratee, context, <span class="hljs-number">1</span>);
-    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>; i &lt; n; i++) accum[i] = iteratee(i);
-    <span class="hljs-keyword">return</span> accum;
-  };</pre></div></div>
             
         </li>
         
@@ -3240,17 +3279,8 @@ previous owner. Returns a reference to the Underscore object.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-158">&#182;</a>
               </div>
-              <p>Return a random integer between min and max (inclusive).</p>
-
+              
             </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.random = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(min, max)</span> </span>{
-    <span class="hljs-keyword">if</span> (max == <span class="hljs-literal">null</span>) {
-      max = min;
-      min = <span class="hljs-number">0</span>;
-    }
-    <span class="hljs-keyword">return</span> min + <span class="hljs-built_in">Math</span>.floor(<span class="hljs-built_in">Math</span>.random() * (max - min + <span class="hljs-number">1</span>));
-  };</pre></div></div>
             
         </li>
         
@@ -3261,12 +3291,14 @@ previous owner. Returns a reference to the Underscore object.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-159">&#182;</a>
               </div>
-              <p>A (possibly faster) way to get the current timestamp as an integer.</p>
+              <p>Run Underscore.js in <em>noConflict</em> mode, returning the <code>_</code> variable to its
+previous owner. Returns a reference to the Underscore object.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.now = <span class="hljs-built_in">Date</span>.now || <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-    <span class="hljs-keyword">return</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Date</span>().getTime();
+            <div class="content"><div class='highlight'><pre>  _.noConflict = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+    root._ = previousUnderscore;
+    <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
   };</pre></div></div>
             
         </li>
@@ -3277,6 +3309,144 @@ previous owner. Returns a reference to the Underscore object.</p>
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-160">&#182;</a>
+              </div>
+              <p>Keep the identity function around for default iteratees.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.identity = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">value</span>) </span>{
+    <span class="hljs-keyword">return</span> value;
+  };</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-161">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-161">&#182;</a>
+              </div>
+              <p>Predicate-generating functions. Often useful outside of Underscore.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.constant = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">value</span>) </span>{
+    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+      <span class="hljs-keyword">return</span> value;
+    };
+  };
+
+  _.noop = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>)</span>{};
+
+  _.property = property;</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-162">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-162">&#182;</a>
+              </div>
+              <p>Generates a function for a given object that returns a given property.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.propertyOf = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+    <span class="hljs-keyword">return</span> obj == <span class="hljs-literal">null</span> ? <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>)</span>{} : <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">key</span>) </span>{
+      <span class="hljs-keyword">return</span> obj[key];
+    };
+  };</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-163">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-163">&#182;</a>
+              </div>
+              <p>Returns a predicate for checking whether an object has a given set of
+<code>key:value</code> pairs.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.matcher = _.matches = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">attrs</span>) </span>{
+    attrs = _.extendOwn({}, attrs);
+    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+      <span class="hljs-keyword">return</span> _.isMatch(obj, attrs);
+    };
+  };</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-164">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-164">&#182;</a>
+              </div>
+              <p>Run a function <strong>n</strong> times.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.times = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">n, iteratee, context</span>) </span>{
+    <span class="hljs-keyword">var</span> accum = <span class="hljs-built_in">Array</span>(<span class="hljs-built_in">Math</span>.max(<span class="hljs-number">0</span>, n));
+    iteratee = optimizeCb(iteratee, context, <span class="hljs-number">1</span>);
+    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>; i &lt; n; i++) accum[i] = iteratee(i);
+    <span class="hljs-keyword">return</span> accum;
+  };</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-165">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-165">&#182;</a>
+              </div>
+              <p>Return a random integer between min and max (inclusive).</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.random = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">min, max</span>) </span>{
+    <span class="hljs-keyword">if</span> (max == <span class="hljs-literal">null</span>) {
+      max = min;
+      min = <span class="hljs-number">0</span>;
+    }
+    <span class="hljs-keyword">return</span> min + <span class="hljs-built_in">Math</span>.floor(<span class="hljs-built_in">Math</span>.random() * (max - min + <span class="hljs-number">1</span>));
+  };</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-166">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-166">&#182;</a>
+              </div>
+              <p>A (possibly faster) way to get the current timestamp as an integer.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.now = <span class="hljs-built_in">Date</span>.now || <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+    <span class="hljs-keyword">return</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Date</span>().getTime();
+  };</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-167">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-167">&#182;</a>
               </div>
               <p>List of HTML entities for escaping.</p>
 
@@ -3295,29 +3465,29 @@ previous owner. Returns a reference to the Underscore object.</p>
         </li>
         
         
-        <li id="section-161">
+        <li id="section-168">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-161">&#182;</a>
+                <a class="pilcrow" href="#section-168">&#182;</a>
               </div>
               <p>Functions for escaping and unescaping strings to/from HTML interpolation.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> createEscaper = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(map)</span> </span>{
-    <span class="hljs-keyword">var</span> escaper = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(match)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> createEscaper = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">map</span>) </span>{
+    <span class="hljs-keyword">var</span> escaper = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">match</span>) </span>{
       <span class="hljs-keyword">return</span> map[match];
     };</pre></div></div>
             
         </li>
         
         
-        <li id="section-162">
+        <li id="section-169">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-162">&#182;</a>
+                <a class="pilcrow" href="#section-169">&#182;</a>
               </div>
               <p>Regexes for identifying a key that needs to be escaped</p>
 
@@ -3326,7 +3496,7 @@ previous owner. Returns a reference to the Underscore object.</p>
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">var</span> source = <span class="hljs-string">'(?:'</span> + _.keys(map).join(<span class="hljs-string">'|'</span>) + <span class="hljs-string">')'</span>;
     <span class="hljs-keyword">var</span> testRegexp = <span class="hljs-built_in">RegExp</span>(source);
     <span class="hljs-keyword">var</span> replaceRegexp = <span class="hljs-built_in">RegExp</span>(source, <span class="hljs-string">'g'</span>);
-    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(string)</span> </span>{
+    <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">string</span>) </span>{
       string = string == <span class="hljs-literal">null</span> ? <span class="hljs-string">''</span> : <span class="hljs-string">''</span> + string;
       <span class="hljs-keyword">return</span> testRegexp.test(string) ? string.replace(replaceRegexp, escaper) : string;
     };
@@ -3337,19 +3507,19 @@ previous owner. Returns a reference to the Underscore object.</p>
         </li>
         
         
-        <li id="section-163">
+        <li id="section-170">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-163">&#182;</a>
+                <a class="pilcrow" href="#section-170">&#182;</a>
               </div>
               <p>If the value of the named <code>property</code> is a function then invoke it with the
 <code>object</code> as context; otherwise, return it.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.result = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(object, property, fallback)</span> </span>{
-    <span class="hljs-keyword">var</span> value = object == <span class="hljs-literal">null</span> ? <span class="hljs-keyword">void</span> <span class="hljs-number">0</span> : object[property];
+            <div class="content"><div class='highlight'><pre>  _.result = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">object, prop, fallback</span>) </span>{
+    <span class="hljs-keyword">var</span> value = object == <span class="hljs-literal">null</span> ? <span class="hljs-keyword">void</span> <span class="hljs-number">0</span> : object[prop];
     <span class="hljs-keyword">if</span> (value === <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>) {
       value = fallback;
     }
@@ -3359,11 +3529,11 @@ previous owner. Returns a reference to the Underscore object.</p>
         </li>
         
         
-        <li id="section-164">
+        <li id="section-171">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-164">&#182;</a>
+                <a class="pilcrow" href="#section-171">&#182;</a>
               </div>
               <p>Generate a unique integer id (unique within the entire client session).
 Useful for temporary DOM ids.</p>
@@ -3371,7 +3541,7 @@ Useful for temporary DOM ids.</p>
             </div>
             
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> idCounter = <span class="hljs-number">0</span>;
-  _.uniqueId = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(prefix)</span> </span>{
+  _.uniqueId = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">prefix</span>) </span>{
     <span class="hljs-keyword">var</span> id = ++idCounter + <span class="hljs-string">''</span>;
     <span class="hljs-keyword">return</span> prefix ? prefix + id : id;
   };</pre></div></div>
@@ -3379,11 +3549,11 @@ Useful for temporary DOM ids.</p>
         </li>
         
         
-        <li id="section-165">
+        <li id="section-172">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-165">&#182;</a>
+                <a class="pilcrow" href="#section-172">&#182;</a>
               </div>
               <p>By default, Underscore uses ERB-style template delimiters, change the
 following template settings to use alternative delimiters.</p>
@@ -3391,19 +3561,19 @@ following template settings to use alternative delimiters.</p>
             </div>
             
             <div class="content"><div class='highlight'><pre>  _.templateSettings = {
-    evaluate    : <span class="hljs-regexp">/&lt;%([\s\S]+?)%&gt;/g</span>,
-    interpolate : <span class="hljs-regexp">/&lt;%=([\s\S]+?)%&gt;/g</span>,
-    <span class="hljs-built_in">escape</span>      : <span class="hljs-regexp">/&lt;%-([\s\S]+?)%&gt;/g</span>
+    evaluate: <span class="hljs-regexp">/&lt;%([\s\S]+?)%&gt;/g</span>,
+    interpolate: <span class="hljs-regexp">/&lt;%=([\s\S]+?)%&gt;/g</span>,
+    <span class="hljs-built_in">escape</span>: <span class="hljs-regexp">/&lt;%-([\s\S]+?)%&gt;/g</span>
   };</pre></div></div>
             
         </li>
         
         
-        <li id="section-166">
+        <li id="section-173">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-166">&#182;</a>
+                <a class="pilcrow" href="#section-173">&#182;</a>
               </div>
               <p>When customizing <code>templateSettings</code>, if you don’t want to define an
 interpolation, evaluation or escaping regex, we need one that is
@@ -3416,11 +3586,11 @@ guaranteed not to match.</p>
         </li>
         
         
-        <li id="section-167">
+        <li id="section-174">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-167">&#182;</a>
+                <a class="pilcrow" href="#section-174">&#182;</a>
               </div>
               <p>Certain characters need to be escaped so that they can be put into a
 string literal.</p>
@@ -3428,28 +3598,28 @@ string literal.</p>
             </div>
             
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> escapes = {
-    <span class="hljs-string">"'"</span>:      <span class="hljs-string">"'"</span>,
-    <span class="hljs-string">'\\'</span>:     <span class="hljs-string">'\\'</span>,
-    <span class="hljs-string">'\r'</span>:     <span class="hljs-string">'r'</span>,
-    <span class="hljs-string">'\n'</span>:     <span class="hljs-string">'n'</span>,
+    <span class="hljs-string">"'"</span>: <span class="hljs-string">"'"</span>,
+    <span class="hljs-string">'\\'</span>: <span class="hljs-string">'\\'</span>,
+    <span class="hljs-string">'\r'</span>: <span class="hljs-string">'r'</span>,
+    <span class="hljs-string">'\n'</span>: <span class="hljs-string">'n'</span>,
     <span class="hljs-string">'\u2028'</span>: <span class="hljs-string">'u2028'</span>,
     <span class="hljs-string">'\u2029'</span>: <span class="hljs-string">'u2029'</span>
   };
 
-  <span class="hljs-keyword">var</span> escaper = <span class="hljs-regexp">/\\|'|\r|\n|\u2028|\u2029/g</span>;
+  <span class="hljs-keyword">var</span> escapeRegExp = <span class="hljs-regexp">/\\|'|\r|\n|\u2028|\u2029/g</span>;
 
-  <span class="hljs-keyword">var</span> escapeChar = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(match)</span> </span>{
+  <span class="hljs-keyword">var</span> escapeChar = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">match</span>) </span>{
     <span class="hljs-keyword">return</span> <span class="hljs-string">'\\'</span> + escapes[match];
   };</pre></div></div>
             
         </li>
         
         
-        <li id="section-168">
+        <li id="section-175">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-168">&#182;</a>
+                <a class="pilcrow" href="#section-175">&#182;</a>
               </div>
               <p>JavaScript micro-templating, similar to John Resig’s implementation.
 Underscore templating handles arbitrary delimiters, preserves whitespace,
@@ -3458,18 +3628,18 @@ NB: <code>oldSettings</code> only exists for backwards compatibility.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.template = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(text, settings, oldSettings)</span> </span>{
+            <div class="content"><div class='highlight'><pre>  _.template = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">text, settings, oldSettings</span>) </span>{
     <span class="hljs-keyword">if</span> (!settings &amp;&amp; oldSettings) settings = oldSettings;
     settings = _.defaults({}, settings, _.templateSettings);</pre></div></div>
             
         </li>
         
         
-        <li id="section-169">
+        <li id="section-176">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-169">&#182;</a>
+                <a class="pilcrow" href="#section-176">&#182;</a>
               </div>
               <p>Combine delimiters into one regular expression via alternation.</p>
 
@@ -3484,11 +3654,11 @@ NB: <code>oldSettings</code> only exists for backwards compatibility.</p>
         </li>
         
         
-        <li id="section-170">
+        <li id="section-177">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-170">&#182;</a>
+                <a class="pilcrow" href="#section-177">&#182;</a>
               </div>
               <p>Compile the template source, escaping string literals appropriately.</p>
 
@@ -3496,8 +3666,8 @@ NB: <code>oldSettings</code> only exists for backwards compatibility.</p>
             
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">var</span> index = <span class="hljs-number">0</span>;
     <span class="hljs-keyword">var</span> source = <span class="hljs-string">"__p+='"</span>;
-    text.replace(matcher, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(match, escape, interpolate, evaluate, offset)</span> </span>{
-      source += text.slice(index, offset).replace(escaper, escapeChar);
+    text.replace(matcher, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">match, escape, interpolate, evaluate, offset</span>) </span>{
+      source += text.slice(index, offset).replace(escapeRegExp, escapeChar);
       index = offset + match.length;
 
       <span class="hljs-keyword">if</span> (<span class="hljs-built_in">escape</span>) {
@@ -3511,13 +3681,13 @@ NB: <code>oldSettings</code> only exists for backwards compatibility.</p>
         </li>
         
         
-        <li id="section-171">
+        <li id="section-178">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-171">&#182;</a>
+                <a class="pilcrow" href="#section-178">&#182;</a>
               </div>
-              <p>Adobe VMs need the match returned to produce the correct offest.</p>
+              <p>Adobe VMs need the match returned to produce the correct offset.</p>
 
             </div>
             
@@ -3528,11 +3698,11 @@ NB: <code>oldSettings</code> only exists for backwards compatibility.</p>
         </li>
         
         
-        <li id="section-172">
+        <li id="section-179">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-172">&#182;</a>
+                <a class="pilcrow" href="#section-179">&#182;</a>
               </div>
               <p>If a variable is not specified, place data values in local scope.</p>
 
@@ -3544,25 +3714,26 @@ NB: <code>oldSettings</code> only exists for backwards compatibility.</p>
       <span class="hljs-string">"print=function(){__p+=__j.call(arguments,'');};\n"</span> +
       source + <span class="hljs-string">'return __p;\n'</span>;
 
+    <span class="hljs-keyword">var</span> render;
     <span class="hljs-keyword">try</span> {
-      <span class="hljs-keyword">var</span> render = <span class="hljs-keyword">new</span> <span class="hljs-built_in">Function</span>(settings.variable || <span class="hljs-string">'obj'</span>, <span class="hljs-string">'_'</span>, source);
+      render = <span class="hljs-keyword">new</span> <span class="hljs-built_in">Function</span>(settings.variable || <span class="hljs-string">'obj'</span>, <span class="hljs-string">'_'</span>, source);
     } <span class="hljs-keyword">catch</span> (e) {
       e.source = source;
       <span class="hljs-keyword">throw</span> e;
     }
 
-    <span class="hljs-keyword">var</span> template = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(data)</span> </span>{
+    <span class="hljs-keyword">var</span> template = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">data</span>) </span>{
       <span class="hljs-keyword">return</span> render.call(<span class="hljs-keyword">this</span>, data, _);
     };</pre></div></div>
             
         </li>
         
         
-        <li id="section-173">
+        <li id="section-180">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-173">&#182;</a>
+                <a class="pilcrow" href="#section-180">&#182;</a>
               </div>
               <p>Provide the compiled source as a convenience for precompilation.</p>
 
@@ -3577,148 +3748,21 @@ NB: <code>oldSettings</code> only exists for backwards compatibility.</p>
         </li>
         
         
-        <li id="section-174">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-174">&#182;</a>
-              </div>
-              <p>Add a “chain” function. Start chaining a wrapped Underscore object.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.chain = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-    <span class="hljs-keyword">var</span> instance = _(obj);
-    instance._chain = <span class="hljs-literal">true</span>;
-    <span class="hljs-keyword">return</span> instance;
-  };</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-175">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-175">&#182;</a>
-              </div>
-              <h2 id="oop">OOP</h2>
-
-            </div>
-            
-        </li>
-        
-        
-        <li id="section-176">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-176">&#182;</a>
-              </div>
-              <p>If Underscore is called as a function, it returns a wrapped object that
-can be used OO-style. This wrapper holds altered versions of all the
-underscore functions. Wrapped objects may be chained.</p>
-
-            </div>
-            
-        </li>
-        
-        
-        <li id="section-177">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-177">&#182;</a>
-              </div>
-              <p>Helper function to continue chaining intermediate results.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> result = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(instance, obj)</span> </span>{
-    <span class="hljs-keyword">return</span> instance._chain ? _(obj).chain() : obj;
-  };</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-178">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-178">&#182;</a>
-              </div>
-              <p>Add your own custom functions to the Underscore object.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.mixin = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
-    _.each(_.functions(obj), <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(name)</span> </span>{
-      <span class="hljs-keyword">var</span> func = _[name] = obj[name];
-      _.prototype[name] = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-        <span class="hljs-keyword">var</span> args = [<span class="hljs-keyword">this</span>._wrapped];
-        push.apply(args, <span class="hljs-built_in">arguments</span>);
-        <span class="hljs-keyword">return</span> result(<span class="hljs-keyword">this</span>, func.apply(_, args));
-      };
-    });
-  };</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-179">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-179">&#182;</a>
-              </div>
-              <p>Add all of the Underscore functions to the wrapper object.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.mixin(_);</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-180">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-180">&#182;</a>
-              </div>
-              <p>Add all mutator Array functions to the wrapper.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.each([<span class="hljs-string">'pop'</span>, <span class="hljs-string">'push'</span>, <span class="hljs-string">'reverse'</span>, <span class="hljs-string">'shift'</span>, <span class="hljs-string">'sort'</span>, <span class="hljs-string">'splice'</span>, <span class="hljs-string">'unshift'</span>], <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(name)</span> </span>{
-    <span class="hljs-keyword">var</span> method = ArrayProto[name];
-    _.prototype[name] = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">var</span> obj = <span class="hljs-keyword">this</span>._wrapped;
-      method.apply(obj, <span class="hljs-built_in">arguments</span>);
-      <span class="hljs-keyword">if</span> ((name === <span class="hljs-string">'shift'</span> || name === <span class="hljs-string">'splice'</span>) &amp;&amp; obj.length === <span class="hljs-number">0</span>) <span class="hljs-keyword">delete</span> obj[<span class="hljs-number">0</span>];
-      <span class="hljs-keyword">return</span> result(<span class="hljs-keyword">this</span>, obj);
-    };
-  });</pre></div></div>
-            
-        </li>
-        
-        
         <li id="section-181">
             <div class="annotation">
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-181">&#182;</a>
               </div>
-              <p>Add all accessor Array functions to the wrapper.</p>
+              <p>Add a “chain” function. Start chaining a wrapped Underscore object.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  _.each([<span class="hljs-string">'concat'</span>, <span class="hljs-string">'join'</span>, <span class="hljs-string">'slice'</span>], <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(name)</span> </span>{
-    <span class="hljs-keyword">var</span> method = ArrayProto[name];
-    _.prototype[name] = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">return</span> result(<span class="hljs-keyword">this</span>, method.apply(<span class="hljs-keyword">this</span>._wrapped, <span class="hljs-built_in">arguments</span>));
-    };
-  });</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  _.chain = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+    <span class="hljs-keyword">var</span> instance = _(obj);
+    instance._chain = <span class="hljs-literal">true</span>;
+    <span class="hljs-keyword">return</span> instance;
+  };</pre></div></div>
             
         </li>
         
@@ -3729,13 +3773,9 @@ underscore functions. Wrapped objects may be chained.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-182">&#182;</a>
               </div>
-              <p>Extracts the result from a wrapped and chained object.</p>
+              <h2 id="oop">OOP</h2>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.prototype.value = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-    <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>._wrapped;
-  };</pre></div></div>
             
         </li>
         
@@ -3746,16 +3786,11 @@ underscore functions. Wrapped objects may be chained.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-183">&#182;</a>
               </div>
-              <p>Provide unwrapping proxy for some methods used in engine operations
-such as arithmetic and JSON stringification.</p>
+              <p>If Underscore is called as a function, it returns a wrapped object that
+can be used OO-style. This wrapper holds altered versions of all the
+underscore functions. Wrapped objects may be chained.</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>  _.prototype.valueOf = _.prototype.toJSON = _.prototype.value;
-
-  _.prototype.toString = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-    <span class="hljs-keyword">return</span> <span class="hljs-string">''</span> + <span class="hljs-keyword">this</span>._wrapped;
-  };</pre></div></div>
             
         </li>
         
@@ -3765,6 +3800,142 @@ such as arithmetic and JSON stringification.</p>
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-184">&#182;</a>
+              </div>
+              <p>Helper function to continue chaining intermediate results.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> chainResult = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">instance, obj</span>) </span>{
+    <span class="hljs-keyword">return</span> instance._chain ? _(obj).chain() : obj;
+  };</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-185">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-185">&#182;</a>
+              </div>
+              <p>Add your own custom functions to the Underscore object.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.mixin = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">obj</span>) </span>{
+    _.each(_.functions(obj), <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">name</span>) </span>{
+      <span class="hljs-keyword">var</span> func = _[name] = obj[name];
+      _.prototype[name] = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+        <span class="hljs-keyword">var</span> args = [<span class="hljs-keyword">this</span>._wrapped];
+        push.apply(args, <span class="hljs-built_in">arguments</span>);
+        <span class="hljs-keyword">return</span> chainResult(<span class="hljs-keyword">this</span>, func.apply(_, args));
+      };
+    });
+  };</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-186">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-186">&#182;</a>
+              </div>
+              <p>Add all of the Underscore functions to the wrapper object.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.mixin(_);</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-187">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-187">&#182;</a>
+              </div>
+              <p>Add all mutator Array functions to the wrapper.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.each([<span class="hljs-string">'pop'</span>, <span class="hljs-string">'push'</span>, <span class="hljs-string">'reverse'</span>, <span class="hljs-string">'shift'</span>, <span class="hljs-string">'sort'</span>, <span class="hljs-string">'splice'</span>, <span class="hljs-string">'unshift'</span>], <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">name</span>) </span>{
+    <span class="hljs-keyword">var</span> method = ArrayProto[name];
+    _.prototype[name] = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+      <span class="hljs-keyword">var</span> obj = <span class="hljs-keyword">this</span>._wrapped;
+      method.apply(obj, <span class="hljs-built_in">arguments</span>);
+      <span class="hljs-keyword">if</span> ((name === <span class="hljs-string">'shift'</span> || name === <span class="hljs-string">'splice'</span>) &amp;&amp; obj.length === <span class="hljs-number">0</span>) <span class="hljs-keyword">delete</span> obj[<span class="hljs-number">0</span>];
+      <span class="hljs-keyword">return</span> chainResult(<span class="hljs-keyword">this</span>, obj);
+    };
+  });</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-188">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-188">&#182;</a>
+              </div>
+              <p>Add all accessor Array functions to the wrapper.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.each([<span class="hljs-string">'concat'</span>, <span class="hljs-string">'join'</span>, <span class="hljs-string">'slice'</span>], <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">name</span>) </span>{
+    <span class="hljs-keyword">var</span> method = ArrayProto[name];
+    _.prototype[name] = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+      <span class="hljs-keyword">return</span> chainResult(<span class="hljs-keyword">this</span>, method.apply(<span class="hljs-keyword">this</span>._wrapped, <span class="hljs-built_in">arguments</span>));
+    };
+  });</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-189">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-189">&#182;</a>
+              </div>
+              <p>Extracts the result from a wrapped and chained object.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.prototype.value = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+    <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>._wrapped;
+  };</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-190">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-190">&#182;</a>
+              </div>
+              <p>Provide unwrapping proxy for some methods used in engine operations
+such as arithmetic and JSON stringification.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  _.prototype.valueOf = _.prototype.toJSON = _.prototype.value;
+
+  _.prototype.toString = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+    <span class="hljs-keyword">return</span> <span class="hljs-string">''</span> + <span class="hljs-keyword">this</span>._wrapped;
+  };</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-191">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-191">&#182;</a>
               </div>
               <p>AMD registration happens at the end for compatibility with AMD loaders
 that may not enforce next-turn semantics on modules. Even though general
@@ -3776,12 +3947,12 @@ anonymous define() is called outside of a loader request.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">if</span> (<span class="hljs-keyword">typeof</span> define === <span class="hljs-string">'function'</span> &amp;&amp; define.amd) {
-    define(<span class="hljs-string">'underscore'</span>, [], <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">if</span> (<span class="hljs-keyword">typeof</span> define == <span class="hljs-string">'function'</span> &amp;&amp; define.amd) {
+    define(<span class="hljs-string">'underscore'</span>, [], <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
       <span class="hljs-keyword">return</span> _;
     });
   }
-}.call(<span class="hljs-keyword">this</span>));</pre></div></div>
+}());</pre></div></div>
             
         </li>
         

--- a/test/arrays.js
+++ b/test/arrays.js
@@ -536,6 +536,16 @@
     assert.deepEqual(_.range(3, 10, 3), [3, 6, 9], 'range with three arguments a &amp; b &amp; c, c &lt; b-a, a &lt; b generates an array of elements a,a+c,a+2c,...,b - (multiplier of a) &lt; c');
     assert.deepEqual(_.range(3, 10, 15), [3], 'range with three arguments a &amp; b &amp; c, c &gt; b-a, a &lt; b generates an array with a single element, equal to a');
     assert.deepEqual(_.range(12, 7, -2), [12, 10, 8], 'range with three arguments a &amp; b &amp; c, a &gt; b, c &lt; 0 generates an array of elements a,a-c,a-2c and ends with the number not less than b');
+
+    assert.deepEqual(_.range( 1, 5, 1, Math.pow, Math, [2]), [1, 4, 9, 16], 'range with the squares of one to four');
+    assert.deepEqual(_.range( 4, 10, 2, Math.pow, Math, [4]), [256, 1296, 4096], 'range with every second number from 4 to 10 put to the power of four');
+
+    var factorial = function(n) {
+      if ( n === 0 || n === 1 ) { return 1; }
+      return n * factorial(n - 1);
+    };
+    assert.deepEqual(_.range( 1, 6, 1, factorial, null, [2]), [1, 2, 6, 24, 120], 'range with the factorials from 1 to 6');
+
     assert.deepEqual(_.range(0, -10, -1), [0, -1, -2, -3, -4, -5, -6, -7, -8, -9], 'final example in the Python docs');
     assert.strictEqual(1 / _.range(-0, 1)[0], -Infinity, 'should preserve -0');
   });

--- a/test/collections.js
+++ b/test/collections.js
@@ -465,7 +465,7 @@
 
     assert.deepEqual(_.invoke([{a: null}, {}, {a: _.constant(1)}], 'a'), [null, void 0, 1], 'handles null & undefined');
 
-    assert.throws(function() {
+    assert['throws'](function() {
       _.invoke([{a: 1}], 'a');
     }, TypeError, 'throws for non-functions');
   });

--- a/test/functions.js
+++ b/test/functions.js
@@ -44,7 +44,7 @@
     assert.equal(boundf().hello, 'moe curly', "When called without the new operator, it's OK to be bound to the context");
     assert.ok(newBoundf instanceof F, 'a bound instance is an instance of the original function');
 
-    assert.throws(function() { _.bind('notafunction'); }, TypeError, 'throws an error when binding to a non-function');
+    assert['throws'](function() { _.bind('notafunction'); }, TypeError, 'throws an error when binding to a non-function');
   });
 
   test('partial', function(assert) {
@@ -109,9 +109,9 @@
       sayLast: function() { return this.sayHi(_.last(arguments)); }
     };
 
-    assert.throws(function() { _.bindAll(moe); }, Error, 'throws an error for bindAll with no functions named');
-    assert.throws(function() { _.bindAll(moe, 'sayBye'); }, TypeError, 'throws an error for bindAll if the given key is undefined');
-    assert.throws(function() { _.bindAll(moe, 'name'); }, TypeError, 'throws an error for bindAll if the given key is not a function');
+    assert['throws'](function() { _.bindAll(moe); }, Error, 'throws an error for bindAll with no functions named');
+    assert['throws'](function() { _.bindAll(moe, 'sayBye'); }, TypeError, 'throws an error for bindAll if the given key is undefined');
+    assert['throws'](function() { _.bindAll(moe, 'name'); }, TypeError, 'throws an error for bindAll if the given key is not a function');
 
     _.bindAll(moe, 'sayHi', 'sayLast');
     curly.sayHi = moe.sayHi;

--- a/underscore.js
+++ b/underscore.js
@@ -105,8 +105,8 @@
     startIndex = startIndex == null ? func.length - 1 : +startIndex;
     return function() {
       var length = Math.max(arguments.length - startIndex, 0);
-      var rest = Array(length);
-      for (var index = 0; index < length; index++) {
+      var rest = Array(length), index;
+      for (index = 0; index < length; index++) {
         rest[index] = arguments[index + startIndex];
       }
       switch (startIndex) {
@@ -688,18 +688,29 @@
   // Generate an integer Array containing an arithmetic progression. A port of
   // the native Python `range()` function. See
   // [the Python documentation](http://docs.python.org/library/functions.html#range).
-  _.range = function(start, stop, step) {
+  _.range = function(start, stop, step, iteratee, toBind, providedArgs) {
     if (stop == null) {
       stop = start || 0;
       start = 0;
     }
+
     step = step || 1;
 
-    var length = Math.max(Math.ceil((stop - start) / step), 0);
+    var isFunc;
+    if ( _.isFunction( iteratee ) ) {
+      isFunc = true;
+    }
+    var length = Math.max(Math.ceil((stop - start) / step ), 0);
     var range = Array(length);
 
-    for (var idx = 0; idx < length; idx++, start += step) {
-      range[idx] = start;
+    var increment = function(index) {
+      var args = providedArgs.slice(0);
+      args.unshift( index );
+      return iteratee.apply( toBind, args );
+    };
+
+    for (var idx = 0; idx < length; start += step, idx++ ) {
+      range[idx] = isFunc ? increment(start) : start;
     }
 
     return range;


### PR DESCRIPTION
Hey Jeremy, tried to add the ability to generate non-linear ranges (using functions such as factorials) using ` _.range `.  I am sure there are better ways to get it working, but I think it does the job! 

The sort of thing I was hoping to get working... 

```javascript
_.range( 1, 5, 1, Math.pow, Math, [2] );
// => [ 1, 4, 9, 16 ]

_.range( 4, 10, 2, Math.pow, Math, [4] );
// => [ 256, 1296, 4096 ]

var factorial = function(n) {
  if ( n === 0 || n === 1 ) { return 1; }
  return n * factorial(n - 1);
};
_.range( 1, 6, 1, factorial, null, [2] );
// => [ 1, 2, 6, 24, 120 ]
```

Sorry, but I changed a few things in the test suites! Only minimal changes, but I tried to get rid of the throws syntax error message, and I also had to up the max-params eslint rule to allow for 6 parameters (probably not a great idea - but that allowed for the new params I tried to let _.range allow).

The parameters that I have added...

```javascript
_.range( start, stop, step, iteratee, toBind, providedArgs );
```

- ` start `, ` stop ` and ` step ` are all the same
- ` iteratee ` is a callback for each iteration of the loop
- ` toBind ` is what the user wants ` this ` to be, mainly set up to allow for things like Math.pow
  - I probably could have used ` bind ` but I am using the toBind variable for the ` apply ` method
- ` providedArgs ` expects an array, just so we can pass in static values to the ` apply ` method later on (if that is necessary)

Hopefully it is okay! Let me know if I can do anything (or any advice, suggested edits etc.)