### PR TITLE
Make iterator context tests explicit about type

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -52,7 +52,9 @@
   QUnit.test('lookupIterator with contexts', function(assert) {
     _.each([true, false, 'yes', '', 0, 1, {}], function(context) {
       _.each([1], function() {
-        assert.equal(this, context);
+        assert.strictEqual(typeof this, 'object', 'context is a wrapped primitive');
+        assert.strictEqual(this.valueOf(), context, 'the unwrapped context is the specified primitive');
+        assert.equal(this, context, 'context can be coerced to the specified primitive');
       }, context);
     });
   });


### PR DESCRIPTION
By using a coercive assertion, the tests were not being explicit about
the fact that when specifying a primitive as the context for `_.each`,
the `this` value will actually be a wrapped version of the given
primitive.

This change simply makes the assertions more explicit.