### PR TITLE
Always use strictEqual in tests

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -4,20 +4,20 @@
   QUnit.module('Arrays');
 
   QUnit.test('first', function(assert) {
-    assert.equal(_.first([1, 2, 3]), 1, 'can pull out the first element of an array');
-    assert.equal(_([1, 2, 3]).first(), 1, 'can perform OO-style "first()"');
+    assert.strictEqual(_.first([1, 2, 3]), 1, 'can pull out the first element of an array');
+    assert.strictEqual(_([1, 2, 3]).first(), 1, 'can perform OO-style "first()"');
     assert.deepEqual(_.first([1, 2, 3], 0), [], 'returns an empty array when n <= 0 (0 case)');
     assert.deepEqual(_.first([1, 2, 3], -1), [], 'returns an empty array when n <= 0 (negative case)');
     assert.deepEqual(_.first([1, 2, 3], 2), [1, 2], 'can fetch the first n elements');
     assert.deepEqual(_.first([1, 2, 3], 5), [1, 2, 3], 'returns the whole array if n > length');
     var result = (function(){ return _.first(arguments); }(4, 3, 2, 1));
-    assert.equal(result, 4, 'works on an arguments object');
+    assert.strictEqual(result, 4, 'works on an arguments object');
     result = _.map([[1, 2, 3], [1, 2, 3]], _.first);
     assert.deepEqual(result, [1, 1], 'works well with _.map');
-    assert.equal(_.first(null), void 0, 'returns undefined when called on null');
+    assert.strictEqual(_.first(null), void 0, 'returns undefined when called on null');
 
     Array.prototype[0] = 'boo';
-    assert.equal(_.first([]), void 0, 'return undefined when called on a empty array');
+    assert.strictEqual(_.first([]), void 0, 'return undefined when called on a empty array');
     delete Array.prototype[0];
   });
 
@@ -59,21 +59,21 @@
   });
 
   QUnit.test('last', function(assert) {
-    assert.equal(_.last([1, 2, 3]), 3, 'can pull out the last element of an array');
-    assert.equal(_([1, 2, 3]).last(), 3, 'can perform OO-style "last()"');
+    assert.strictEqual(_.last([1, 2, 3]), 3, 'can pull out the last element of an array');
+    assert.strictEqual(_([1, 2, 3]).last(), 3, 'can perform OO-style "last()"');
     assert.deepEqual(_.last([1, 2, 3], 0), [], 'returns an empty array when n <= 0 (0 case)');
     assert.deepEqual(_.last([1, 2, 3], -1), [], 'returns an empty array when n <= 0 (negative case)');
     assert.deepEqual(_.last([1, 2, 3], 2), [2, 3], 'can fetch the last n elements');
     assert.deepEqual(_.last([1, 2, 3], 5), [1, 2, 3], 'returns the whole array if n > length');
     var result = (function(){ return _(arguments).last(); }(1, 2, 3, 4));
-    assert.equal(result, 4, 'works on an arguments object');
+    assert.strictEqual(result, 4, 'works on an arguments object');
     result = _.map([[1, 2, 3], [1, 2, 3]], _.last);
     assert.deepEqual(result, [3, 3], 'works well with _.map');
-    assert.equal(_.last(null), void 0, 'returns undefined when called on null');
+    assert.strictEqual(_.last(null), void 0, 'returns undefined when called on null');
 
     var arr = [];
     arr[-1] = 'boo';
-    assert.equal(_.last(arr), void 0, 'return undefined when called on a empty array');
+    assert.strictEqual(_.last(arr), void 0, 'return undefined when called on a empty array');
   });
 
   QUnit.test('compact', function(assert) {
@@ -99,10 +99,10 @@
     list = [[1], [2], [3], [[4]]];
     assert.deepEqual(_.flatten(list, true), [1, 2, 3, [4]], 'can shallowly flatten arrays containing only other arrays');
 
-    assert.equal(_.flatten([_.range(10), _.range(10), 5, 1, 3], true).length, 23, 'can flatten medium length arrays');
-    assert.equal(_.flatten([_.range(10), _.range(10), 5, 1, 3]).length, 23, 'can shallowly flatten medium length arrays');
-    assert.equal(_.flatten([new Array(1000000), _.range(56000), 5, 1, 3]).length, 1056003, 'can handle massive arrays');
-    assert.equal(_.flatten([new Array(1000000), _.range(56000), 5, 1, 3], true).length, 1056003, 'can handle massive arrays in shallow mode');
+    assert.strictEqual(_.flatten([_.range(10), _.range(10), 5, 1, 3], true).length, 23, 'can flatten medium length arrays');
+    assert.strictEqual(_.flatten([_.range(10), _.range(10), 5, 1, 3]).length, 23, 'can shallowly flatten medium length arrays');
+    assert.strictEqual(_.flatten([new Array(1000000), _.range(56000), 5, 1, 3]).length, 1056003, 'can handle massive arrays');
+    assert.strictEqual(_.flatten([new Array(1000000), _.range(56000), 5, 1, 3], true).length, 1056003, 'can handle massive arrays in shallow mode');
 
     var x = _.range(100000);
     for (var i = 0; i < 1000; i++) x = [x];
@@ -124,9 +124,9 @@
   QUnit.test('sortedIndex', function(assert) {
     var numbers = [10, 20, 30, 40, 50];
     var indexFor35 = _.sortedIndex(numbers, 35);
-    assert.equal(indexFor35, 3, 'finds the index at which a value should be inserted to retain order');
+    assert.strictEqual(indexFor35, 3, 'finds the index at which a value should be inserted to retain order');
     var indexFor30 = _.sortedIndex(numbers, 30);
-    assert.equal(indexFor30, 2, 'finds the smallest index at which a value could be inserted to retain order');
+    assert.strictEqual(indexFor30, 2, 'finds the smallest index at which a value could be inserted to retain order');
 
     var objects = [{x: 10}, {x: 20}, {x: 30}, {x: 40}];
     var iterator = function(obj){ return obj.x; };
@@ -145,7 +145,7 @@
     while (length--) {
       largeArray[values[length]] = values[length];
     }
-    assert.equal(_.sortedIndex(largeArray, 2147483648), 2147483648, 'works with large indexes');
+    assert.strictEqual(_.sortedIndex(largeArray, 2147483648), 2147483648, 'works with large indexes');
   });
 
   QUnit.test('uniq', function(assert) {
@@ -300,41 +300,41 @@
 
   QUnit.test('indexOf', function(assert) {
     var numbers = [1, 2, 3];
-    assert.equal(_.indexOf(numbers, 2), 1, 'can compute indexOf');
+    assert.strictEqual(_.indexOf(numbers, 2), 1, 'can compute indexOf');
     var result = (function(){ return _.indexOf(arguments, 2); }(1, 2, 3));
-    assert.equal(result, 1, 'works on an arguments object');
+    assert.strictEqual(result, 1, 'works on an arguments object');
 
     _.each([null, void 0, [], false], function(val) {
       var msg = 'Handles: ' + (_.isArray(val) ? '[]' : val);
-      assert.equal(_.indexOf(val, 2), -1, msg);
-      assert.equal(_.indexOf(val, 2, -1), -1, msg);
-      assert.equal(_.indexOf(val, 2, -20), -1, msg);
-      assert.equal(_.indexOf(val, 2, 15), -1, msg);
+      assert.strictEqual(_.indexOf(val, 2), -1, msg);
+      assert.strictEqual(_.indexOf(val, 2, -1), -1, msg);
+      assert.strictEqual(_.indexOf(val, 2, -20), -1, msg);
+      assert.strictEqual(_.indexOf(val, 2, 15), -1, msg);
     });
 
     var num = 35;
     numbers = [10, 20, 30, 40, 50];
     var index = _.indexOf(numbers, num, true);
-    assert.equal(index, -1, '35 is not in the list');
+    assert.strictEqual(index, -1, '35 is not in the list');
 
     numbers = [10, 20, 30, 40, 50]; num = 40;
     index = _.indexOf(numbers, num, true);
-    assert.equal(index, 3, '40 is in the list');
+    assert.strictEqual(index, 3, '40 is in the list');
 
     numbers = [1, 40, 40, 40, 40, 40, 40, 40, 50, 60, 70]; num = 40;
-    assert.equal(_.indexOf(numbers, num, true), 1, '40 is in the list');
-    assert.equal(_.indexOf(numbers, 6, true), -1, '6 isnt in the list');
-    assert.equal(_.indexOf([1, 2, 5, 4, 6, 7], 5, true), -1, 'sorted indexOf doesn\'t uses binary search');
+    assert.strictEqual(_.indexOf(numbers, num, true), 1, '40 is in the list');
+    assert.strictEqual(_.indexOf(numbers, 6, true), -1, '6 isnt in the list');
+    assert.strictEqual(_.indexOf([1, 2, 5, 4, 6, 7], 5, true), -1, 'sorted indexOf doesn\'t uses binary search');
     assert.ok(_.every(['1', [], {}, null], function() {
       return _.indexOf(numbers, num, {}) === 1;
     }), 'non-nums as fromIndex make indexOf assume sorted');
 
     numbers = [1, 2, 3, 1, 2, 3, 1, 2, 3];
     index = _.indexOf(numbers, 2, 5);
-    assert.equal(index, 7, 'supports the fromIndex argument');
+    assert.strictEqual(index, 7, 'supports the fromIndex argument');
 
     index = _.indexOf([,,, 0], void 0);
-    assert.equal(index, 0, 'treats sparse arrays as if they were dense');
+    assert.strictEqual(index, 0, 'treats sparse arrays as if they were dense');
 
     var array = [1, 2, 3, 1, 2, 3];
     assert.strictEqual(_.indexOf(array, 1, -3), 3, 'neg `fromIndex` starts at the right index');
@@ -346,7 +346,7 @@
     assert.strictEqual(_.indexOf([1, 2, 3], 1, true), 0);
 
     index = _.indexOf([], void 0, true);
-    assert.equal(index, -1, 'empty array with truthy `isSorted` returns -1');
+    assert.strictEqual(index, -1, 'empty array with truthy `isSorted` returns -1');
   });
 
   QUnit.test('indexOf with NaN', function(assert) {
@@ -371,26 +371,26 @@
   QUnit.test('lastIndexOf', function(assert) {
     var numbers = [1, 0, 1];
     var falsey = [void 0, '', 0, false, NaN, null, void 0];
-    assert.equal(_.lastIndexOf(numbers, 1), 2);
+    assert.strictEqual(_.lastIndexOf(numbers, 1), 2);
 
     numbers = [1, 0, 1, 0, 0, 1, 0, 0, 0];
     numbers.lastIndexOf = null;
-    assert.equal(_.lastIndexOf(numbers, 1), 5, 'can compute lastIndexOf, even without the native function');
-    assert.equal(_.lastIndexOf(numbers, 0), 8, 'lastIndexOf the other element');
+    assert.strictEqual(_.lastIndexOf(numbers, 1), 5, 'can compute lastIndexOf, even without the native function');
+    assert.strictEqual(_.lastIndexOf(numbers, 0), 8, 'lastIndexOf the other element');
     var result = (function(){ return _.lastIndexOf(arguments, 1); }(1, 0, 1, 0, 0, 1, 0, 0, 0));
-    assert.equal(result, 5, 'works on an arguments object');
+    assert.strictEqual(result, 5, 'works on an arguments object');
 
     _.each([null, void 0, [], false], function(val) {
       var msg = 'Handles: ' + (_.isArray(val) ? '[]' : val);
-      assert.equal(_.lastIndexOf(val, 2), -1, msg);
-      assert.equal(_.lastIndexOf(val, 2, -1), -1, msg);
-      assert.equal(_.lastIndexOf(val, 2, -20), -1, msg);
-      assert.equal(_.lastIndexOf(val, 2, 15), -1, msg);
+      assert.strictEqual(_.lastIndexOf(val, 2), -1, msg);
+      assert.strictEqual(_.lastIndexOf(val, 2, -1), -1, msg);
+      assert.strictEqual(_.lastIndexOf(val, 2, -20), -1, msg);
+      assert.strictEqual(_.lastIndexOf(val, 2, 15), -1, msg);
     });
 
     numbers = [1, 2, 3, 1, 2, 3, 1, 2, 3];
     var index = _.lastIndexOf(numbers, 2, 2);
-    assert.equal(index, 1, 'supports the fromIndex argument');
+    assert.strictEqual(index, 1, 'supports the fromIndex argument');
 
     var array = [1, 2, 3, 1, 2, 3];
 
@@ -454,33 +454,33 @@
       {a: 0, b: 0}
     ];
 
-    assert.equal(_.findIndex(objects, function(obj) {
+    assert.strictEqual(_.findIndex(objects, function(obj) {
       return obj.a === 0;
     }), 0);
 
-    assert.equal(_.findIndex(objects, function(obj) {
+    assert.strictEqual(_.findIndex(objects, function(obj) {
       return obj.b * obj.a === 4;
     }), 2);
 
-    assert.equal(_.findIndex(objects, 'a'), 1, 'Uses lookupIterator');
+    assert.strictEqual(_.findIndex(objects, 'a'), 1, 'Uses lookupIterator');
 
-    assert.equal(_.findIndex(objects, function(obj) {
+    assert.strictEqual(_.findIndex(objects, function(obj) {
       return obj.b * obj.a === 5;
     }), -1);
 
-    assert.equal(_.findIndex(null, _.noop), -1);
+    assert.strictEqual(_.findIndex(null, _.noop), -1);
     assert.strictEqual(_.findIndex(objects, function(a) {
       return a.foo === null;
     }), -1);
     _.findIndex([{a: 1}], function(a, key, obj) {
-      assert.equal(key, 0);
+      assert.strictEqual(key, 0);
       assert.deepEqual(obj, [{a: 1}]);
       assert.strictEqual(this, objects, 'called with context');
     }, objects);
 
     var sparse = [];
     sparse[20] = {a: 2, b: 2};
-    assert.equal(_.findIndex(sparse, function(obj) {
+    assert.strictEqual(_.findIndex(sparse, function(obj) {
       return obj && obj.b * obj.a === 4;
     }), 20, 'Works with sparse arrays');
 
@@ -497,33 +497,33 @@
       {a: 0, b: 0}
     ];
 
-    assert.equal(_.findLastIndex(objects, function(obj) {
+    assert.strictEqual(_.findLastIndex(objects, function(obj) {
       return obj.a === 0;
     }), 3);
 
-    assert.equal(_.findLastIndex(objects, function(obj) {
+    assert.strictEqual(_.findLastIndex(objects, function(obj) {
       return obj.b * obj.a === 4;
     }), 2);
 
-    assert.equal(_.findLastIndex(objects, 'a'), 2, 'Uses lookupIterator');
+    assert.strictEqual(_.findLastIndex(objects, 'a'), 2, 'Uses lookupIterator');
 
-    assert.equal(_.findLastIndex(objects, function(obj) {
+    assert.strictEqual(_.findLastIndex(objects, function(obj) {
       return obj.b * obj.a === 5;
     }), -1);
 
-    assert.equal(_.findLastIndex(null, _.noop), -1);
+    assert.strictEqual(_.findLastIndex(null, _.noop), -1);
     assert.strictEqual(_.findLastIndex(objects, function(a) {
       return a.foo === null;
     }), -1);
     _.findLastIndex([{a: 1}], function(a, key, obj) {
-      assert.equal(key, 0);
+      assert.strictEqual(key, 0);
       assert.deepEqual(obj, [{a: 1}]);
       assert.strictEqual(this, objects, 'called with context');
     }, objects);
 
     var sparse = [];
     sparse[20] = {a: 2, b: 2};
-    assert.equal(_.findLastIndex(sparse, function(obj) {
+    assert.strictEqual(_.findLastIndex(sparse, function(obj) {
       return obj && obj.b * obj.a === 4;
     }), 20, 'Works with sparse arrays');
 

--- a/test/chaining.js
+++ b/test/chaining.js
@@ -19,8 +19,8 @@
         return hash;
       }, {})
       .value();
-    assert.equal(counts.a, 16, 'counted all the letters in the song');
-    assert.equal(counts.e, 10, 'counted all the letters in the song');
+    assert.strictEqual(counts.a, 16, 'counted all the letters in the song');
+    assert.strictEqual(counts.e, 10, 'counted all the letters in the song');
   });
 
   QUnit.test('select/reject/sortBy', function(assert) {

--- a/test/collections.js
+++ b/test/collections.js
@@ -5,7 +5,7 @@
 
   QUnit.test('each', function(assert) {
     _.each([1, 2, 3], function(num, i) {
-      assert.equal(num, i + 1, 'each iterators provide value and iteration count');
+      assert.strictEqual(num, i + 1, 'each iterators provide value and iteration count');
     });
 
     var answers = [];
@@ -28,7 +28,7 @@
     var count = 0;
     obj = {1: 'foo', 2: 'bar', 3: 'baz'};
     _.each(obj, function(){ count++; });
-    assert.equal(count, 3, 'the fun should be called only 3 times');
+    assert.strictEqual(count, 3, 'the fun should be called only 3 times');
 
     var answer = null;
     _.each([1, 2, 3], function(num, index, arr){ if (_.include(arr, num)) answer = true; });
@@ -36,7 +36,7 @@
 
     answers = 0;
     _.each(null, function(){ ++answers; });
-    assert.equal(answers, 0, 'handles a null properly');
+    assert.strictEqual(answers, 0, 'handles a null properly');
 
     _.each(false, function(){});
 
@@ -122,14 +122,14 @@
         ++answers;
         return method === 'every' ? true : null;
       }, {});
-      assert.equal(answers, 100, method + ' enumerates [0, length)');
+      assert.strictEqual(answers, 100, method + ' enumerates [0, length)');
 
       var growingCollection = [1, 2, 3], count = 0;
       _[method](growingCollection, function() {
         if (count < 10) growingCollection.push(count++);
         return method === 'every' ? true : null;
       }, {});
-      assert.equal(count, 3, method + ' is resistant to length changes');
+      assert.strictEqual(count, 3, method + ' is resistant to length changes');
     });
 
     _.each(collection.concat(object), function(method) {
@@ -139,7 +139,7 @@
         return method === 'every' ? true : null;
       }, {});
 
-      assert.equal(count, 2, method + ' is resistant to property changes');
+      assert.strictEqual(count, 2, method + ' is resistant to property changes');
     });
   });
 
@@ -175,25 +175,25 @@
 
   QUnit.test('reduce', function(assert) {
     var sum = _.reduce([1, 2, 3], function(memo, num){ return memo + num; }, 0);
-    assert.equal(sum, 6, 'can sum up an array');
+    assert.strictEqual(sum, 6, 'can sum up an array');
 
     var context = {multiplier: 3};
     sum = _.reduce([1, 2, 3], function(memo, num){ return memo + num * this.multiplier; }, 0, context);
-    assert.equal(sum, 18, 'can reduce with a context object');
+    assert.strictEqual(sum, 18, 'can reduce with a context object');
 
     sum = _([1, 2, 3]).reduce(function(memo, num){ return memo + num; }, 0);
-    assert.equal(sum, 6, 'OO-style reduce');
+    assert.strictEqual(sum, 6, 'OO-style reduce');
 
     sum = _.reduce([1, 2, 3], function(memo, num){ return memo + num; });
-    assert.equal(sum, 6, 'default initial value');
+    assert.strictEqual(sum, 6, 'default initial value');
 
     var prod = _.reduce([1, 2, 3, 4], function(memo, num){ return memo * num; });
-    assert.equal(prod, 24, 'can reduce via multiplication');
+    assert.strictEqual(prod, 24, 'can reduce via multiplication');
 
     assert.strictEqual(_.reduce(null, _.noop, 138), 138, 'handles a null (with initial value) properly');
-    assert.equal(_.reduce([], _.noop, void 0), void 0, 'undefined can be passed as a special case');
-    assert.equal(_.reduce([_], _.noop), _, 'collection of length one with no initial value returns the first item');
-    assert.equal(_.reduce([], _.noop), void 0, 'returns undefined when collection is empty and no initial value');
+    assert.strictEqual(_.reduce([], _.noop, void 0), void 0, 'undefined can be passed as a special case');
+    assert.strictEqual(_.reduce([_], _.noop), _, 'collection of length one with no initial value returns the first item');
+    assert.strictEqual(_.reduce([], _.noop), void 0, 'returns undefined when collection is empty and no initial value');
   });
 
   QUnit.test('foldl', function(assert) {
@@ -206,19 +206,19 @@
 
   QUnit.test('reduceRight', function(assert) {
     var list = _.reduceRight(['foo', 'bar', 'baz'], function(memo, str){ return memo + str; }, '');
-    assert.equal(list, 'bazbarfoo', 'can perform right folds');
+    assert.strictEqual(list, 'bazbarfoo', 'can perform right folds');
 
     list = _.reduceRight(['foo', 'bar', 'baz'], function(memo, str){ return memo + str; });
-    assert.equal(list, 'bazbarfoo', 'default initial value');
+    assert.strictEqual(list, 'bazbarfoo', 'default initial value');
 
     var sum = _.reduceRight({a: 1, b: 2, c: 3}, function(memo, num){ return memo + num; });
-    assert.equal(sum, 6, 'default initial value on object');
+    assert.strictEqual(sum, 6, 'default initial value on object');
 
     assert.strictEqual(_.reduceRight(null, _.noop, 138), 138, 'handles a null (with initial value) properly');
-    assert.equal(_.reduceRight([_], _.noop), _, 'collection of length one with no initial value returns the first item');
+    assert.strictEqual(_.reduceRight([_], _.noop), _, 'collection of length one with no initial value returns the first item');
 
-    assert.equal(_.reduceRight([], _.noop, void 0), void 0, 'undefined can be passed as a special case');
-    assert.equal(_.reduceRight([], _.noop), void 0, 'returns undefined when collection is empty and no initial value');
+    assert.strictEqual(_.reduceRight([], _.noop, void 0), void 0, 'undefined can be passed as a special case');
+    assert.strictEqual(_.reduceRight([], _.noop), void 0, 'returns undefined when collection is empty and no initial value');
 
     // Assert that the correct arguments are being passed.
 
@@ -274,7 +274,7 @@
     assert.notOk(_.find([], {c: 1}), 'undefined when searching empty list');
 
     var result = _.find([1, 2, 3], function(num){ return num * 2 === 4; });
-    assert.equal(result, 2, 'found the first "2" and broke the loop');
+    assert.strictEqual(result, 2, 'found the first "2" and broke the loop');
 
     var obj = {
       a: {x: 1, z: 3},
@@ -290,7 +290,7 @@
     }), {x: 4, z: 1});
 
     _.findIndex([{a: 1}], function(a, key, o) {
-      assert.equal(key, 0);
+      assert.strictEqual(key, 0);
       assert.deepEqual(o, [{a: 1}]);
       assert.strictEqual(this, _, 'called with context');
     }, _);
@@ -310,7 +310,7 @@
     assert.deepEqual(_.filter([{}, evenObject, []], 'two'), [evenObject], 'predicate string map to object properties');
 
     _.filter([1], function() {
-      assert.equal(this, evenObject, 'given context');
+      assert.strictEqual(this, evenObject, 'given context');
     }, evenObject);
 
     // Can be used like _.where.
@@ -332,7 +332,7 @@
     var context = 'obj';
 
     var evens = _.reject([1, 2, 3, 4, 5, 6], function(num){
-      assert.equal(context, 'obj');
+      assert.strictEqual(context, 'obj');
       return num % 2 !== 0;
     }, context);
     assert.deepEqual(evens, [2, 4, 6], 'rejected each odd number');
@@ -489,12 +489,12 @@
     };
     var list = [[5, 1, 7], [3, 2, 1]];
     var s = 'foo';
-    assert.equal(s.call(), 42, 'call function exists');
+    assert.strictEqual(s.call(), 42, 'call function exists');
     var result = _.invoke(list, 'sort');
     assert.deepEqual(result[0], [1, 5, 7], 'first array sorted');
     assert.deepEqual(result[1], [1, 2, 3], 'second array sorted');
     delete String.prototype.call;
-    assert.equal(s.call, void 0, 'call function removed');
+    assert.strictEqual(s.call, void 0, 'call function removed');
   });
 
   QUnit.test('pluck', function(assert) {
@@ -508,13 +508,13 @@
   QUnit.test('where', function(assert) {
     var list = [{a: 1, b: 2}, {a: 2, b: 2}, {a: 1, b: 3}, {a: 1, b: 4}];
     var result = _.where(list, {a: 1});
-    assert.equal(result.length, 3);
-    assert.equal(result[result.length - 1].b, 4);
+    assert.strictEqual(result.length, 3);
+    assert.strictEqual(result[result.length - 1].b, 4);
     result = _.where(list, {b: 2});
-    assert.equal(result.length, 2);
-    assert.equal(result[0].a, 1);
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0].a, 1);
     result = _.where(list, {});
-    assert.equal(result.length, list.length);
+    assert.strictEqual(result.length, list.length);
 
     function test() {}
     test.map = _.map;
@@ -536,7 +536,7 @@
 
     function test() {}
     test.map = _.map;
-    assert.equal(_.findWhere([_, {a: 1, b: 2}, _], test), _, 'checks properties given function');
+    assert.strictEqual(_.findWhere([_, {a: 1, b: 2}, _], test), _, 'checks properties given function');
 
     function TestClass() {
       this.y = 5;
@@ -547,42 +547,42 @@
   });
 
   QUnit.test('max', function(assert) {
-    assert.equal(-Infinity, _.max(null), 'can handle null/undefined');
-    assert.equal(-Infinity, _.max(void 0), 'can handle null/undefined');
-    assert.equal(-Infinity, _.max(null, _.identity), 'can handle null/undefined');
+    assert.strictEqual(-Infinity, _.max(null), 'can handle null/undefined');
+    assert.strictEqual(-Infinity, _.max(void 0), 'can handle null/undefined');
+    assert.strictEqual(-Infinity, _.max(null, _.identity), 'can handle null/undefined');
 
-    assert.equal(_.max([1, 2, 3]), 3, 'can perform a regular Math.max');
+    assert.strictEqual(_.max([1, 2, 3]), 3, 'can perform a regular Math.max');
 
     var neg = _.max([1, 2, 3], function(num){ return -num; });
-    assert.equal(neg, 1, 'can perform a computation-based max');
+    assert.strictEqual(neg, 1, 'can perform a computation-based max');
 
-    assert.equal(-Infinity, _.max({}), 'Maximum value of an empty object');
-    assert.equal(-Infinity, _.max([]), 'Maximum value of an empty array');
-    assert.equal(_.max({a: 'a'}), -Infinity, 'Maximum value of a non-numeric collection');
+    assert.strictEqual(-Infinity, _.max({}), 'Maximum value of an empty object');
+    assert.strictEqual(-Infinity, _.max([]), 'Maximum value of an empty array');
+    assert.strictEqual(_.max({a: 'a'}), -Infinity, 'Maximum value of a non-numeric collection');
 
-    assert.equal(_.max(_.range(1, 300000)), 299999, 'Maximum value of a too-big array');
+    assert.strictEqual(_.max(_.range(1, 300000)), 299999, 'Maximum value of a too-big array');
 
-    assert.equal(_.max([1, 2, 3, 'test']), 3, 'Finds correct max in array starting with num and containing a NaN');
-    assert.equal(_.max(['test', 1, 2, 3]), 3, 'Finds correct max in array starting with NaN');
+    assert.strictEqual(_.max([1, 2, 3, 'test']), 3, 'Finds correct max in array starting with num and containing a NaN');
+    assert.strictEqual(_.max(['test', 1, 2, 3]), 3, 'Finds correct max in array starting with NaN');
 
-    assert.equal(_.max([1, 2, 3, null]), 3, 'Finds correct max in array starting with num and containing a `null`');
-    assert.equal(_.max([null, 1, 2, 3]), 3, 'Finds correct max in array starting with a `null`');
+    assert.strictEqual(_.max([1, 2, 3, null]), 3, 'Finds correct max in array starting with num and containing a `null`');
+    assert.strictEqual(_.max([null, 1, 2, 3]), 3, 'Finds correct max in array starting with a `null`');
 
-    assert.equal(_.max([1, 2, 3, '']), 3, 'Finds correct max in array starting with num and containing an empty string');
-    assert.equal(_.max(['', 1, 2, 3]), 3, 'Finds correct max in array starting with an empty string');
+    assert.strictEqual(_.max([1, 2, 3, '']), 3, 'Finds correct max in array starting with num and containing an empty string');
+    assert.strictEqual(_.max(['', 1, 2, 3]), 3, 'Finds correct max in array starting with an empty string');
 
-    assert.equal(_.max([1, 2, 3, false]), 3, 'Finds correct max in array starting with num and containing a false');
-    assert.equal(_.max([false, 1, 2, 3]), 3, 'Finds correct max in array starting with a false');
+    assert.strictEqual(_.max([1, 2, 3, false]), 3, 'Finds correct max in array starting with num and containing a false');
+    assert.strictEqual(_.max([false, 1, 2, 3]), 3, 'Finds correct max in array starting with a false');
 
-    assert.equal(_.max([0, 1, 2, 3, 4]), 4, 'Finds correct max in array containing a zero');
-    assert.equal(_.max([-3, -2, -1, 0]), 0, 'Finds correct max in array containing negative numbers');
+    assert.strictEqual(_.max([0, 1, 2, 3, 4]), 4, 'Finds correct max in array containing a zero');
+    assert.strictEqual(_.max([-3, -2, -1, 0]), 0, 'Finds correct max in array containing negative numbers');
 
     assert.deepEqual(_.map([[1, 2, 3], [4, 5, 6]], _.max), [3, 6], 'Finds correct max in array when mapping through multiple arrays');
 
     var a = {x: -Infinity};
     var b = {x: -Infinity};
     var iterator = function(o){ return o.x; };
-    assert.equal(_.max([a, b], iterator), a, 'Respects iterator return value of -Infinity');
+    assert.strictEqual(_.max([a, b], iterator), a, 'Respects iterator return value of -Infinity');
 
     assert.deepEqual(_.max([{a: 1}, {a: 0, b: 3}, {a: 4}, {a: 2}], 'a'), {a: 4}, 'String keys use property iterator');
 
@@ -592,40 +592,40 @@
   });
 
   QUnit.test('min', function(assert) {
-    assert.equal(_.min(null), Infinity, 'can handle null/undefined');
-    assert.equal(_.min(void 0), Infinity, 'can handle null/undefined');
-    assert.equal(_.min(null, _.identity), Infinity, 'can handle null/undefined');
+    assert.strictEqual(_.min(null), Infinity, 'can handle null/undefined');
+    assert.strictEqual(_.min(void 0), Infinity, 'can handle null/undefined');
+    assert.strictEqual(_.min(null, _.identity), Infinity, 'can handle null/undefined');
 
-    assert.equal(_.min([1, 2, 3]), 1, 'can perform a regular Math.min');
+    assert.strictEqual(_.min([1, 2, 3]), 1, 'can perform a regular Math.min');
 
     var neg = _.min([1, 2, 3], function(num){ return -num; });
-    assert.equal(neg, 3, 'can perform a computation-based min');
+    assert.strictEqual(neg, 3, 'can perform a computation-based min');
 
-    assert.equal(_.min({}), Infinity, 'Minimum value of an empty object');
-    assert.equal(_.min([]), Infinity, 'Minimum value of an empty array');
-    assert.equal(_.min({a: 'a'}), Infinity, 'Minimum value of a non-numeric collection');
+    assert.strictEqual(_.min({}), Infinity, 'Minimum value of an empty object');
+    assert.strictEqual(_.min([]), Infinity, 'Minimum value of an empty array');
+    assert.strictEqual(_.min({a: 'a'}), Infinity, 'Minimum value of a non-numeric collection');
 
     assert.deepEqual(_.map([[1, 2, 3], [4, 5, 6]], _.min), [1, 4], 'Finds correct min in array when mapping through multiple arrays');
 
     var now = new Date(9999999999);
     var then = new Date(0);
-    assert.equal(_.min([now, then]), then);
+    assert.strictEqual(_.min([now, then]), then);
 
-    assert.equal(_.min(_.range(1, 300000)), 1, 'Minimum value of a too-big array');
+    assert.strictEqual(_.min(_.range(1, 300000)), 1, 'Minimum value of a too-big array');
 
-    assert.equal(_.min([1, 2, 3, 'test']), 1, 'Finds correct min in array starting with num and containing a NaN');
-    assert.equal(_.min(['test', 1, 2, 3]), 1, 'Finds correct min in array starting with NaN');
+    assert.strictEqual(_.min([1, 2, 3, 'test']), 1, 'Finds correct min in array starting with num and containing a NaN');
+    assert.strictEqual(_.min(['test', 1, 2, 3]), 1, 'Finds correct min in array starting with NaN');
 
-    assert.equal(_.min([1, 2, 3, null]), 1, 'Finds correct min in array starting with num and containing a `null`');
-    assert.equal(_.min([null, 1, 2, 3]), 1, 'Finds correct min in array starting with a `null`');
+    assert.strictEqual(_.min([1, 2, 3, null]), 1, 'Finds correct min in array starting with num and containing a `null`');
+    assert.strictEqual(_.min([null, 1, 2, 3]), 1, 'Finds correct min in array starting with a `null`');
 
-    assert.equal(_.min([0, 1, 2, 3, 4]), 0, 'Finds correct min in array containing a zero');
-    assert.equal(_.min([-3, -2, -1, 0]), -3, 'Finds correct min in array containing negative numbers');
+    assert.strictEqual(_.min([0, 1, 2, 3, 4]), 0, 'Finds correct min in array containing a zero');
+    assert.strictEqual(_.min([-3, -2, -1, 0]), -3, 'Finds correct min in array containing negative numbers');
 
     var a = {x: Infinity};
     var b = {x: Infinity};
     var iterator = function(o){ return o.x; };
-    assert.equal(_.min([a, b], iterator), a, 'Respects iterator return value of Infinity');
+    assert.strictEqual(_.min([a, b], iterator), a, 'Respects iterator return value of Infinity');
 
     assert.deepEqual(_.min([{a: 1}, {a: 0, b: 3}, {a: 4}, {a: 2}], 'a'), {a: 0, b: 3}, 'String keys use property iterator');
 
@@ -699,16 +699,16 @@
     grouped = _.groupBy([4.2, 6.1, 6.4], function(num) {
       return Math.floor(num) > 4 ? 'hasOwnProperty' : 'constructor';
     });
-    assert.equal(grouped.constructor.length, 1);
-    assert.equal(grouped.hasOwnProperty.length, 2);
+    assert.strictEqual(grouped.constructor.length, 1);
+    assert.strictEqual(grouped.hasOwnProperty.length, 2);
 
     var array = [{}];
     _.groupBy(array, function(value, index, obj){ assert.strictEqual(obj, array); });
 
     array = [1, 2, 1, 2, 3];
     grouped = _.groupBy(array);
-    assert.equal(grouped['1'].length, 2);
-    assert.equal(grouped['3'].length, 1);
+    assert.strictEqual(grouped['1'].length, 2);
+    assert.strictEqual(grouped['3'].length, 1);
 
     var matrix = [
       [1, 2],
@@ -721,32 +721,32 @@
 
   QUnit.test('indexBy', function(assert) {
     var parity = _.indexBy([1, 2, 3, 4, 5], function(num){ return num % 2 === 0; });
-    assert.equal(parity['true'], 4);
-    assert.equal(parity['false'], 5);
+    assert.strictEqual(parity['true'], 4);
+    assert.strictEqual(parity['false'], 5);
 
     var list = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
     var grouped = _.indexBy(list, 'length');
-    assert.equal(grouped['3'], 'ten');
-    assert.equal(grouped['4'], 'nine');
-    assert.equal(grouped['5'], 'eight');
+    assert.strictEqual(grouped['3'], 'ten');
+    assert.strictEqual(grouped['4'], 'nine');
+    assert.strictEqual(grouped['5'], 'eight');
 
     var array = [1, 2, 1, 2, 3];
     grouped = _.indexBy(array);
-    assert.equal(grouped['1'], 1);
-    assert.equal(grouped['2'], 2);
-    assert.equal(grouped['3'], 3);
+    assert.strictEqual(grouped['1'], 1);
+    assert.strictEqual(grouped['2'], 2);
+    assert.strictEqual(grouped['3'], 3);
   });
 
   QUnit.test('countBy', function(assert) {
     var parity = _.countBy([1, 2, 3, 4, 5], function(num){ return num % 2 === 0; });
-    assert.equal(parity['true'], 2);
-    assert.equal(parity['false'], 3);
+    assert.strictEqual(parity['true'], 2);
+    assert.strictEqual(parity['false'], 3);
 
     var list = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
     var grouped = _.countBy(list, 'length');
-    assert.equal(grouped['3'], 4);
-    assert.equal(grouped['4'], 3);
-    assert.equal(grouped['5'], 3);
+    assert.strictEqual(grouped['3'], 4);
+    assert.strictEqual(grouped['4'], 3);
+    assert.strictEqual(grouped['5'], 3);
 
     var context = {};
     _.countBy([{}], function(){ assert.strictEqual(this, context); }, context);
@@ -754,16 +754,16 @@
     grouped = _.countBy([4.2, 6.1, 6.4], function(num) {
       return Math.floor(num) > 4 ? 'hasOwnProperty' : 'constructor';
     });
-    assert.equal(grouped.constructor, 1);
-    assert.equal(grouped.hasOwnProperty, 2);
+    assert.strictEqual(grouped.constructor, 1);
+    assert.strictEqual(grouped.hasOwnProperty, 2);
 
     var array = [{}];
     _.countBy(array, function(value, index, obj){ assert.strictEqual(obj, array); });
 
     array = [1, 2, 1, 2, 3];
     grouped = _.countBy(array);
-    assert.equal(grouped['1'], 2);
-    assert.equal(grouped['3'], 1);
+    assert.strictEqual(grouped['1'], 2);
+    assert.strictEqual(grouped['3'], 1);
   });
 
   QUnit.test('shuffle', function(assert) {
@@ -775,7 +775,7 @@
     assert.deepEqual(numbers, _.sortBy(shuffled), 'contains the same members before and after shuffle');
 
     shuffled = _.shuffle({a: 1, b: 2, c: 3, d: 4});
-    assert.equal(shuffled.length, 4);
+    assert.strictEqual(shuffled.length, 4);
     assert.deepEqual(shuffled.sort(), [1, 2, 3, 4], 'works on objects');
   });
 
@@ -825,21 +825,21 @@
   });
 
   QUnit.test('size', function(assert) {
-    assert.equal(_.size({one: 1, two: 2, three: 3}), 3, 'can compute the size of an object');
-    assert.equal(_.size([1, 2, 3]), 3, 'can compute the size of an array');
-    assert.equal(_.size({length: 3, 0: 0, 1: 0, 2: 0}), 3, 'can compute the size of Array-likes');
+    assert.strictEqual(_.size({one: 1, two: 2, three: 3}), 3, 'can compute the size of an object');
+    assert.strictEqual(_.size([1, 2, 3]), 3, 'can compute the size of an array');
+    assert.strictEqual(_.size({length: 3, 0: 0, 1: 0, 2: 0}), 3, 'can compute the size of Array-likes');
 
     var func = function() {
       return _.size(arguments);
     };
 
-    assert.equal(func(1, 2, 3, 4), 4, 'can test the size of the arguments object');
+    assert.strictEqual(func(1, 2, 3, 4), 4, 'can test the size of the arguments object');
 
-    assert.equal(_.size('hello'), 5, 'can compute the size of a string literal');
-    assert.equal(_.size(new String('hello')), 5, 'can compute the size of string object');
+    assert.strictEqual(_.size('hello'), 5, 'can compute the size of a string literal');
+    assert.strictEqual(_.size(new String('hello')), 5, 'can compute the size of string object');
 
-    assert.equal(_.size(null), 0, 'handles nulls');
-    assert.equal(_.size(0), 0, 'handles numbers');
+    assert.strictEqual(_.size(null), 0, 'handles nulls');
+    assert.strictEqual(_.size(0), 0, 'handles numbers');
   });
 
   QUnit.test('partition', function(assert) {
@@ -866,10 +866,10 @@
 
     var object = {a: 1};
     _.partition(object, function(val, key, obj) {
-      assert.equal(val, 1);
-      assert.equal(key, 'a');
-      assert.equal(obj, object);
-      assert.equal(this, predicate);
+      assert.strictEqual(val, 1);
+      assert.strictEqual(key, 'a');
+      assert.strictEqual(obj, object);
+      assert.strictEqual(this, predicate);
     }, predicate);
   });
 
@@ -879,7 +879,7 @@
       parent.innerHTML = '<span id=id1></span>textnode<span id=id2></span>';
 
       var elementChildren = _.filter(parent.childNodes, _.isElement);
-      assert.equal(elementChildren.length, 2);
+      assert.strictEqual(elementChildren.length, 2);
 
       assert.deepEqual(_.map(elementChildren, 'id'), ['id1', 'id2']);
       assert.deepEqual(_.map(parent.childNodes, 'nodeType'), [1, 3, 1]);
@@ -890,8 +890,8 @@
       function compareNode(node) {
         return _.isElement(node) ? node.id.charAt(2) : void 0;
       }
-      assert.equal(_.max(parent.childNodes, compareNode), _.last(parent.childNodes));
-      assert.equal(_.min(parent.childNodes, compareNode), _.first(parent.childNodes));
+      assert.strictEqual(_.max(parent.childNodes, compareNode), _.last(parent.childNodes));
+      assert.strictEqual(_.min(parent.childNodes, compareNode), _.first(parent.childNodes));
     });
   }
 

--- a/test/cross-document.js
+++ b/test/cross-document.js
@@ -132,9 +132,9 @@
         _.isFunction(fn);
       }
 
-      assert.equal(_.isFunction(xml), false);
-      assert.equal(_.isFunction(div), false);
-      assert.equal(_.isFunction(fn), true);
+      assert.strictEqual(_.isFunction(xml), false);
+      assert.strictEqual(_.isFunction(div), false);
+      assert.strictEqual(_.isFunction(fn), true);
     });
   }
 

--- a/test/functions.js
+++ b/test/functions.js
@@ -8,10 +8,10 @@
     var context = {name: 'moe'};
     var func = function(arg) { return 'name: ' + (this.name || arg); };
     var bound = _.bind(func, context);
-    assert.equal(bound(), 'name: moe', 'can bind a function to a context');
+    assert.strictEqual(bound(), 'name: moe', 'can bind a function to a context');
 
     bound = _(func).bind(context);
-    assert.equal(bound(), 'name: moe', 'can do OO-style binding');
+    assert.strictEqual(bound(), 'name: moe', 'can do OO-style binding');
 
     bound = _.bind(func, null, 'curly');
     var result = bound();
@@ -20,14 +20,14 @@
 
     func = function(salutation, name) { return salutation + ': ' + name; };
     func = _.bind(func, this, 'hello');
-    assert.equal(func('moe'), 'hello: moe', 'the function was partially applied in advance');
+    assert.strictEqual(func('moe'), 'hello: moe', 'the function was partially applied in advance');
 
     func = _.bind(func, this, 'curly');
-    assert.equal(func(), 'hello: curly', 'the function was completely applied in advance');
+    assert.strictEqual(func(), 'hello: curly', 'the function was completely applied in advance');
 
     func = function(salutation, firstname, lastname) { return salutation + ': ' + firstname + ' ' + lastname; };
     func = _.bind(func, this, 'hello', 'moe', 'curly');
-    assert.equal(func(), 'hello: moe curly', 'the function was partially applied in advance and can accept multiple arguments');
+    assert.strictEqual(func(), 'hello: moe curly', 'the function was partially applied in advance and can accept multiple arguments');
 
     func = function() { return this; };
     assert.strictEqual(typeof _.bind(func, 0)(), 'object', 'binding a primitive to `this` returns a wrapped primitive');
@@ -42,8 +42,8 @@
     var boundf = _.bind(F, {hello: 'moe curly'});
     var Boundf = boundf; // make eslint happy.
     var newBoundf = new Boundf();
-    assert.equal(newBoundf.hello, void 0, 'function should not be bound to the context, to comply with ECMAScript 5');
-    assert.equal(boundf().hello, 'moe curly', "When called without the new operator, it's OK to be bound to the context");
+    assert.strictEqual(newBoundf.hello, void 0, 'function should not be bound to the context, to comply with ECMAScript 5');
+    assert.strictEqual(boundf().hello, 'moe curly', "When called without the new operator, it's OK to be bound to the context");
     assert.ok(newBoundf instanceof F, 'a bound instance is an instance of the original function');
 
     assert.raises(function() { _.bind('notafunction'); }, TypeError, 'throws an error when binding to a non-function');
@@ -54,17 +54,17 @@
     var func = function() { return this.name + ' ' + _.toArray(arguments).join(' '); };
 
     obj.func = _.partial(func, 'a', 'b');
-    assert.equal(obj.func('c', 'd'), 'moe a b c d', 'can partially apply');
+    assert.strictEqual(obj.func('c', 'd'), 'moe a b c d', 'can partially apply');
 
     obj.func = _.partial(func, _, 'b', _, 'd');
-    assert.equal(obj.func('a', 'c'), 'moe a b c d', 'can partially apply with placeholders');
+    assert.strictEqual(obj.func('a', 'c'), 'moe a b c d', 'can partially apply with placeholders');
 
     func = _.partial(function() { return arguments.length; }, _, 'b', _, 'd');
-    assert.equal(func('a', 'c', 'e'), 5, 'accepts more arguments than the number of placeholders');
-    assert.equal(func('a'), 4, 'accepts fewer arguments than the number of placeholders');
+    assert.strictEqual(func('a', 'c', 'e'), 5, 'accepts more arguments than the number of placeholders');
+    assert.strictEqual(func('a'), 4, 'accepts fewer arguments than the number of placeholders');
 
     func = _.partial(function() { return typeof arguments[2]; }, _, 'b', _, 'd');
-    assert.equal(func('a'), 'undefined', 'unfilled placeholders are undefined');
+    assert.strictEqual(func('a'), 'undefined', 'unfilled placeholders are undefined');
 
     // passes context
     function MyWidget(name, options) {
@@ -77,16 +77,16 @@
     var MyWidgetWithCoolOpts = _.partial(MyWidget, _, {a: 1});
     var widget = new MyWidgetWithCoolOpts('foo');
     assert.ok(widget instanceof MyWidget, 'Can partially bind a constructor');
-    assert.equal(widget.get(), 'foo', 'keeps prototype');
+    assert.strictEqual(widget.get(), 'foo', 'keeps prototype');
     assert.deepEqual(widget.options, {a: 1});
 
     _.partial.placeholder = obj;
     func = _.partial(function() { return arguments.length; }, obj, 'b', obj, 'd');
-    assert.equal(func('a'), 4, 'allows the placeholder to be swapped out');
+    assert.strictEqual(func('a'), 4, 'allows the placeholder to be swapped out');
 
     _.partial.placeholder = {};
     func = _.partial(function() { return arguments.length; }, obj, 'b', obj, 'd');
-    assert.equal(func('a'), 5, 'swapping the placeholder preserves previously bound arguments');
+    assert.strictEqual(func('a'), 5, 'swapping the placeholder preserves previously bound arguments');
 
     _.partial.placeholder = _;
   });
@@ -101,8 +101,8 @@
     curly.getName = moe.getName;
     _.bindAll(moe, 'getName', 'sayHi');
     curly.sayHi = moe.sayHi;
-    assert.equal(curly.getName(), 'name: curly', 'unbound function is bound to current object');
-    assert.equal(curly.sayHi(), 'hi: moe', 'bound function is still bound to original object');
+    assert.strictEqual(curly.getName(), 'name: curly', 'unbound function is bound to current object');
+    assert.strictEqual(curly.sayHi(), 'hi: moe', 'bound function is still bound to original object');
 
     curly = {name: 'curly'};
     moe = {
@@ -118,41 +118,41 @@
 
     _.bindAll(moe, 'sayHi', 'sayLast');
     curly.sayHi = moe.sayHi;
-    assert.equal(curly.sayHi(), 'hi: moe');
+    assert.strictEqual(curly.sayHi(), 'hi: moe');
 
     var sayLast = moe.sayLast;
-    assert.equal(sayLast(1, 2, 3, 4, 5, 6, 7, 'Tom'), 'hi: moe', 'createCallback works with any number of arguments');
+    assert.strictEqual(sayLast(1, 2, 3, 4, 5, 6, 7, 'Tom'), 'hi: moe', 'createCallback works with any number of arguments');
 
     _.bindAll(moe, ['getName']);
     var getName = moe.getName;
-    assert.equal(getName(), 'name: moe', 'flattens arguments into a single list');
+    assert.strictEqual(getName(), 'name: moe', 'flattens arguments into a single list');
   });
 
   QUnit.test('memoize', function(assert) {
     var fib = function(n) {
       return n < 2 ? n : fib(n - 1) + fib(n - 2);
     };
-    assert.equal(fib(10), 55, 'a memoized version of fibonacci produces identical results');
+    assert.strictEqual(fib(10), 55, 'a memoized version of fibonacci produces identical results');
     fib = _.memoize(fib); // Redefine `fib` for memoization
-    assert.equal(fib(10), 55, 'a memoized version of fibonacci produces identical results');
+    assert.strictEqual(fib(10), 55, 'a memoized version of fibonacci produces identical results');
 
     var o = function(str) {
       return str;
     };
     var fastO = _.memoize(o);
-    assert.equal(o('toString'), 'toString', 'checks hasOwnProperty');
-    assert.equal(fastO('toString'), 'toString', 'checks hasOwnProperty');
+    assert.strictEqual(o('toString'), 'toString', 'checks hasOwnProperty');
+    assert.strictEqual(fastO('toString'), 'toString', 'checks hasOwnProperty');
 
     // Expose the cache.
     var upper = _.memoize(function(s) {
       return s.toUpperCase();
     });
-    assert.equal(upper('foo'), 'FOO');
-    assert.equal(upper('bar'), 'BAR');
+    assert.strictEqual(upper('foo'), 'FOO');
+    assert.strictEqual(upper('bar'), 'BAR');
     assert.deepEqual(upper.cache, {foo: 'FOO', bar: 'BAR'});
     upper.cache = {foo: 'BAR', bar: 'FOO'};
-    assert.equal(upper('foo'), 'BAR');
-    assert.equal(upper('bar'), 'FOO');
+    assert.strictEqual(upper('foo'), 'BAR');
+    assert.strictEqual(upper('bar'), 'FOO');
 
     var hashed = _.memoize(function(key) {
       //https://github.com/jashkenas/underscore/pull/1679#discussion_r13736209
@@ -202,8 +202,8 @@
     var throttledIncr = _.throttle(incr, 32);
     throttledIncr(); throttledIncr();
 
-    assert.equal(counter, 1, 'incr was called immediately');
-    _.delay(function(){ assert.equal(counter, 2, 'incr was throttled'); done(); }, 64);
+    assert.strictEqual(counter, 1, 'incr was called immediately');
+    _.delay(function(){ assert.strictEqual(counter, 2, 'incr was throttled'); done(); }, 64);
   });
 
   QUnit.test('throttle arguments', function(assert) {
@@ -214,8 +214,8 @@
     var throttledUpdate = _.throttle(update, 32);
     throttledUpdate(1); throttledUpdate(2);
     _.delay(function(){ throttledUpdate(3); }, 64);
-    assert.equal(value, 1, 'updated to latest value');
-    _.delay(function(){ assert.equal(value, 3, 'updated to latest value'); done(); }, 96);
+    assert.strictEqual(value, 1, 'updated to latest value');
+    _.delay(function(){ assert.strictEqual(value, 3, 'updated to latest value'); done(); }, 96);
   });
 
   QUnit.test('throttle once', function(assert) {
@@ -226,8 +226,8 @@
     var throttledIncr = _.throttle(incr, 32);
     var result = throttledIncr();
     _.delay(function(){
-      assert.equal(result, 1, 'throttled functions return their value');
-      assert.equal(counter, 1, 'incr was called once'); done();
+      assert.strictEqual(result, 1, 'throttled functions return their value');
+      assert.strictEqual(counter, 1, 'incr was called once'); done();
     }, 64);
   });
 
@@ -238,7 +238,7 @@
     var incr = function(){ counter++; };
     var throttledIncr = _.throttle(incr, 32);
     throttledIncr(); throttledIncr();
-    _.delay(function(){ assert.equal(counter, 2, 'incr was called twice'); done(); }, 64);
+    _.delay(function(){ assert.strictEqual(counter, 2, 'incr was called twice'); done(); }, 64);
   });
 
   QUnit.test('more throttling', function(assert) {
@@ -248,11 +248,11 @@
     var incr = function(){ counter++; };
     var throttledIncr = _.throttle(incr, 30);
     throttledIncr(); throttledIncr();
-    assert.equal(counter, 1);
+    assert.strictEqual(counter, 1);
     _.delay(function(){
-      assert.equal(counter, 2);
+      assert.strictEqual(counter, 2);
       throttledIncr();
-      assert.equal(counter, 3);
+      assert.strictEqual(counter, 3);
       done();
     }, 85);
   });
@@ -271,12 +271,12 @@
     _.delay(saveResult, 160);
     _.delay(saveResult, 230);
     _.delay(function() {
-      assert.equal(results[0], 1, 'incr was called once');
-      assert.equal(results[1], 1, 'incr was throttled');
-      assert.equal(results[2], 1, 'incr was throttled');
-      assert.equal(results[3], 2, 'incr was called twice');
-      assert.equal(results[4], 2, 'incr was throttled');
-      assert.equal(results[5], 3, 'incr was called trailing');
+      assert.strictEqual(results[0], 1, 'incr was called once');
+      assert.strictEqual(results[1], 1, 'incr was throttled');
+      assert.strictEqual(results[2], 1, 'incr was throttled');
+      assert.strictEqual(results[3], 2, 'incr was called twice');
+      assert.strictEqual(results[4], 2, 'incr was throttled');
+      assert.strictEqual(results[5], 3, 'incr was called trailing');
       done();
     }, 300);
   });
@@ -310,10 +310,10 @@
     var throttledIncr = _.throttle(incr, 60, {leading: false});
 
     throttledIncr(); throttledIncr();
-    assert.equal(counter, 0);
+    assert.strictEqual(counter, 0);
 
     _.delay(function() {
-      assert.equal(counter, 1);
+      assert.strictEqual(counter, 1);
       done();
     }, 96);
   });
@@ -329,14 +329,14 @@
     _.delay(throttledIncr, 50);
     _.delay(throttledIncr, 60);
     _.delay(throttledIncr, 200);
-    assert.equal(counter, 0);
+    assert.strictEqual(counter, 0);
 
     _.delay(function() {
-      assert.equal(counter, 1);
+      assert.strictEqual(counter, 1);
     }, 250);
 
     _.delay(function() {
-      assert.equal(counter, 2);
+      assert.strictEqual(counter, 2);
       done();
     }, 350);
   });
@@ -366,16 +366,16 @@
     var throttledIncr = _.throttle(incr, 60, {trailing: false});
 
     throttledIncr(); throttledIncr(); throttledIncr();
-    assert.equal(counter, 1);
+    assert.strictEqual(counter, 1);
 
     _.delay(function() {
-      assert.equal(counter, 1);
+      assert.strictEqual(counter, 1);
 
       throttledIncr(); throttledIncr();
-      assert.equal(counter, 2);
+      assert.strictEqual(counter, 2);
 
       _.delay(function() {
-        assert.equal(counter, 2);
+        assert.strictEqual(counter, 2);
         done();
       }, 96);
     }, 96);
@@ -390,14 +390,14 @@
     var origNowFunc = _.now;
 
     throttledIncr();
-    assert.equal(counter, 1);
+    assert.strictEqual(counter, 1);
     _.now = function() {
       return new Date(2013, 0, 1, 1, 1, 1);
     };
 
     _.delay(function() {
       throttledIncr();
-      assert.equal(counter, 2);
+      assert.strictEqual(counter, 2);
       done();
       _.now = origNowFunc;
     }, 200);
@@ -421,9 +421,9 @@
     };
     throttledAppend = _.throttle(append, 32);
     throttledAppend.call('a1', 'a2');
-    assert.equal(value, 'a1a2');
+    assert.strictEqual(value, 'a1a2');
     _.delay(function(){
-      assert.equal(value, 'a1a2c1c2b1b2', 'append was throttled successfully');
+      assert.strictEqual(value, 'a1a2c1c2b1b2', 'append was throttled successfully');
       done();
     }, 100);
   });
@@ -438,8 +438,8 @@
     throttledIncr();
     throttledIncr();
 
-    assert.equal(counter, 2, 'incr was called immediately');
-    _.delay(function(){ assert.equal(counter, 3, 'incr was throttled'); done(); }, 64);
+    assert.strictEqual(counter, 2, 'incr was called immediately');
+    _.delay(function(){ assert.strictEqual(counter, 3, 'incr was throttled'); done(); }, 64);
   });
 
   QUnit.test('throttle cancel with leading: false', function(assert) {
@@ -450,8 +450,8 @@
     throttledIncr();
     throttledIncr.cancel();
 
-    assert.equal(counter, 0, 'incr was throttled');
-    _.delay(function(){ assert.equal(counter, 0, 'incr was throttled'); done(); }, 64);
+    assert.strictEqual(counter, 0, 'incr was throttled');
+    _.delay(function(){ assert.strictEqual(counter, 0, 'incr was throttled'); done(); }, 64);
   });
 
   QUnit.test('debounce', function(assert) {
@@ -462,7 +462,7 @@
     var debouncedIncr = _.debounce(incr, 32);
     debouncedIncr(); debouncedIncr();
     _.delay(debouncedIncr, 16);
-    _.delay(function(){ assert.equal(counter, 1, 'incr was debounced'); done(); }, 96);
+    _.delay(function(){ assert.strictEqual(counter, 1, 'incr was debounced'); done(); }, 96);
   });
 
   QUnit.test('debounce cancel', function(assert) {
@@ -473,7 +473,7 @@
     var debouncedIncr = _.debounce(incr, 32);
     debouncedIncr();
     debouncedIncr.cancel();
-    _.delay(function(){ assert.equal(counter, 0, 'incr was not called'); done(); }, 96);
+    _.delay(function(){ assert.strictEqual(counter, 0, 'incr was not called'); done(); }, 96);
   });
 
   QUnit.test('debounce asap', function(assert) {
@@ -485,17 +485,17 @@
     var debouncedIncr = _.debounce(incr, 64, true);
     a = debouncedIncr();
     b = debouncedIncr();
-    assert.equal(a, 1);
-    assert.equal(b, 1);
-    assert.equal(counter, 1, 'incr was called immediately');
+    assert.strictEqual(a, 1);
+    assert.strictEqual(b, 1);
+    assert.strictEqual(counter, 1, 'incr was called immediately');
     _.delay(debouncedIncr, 16);
     _.delay(debouncedIncr, 32);
     _.delay(debouncedIncr, 48);
     _.delay(function(){
-      assert.equal(counter, 1, 'incr was debounced');
+      assert.strictEqual(counter, 1, 'incr was debounced');
       c = debouncedIncr();
-      assert.equal(c, 2);
-      assert.equal(counter, 2, 'incr was called again');
+      assert.strictEqual(c, 2);
+      assert.strictEqual(counter, 2, 'incr was called again');
       done();
     }, 128);
   });
@@ -510,13 +510,13 @@
     a = debouncedIncr();
     debouncedIncr.cancel();
     b = debouncedIncr();
-    assert.equal(a, 1);
-    assert.equal(b, 2);
-    assert.equal(counter, 2, 'incr was called immediately');
+    assert.strictEqual(a, 1);
+    assert.strictEqual(b, 2);
+    assert.strictEqual(counter, 2, 'incr was called immediately');
     _.delay(debouncedIncr, 16);
     _.delay(debouncedIncr, 32);
     _.delay(debouncedIncr, 48);
-    _.delay(function(){ assert.equal(counter, 2, 'incr was debounced'); done(); }, 128);
+    _.delay(function(){ assert.strictEqual(counter, 2, 'incr was debounced'); done(); }, 128);
   });
 
   QUnit.test('debounce asap recursively', function(assert) {
@@ -528,8 +528,8 @@
       if (counter < 10) debouncedIncr();
     }, 32, true);
     debouncedIncr();
-    assert.equal(counter, 1, 'incr was called immediately');
-    _.delay(function(){ assert.equal(counter, 1, 'incr was debounced'); done(); }, 96);
+    assert.strictEqual(counter, 1, 'incr was called immediately');
+    _.delay(function(){ assert.strictEqual(counter, 1, 'incr was debounced'); done(); }, 96);
   });
 
   QUnit.test('debounce after system time is set backwards', function(assert) {
@@ -542,7 +542,7 @@
     }, 100, true);
 
     debouncedIncr();
-    assert.equal(counter, 1, 'incr was called immediately');
+    assert.strictEqual(counter, 1, 'incr was called immediately');
 
     _.now = function() {
       return new Date(2013, 0, 1, 1, 1, 1);
@@ -550,7 +550,7 @@
 
     _.delay(function() {
       debouncedIncr();
-      assert.equal(counter, 2, 'incr was debounced successfully');
+      assert.strictEqual(counter, 2, 'incr was debounced successfully');
       done();
       _.now = origNowFunc;
     }, 200);
@@ -573,9 +573,9 @@
     };
     debouncedAppend = _.debounce(append, 32);
     debouncedAppend.call('a1', 'a2');
-    assert.equal(value, '');
+    assert.strictEqual(value, '');
     _.delay(function(){
-      assert.equal(value, 'a1a2b1b2', 'append was debounced successfully');
+      assert.strictEqual(value, 'a1a2b1b2', 'append was debounced successfully');
       done();
     }, 100);
   });
@@ -585,9 +585,9 @@
     var increment = _.once(function(){ return ++num; });
     increment();
     increment();
-    assert.equal(num, 1);
+    assert.strictEqual(num, 1);
 
-    assert.equal(increment(), 1, 'stores a memo to the last value');
+    assert.strictEqual(increment(), 1, 'stores a memo to the last value');
   });
 
   QUnit.test('Recursive onced function.', function(assert) {
@@ -602,12 +602,12 @@
   QUnit.test('wrap', function(assert) {
     var greet = function(name){ return 'hi: ' + name; };
     var backwards = _.wrap(greet, function(func, name){ return func(name) + ' ' + name.split('').reverse().join(''); });
-    assert.equal(backwards('moe'), 'hi: moe eom', 'wrapped the salutation function');
+    assert.strictEqual(backwards('moe'), 'hi: moe eom', 'wrapped the salutation function');
 
     var inner = function(){ return 'Hello '; };
     var obj = {name: 'Moe'};
     obj.hi = _.wrap(inner, function(fn){ return fn() + this.name; });
-    assert.equal(obj.hi(), 'Hello Moe');
+    assert.strictEqual(obj.hi(), 'Hello Moe');
 
     var noop = function(){};
     var wrapped = _.wrap(noop, function(){ return Array.prototype.slice.call(arguments, 0); });
@@ -617,34 +617,34 @@
 
   QUnit.test('negate', function(assert) {
     var isOdd = function(n){ return n & 1; };
-    assert.equal(_.negate(isOdd)(2), true, 'should return the complement of the given function');
-    assert.equal(_.negate(isOdd)(3), false, 'should return the complement of the given function');
+    assert.strictEqual(_.negate(isOdd)(2), true, 'should return the complement of the given function');
+    assert.strictEqual(_.negate(isOdd)(3), false, 'should return the complement of the given function');
   });
 
   QUnit.test('compose', function(assert) {
     var greet = function(name){ return 'hi: ' + name; };
     var exclaim = function(sentence){ return sentence + '!'; };
     var composed = _.compose(exclaim, greet);
-    assert.equal(composed('moe'), 'hi: moe!', 'can compose a function that takes another');
+    assert.strictEqual(composed('moe'), 'hi: moe!', 'can compose a function that takes another');
 
     composed = _.compose(greet, exclaim);
-    assert.equal(composed('moe'), 'hi: moe!', 'in this case, the functions are also commutative');
+    assert.strictEqual(composed('moe'), 'hi: moe!', 'in this case, the functions are also commutative');
 
     // f(g(h(x, y, z)))
     function h(x, y, z) {
-      assert.equal(arguments.length, 3, 'First function called with multiple args');
+      assert.strictEqual(arguments.length, 3, 'First function called with multiple args');
       return z * y;
     }
     function g(x) {
-      assert.equal(arguments.length, 1, 'Composed function is called with 1 argument');
+      assert.strictEqual(arguments.length, 1, 'Composed function is called with 1 argument');
       return x;
     }
     function f(x) {
-      assert.equal(arguments.length, 1, 'Composed function is called with 1 argument');
+      assert.strictEqual(arguments.length, 1, 'Composed function is called with 1 argument');
       return x * 2;
     }
     composed = _.compose(f, g, h);
-    assert.equal(composed(1, 2, 3), 12);
+    assert.strictEqual(composed(1, 2, 3), 12);
   });
 
   QUnit.test('after', function(assert) {
@@ -657,10 +657,10 @@
       return afterCalled;
     };
 
-    assert.equal(testAfter(5, 5), 1, 'after(N) should fire after being called N times');
-    assert.equal(testAfter(5, 4), 0, 'after(N) should not fire unless called N times');
-    assert.equal(testAfter(0, 0), 0, 'after(0) should not fire immediately');
-    assert.equal(testAfter(0, 1), 1, 'after(0) should fire when first invoked');
+    assert.strictEqual(testAfter(5, 5), 1, 'after(N) should fire after being called N times');
+    assert.strictEqual(testAfter(5, 4), 0, 'after(N) should not fire unless called N times');
+    assert.strictEqual(testAfter(0, 0), 0, 'after(0) should not fire immediately');
+    assert.strictEqual(testAfter(0, 1), 1, 'after(0) should fire when first invoked');
   });
 
   QUnit.test('before', function(assert) {
@@ -671,27 +671,27 @@
       return beforeCalled;
     };
 
-    assert.equal(testBefore(5, 5), 4, 'before(N) should not fire after being called N times');
-    assert.equal(testBefore(5, 4), 4, 'before(N) should fire before being called N times');
-    assert.equal(testBefore(0, 0), 0, 'before(0) should not fire immediately');
-    assert.equal(testBefore(0, 1), 0, 'before(0) should not fire when first invoked');
+    assert.strictEqual(testBefore(5, 5), 4, 'before(N) should not fire after being called N times');
+    assert.strictEqual(testBefore(5, 4), 4, 'before(N) should fire before being called N times');
+    assert.strictEqual(testBefore(0, 0), 0, 'before(0) should not fire immediately');
+    assert.strictEqual(testBefore(0, 1), 0, 'before(0) should not fire when first invoked');
 
     var context = {num: 0};
     var increment = _.before(3, function(){ return ++this.num; });
     _.times(10, increment, context);
-    assert.equal(increment(), 2, 'stores a memo to the last value');
-    assert.equal(context.num, 2, 'provides context');
+    assert.strictEqual(increment(), 2, 'stores a memo to the last value');
+    assert.strictEqual(context.num, 2, 'provides context');
   });
 
   QUnit.test('iteratee', function(assert) {
     var identity = _.iteratee();
-    assert.equal(identity, _.identity, '_.iteratee is exposed as an external function.');
+    assert.strictEqual(identity, _.identity, '_.iteratee is exposed as an external function.');
 
     function fn() {
       return arguments;
     }
     _.each([_.iteratee(fn), _.iteratee(fn, {})], function(cb) {
-      assert.equal(cb().length, 0);
+      assert.strictEqual(cb().length, 0);
       assert.deepEqual(_.toArray(cb(1, 2, 3)), _.range(1, 4));
       assert.deepEqual(_.toArray(cb(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)), _.range(1, 11));
     });
@@ -710,22 +710,22 @@
 
     // Test all methods that claim to be transformed through `_.iteratee`
     assert.deepEqual(_.countBy(collection, /b/g), {0: 1, 1: 1, 2: 1});
-    assert.equal(_.every(collection, /b/g), false);
+    assert.strictEqual(_.every(collection, /b/g), false);
     assert.deepEqual(_.filter(collection, /b/g), ['bar', 'bbiz']);
-    assert.equal(_.find(collection, /b/g), 'bar');
-    assert.equal(_.findIndex(collection, /b/g), 1);
+    assert.strictEqual(_.find(collection, /b/g), 'bar');
+    assert.strictEqual(_.findIndex(collection, /b/g), 1);
     assert.strictEqual(_.findKey(collection, /b/g), '1');
-    assert.equal(_.findLastIndex(collection, /b/g), 2);
+    assert.strictEqual(_.findLastIndex(collection, /b/g), 2);
     assert.deepEqual(_.groupBy(collection, /b/g), {0: ['foo'], 1: ['bar'], 2: ['bbiz']});
     assert.deepEqual(_.indexBy(collection, /b/g), {0: 'foo', 1: 'bar', 2: 'bbiz'});
     assert.deepEqual(_.map(collection, /b/g), [0, 1, 2]);
-    assert.equal(_.max(collection, /b/g), 'bbiz');
-    assert.equal(_.min(collection, /b/g), 'foo');
+    assert.strictEqual(_.max(collection, /b/g), 'bbiz');
+    assert.strictEqual(_.min(collection, /b/g), 'foo');
     assert.deepEqual(_.partition(collection, /b/g), [['bar', 'bbiz'], ['foo']]);
     assert.deepEqual(_.reject(collection, /b/g), ['foo']);
-    assert.equal(_.some(collection, /b/g), true);
+    assert.strictEqual(_.some(collection, /b/g), true);
     assert.deepEqual(_.sortBy(collection, /b/g), ['foo', 'bar', 'bbiz']);
-    assert.equal(_.sortedIndex(collection, 'blah', /b/g), 1);
+    assert.strictEqual(_.sortedIndex(collection, 'blah', /b/g), 1);
     assert.deepEqual(_.uniq(collection, /b/g), ['foo', 'bar', 'bbiz']);
 
     var objCollection = {a: 'foo', b: 'bar', c: 'bbiz'};

--- a/test/objects.js
+++ b/test/objects.js
@@ -89,7 +89,7 @@
     assert.deepEqual(_.invert(_.invert(obj)), obj, 'two inverts gets you back where you started');
 
     obj = {length: 3};
-    assert.equal(_.invert(obj)['3'], 'length', 'can invert an object with "length"');
+    assert.strictEqual(_.invert(obj)['3'], 'length', 'can invert an object with "length"');
   });
 
   QUnit.test('functions', function(assert) {
@@ -107,9 +107,9 @@
 
   QUnit.test('extend', function(assert) {
     var result;
-    assert.equal(_.extend({}, {a: 'b'}).a, 'b', 'can extend an object with the attributes of another');
-    assert.equal(_.extend({a: 'x'}, {a: 'b'}).a, 'b', 'properties in source override destination');
-    assert.equal(_.extend({x: 'x'}, {a: 'b'}).x, 'x', "properties not in source don't get overriden");
+    assert.strictEqual(_.extend({}, {a: 'b'}).a, 'b', 'can extend an object with the attributes of another');
+    assert.strictEqual(_.extend({a: 'x'}, {a: 'b'}).a, 'b', 'properties in source override destination');
+    assert.strictEqual(_.extend({x: 'x'}, {a: 'b'}).x, 'x', "properties not in source don't get overriden");
     result = _.extend({x: 'x'}, {a: 'a'}, {b: 'b'});
     assert.deepEqual(result, {x: 'x', a: 'a', b: 'b'}, 'can extend from multiple source objects');
     result = _.extend({x: 'x'}, {a: 'a', x: 2}, {a: 'b'});
@@ -130,7 +130,7 @@
       _.extend(result, null, void 0, {a: 1});
     } catch (e) { /* ignored */ }
 
-    assert.equal(result.a, 1, 'should not error on `null` or `undefined` sources');
+    assert.strictEqual(result.a, 1, 'should not error on `null` or `undefined` sources');
 
     assert.strictEqual(_.extend(null, {a: 1}), null, 'extending null results in null');
     assert.strictEqual(_.extend(void 0, {a: 1}), void 0, 'extending undefined results in undefined');
@@ -138,9 +138,9 @@
 
   QUnit.test('extendOwn', function(assert) {
     var result;
-    assert.equal(_.extendOwn({}, {a: 'b'}).a, 'b', 'can extend an object with the attributes of another');
-    assert.equal(_.extendOwn({a: 'x'}, {a: 'b'}).a, 'b', 'properties in source override destination');
-    assert.equal(_.extendOwn({x: 'x'}, {a: 'b'}).x, 'x', "properties not in source don't get overriden");
+    assert.strictEqual(_.extendOwn({}, {a: 'b'}).a, 'b', 'can extend an object with the attributes of another');
+    assert.strictEqual(_.extendOwn({a: 'x'}, {a: 'b'}).a, 'b', 'properties in source override destination');
+    assert.strictEqual(_.extendOwn({x: 'x'}, {a: 'b'}).x, 'x', "properties not in source don't get overriden");
     result = _.extendOwn({x: 'x'}, {a: 'a'}, {b: 'b'});
     assert.deepEqual(result, {x: 'x', a: 'a', b: 'b'}, 'can extend from multiple source objects');
     result = _.extendOwn({x: 'x'}, {a: 'a', x: 2}, {a: 'b'});
@@ -207,7 +207,7 @@
 
     assert.notOk(_.has(_.pick({}, 'foo'), 'foo'), 'does not set own property if property not in object');
     _.pick(data, function(value, key, obj) {
-      assert.equal(obj, data, 'passes same object as third parameter of iteratee');
+      assert.strictEqual(obj, data, 'passes same object as third parameter of iteratee');
     });
   });
 
@@ -249,22 +249,22 @@
     var options = {zero: 0, one: 1, empty: '', nan: NaN, nothing: null};
 
     _.defaults(options, {zero: 1, one: 10, twenty: 20, nothing: 'str'});
-    assert.equal(options.zero, 0, 'value exists');
-    assert.equal(options.one, 1, 'value exists');
-    assert.equal(options.twenty, 20, 'default applied');
-    assert.equal(options.nothing, null, "null isn't overridden");
+    assert.strictEqual(options.zero, 0, 'value exists');
+    assert.strictEqual(options.one, 1, 'value exists');
+    assert.strictEqual(options.twenty, 20, 'default applied');
+    assert.strictEqual(options.nothing, null, "null isn't overridden");
 
     _.defaults(options, {empty: 'full'}, {nan: 'nan'}, {word: 'word'}, {word: 'dog'});
-    assert.equal(options.empty, '', 'value exists');
+    assert.strictEqual(options.empty, '', 'value exists');
     assert.ok(_.isNaN(options.nan), "NaN isn't overridden");
-    assert.equal(options.word, 'word', 'new value is added, first one wins');
+    assert.strictEqual(options.word, 'word', 'new value is added, first one wins');
 
     try {
       options = {};
       _.defaults(options, null, void 0, {a: 1});
     } catch (e) { /* ignored */ }
 
-    assert.equal(options.a, 1, 'should not error on `null` or `undefined` sources');
+    assert.strictEqual(options.a, 1, 'should not error on `null` or `undefined` sources');
 
     assert.deepEqual(_.defaults(null, {a: 1}), {a: 1}, 'defaults skips nulls');
     assert.deepEqual(_.defaults(void 0, {a: 1}), {a: 1}, 'defaults skips undefined');
@@ -273,17 +273,17 @@
   QUnit.test('clone', function(assert) {
     var moe = {name: 'moe', lucky: [13, 27, 34]};
     var clone = _.clone(moe);
-    assert.equal(clone.name, 'moe', 'the clone as the attributes of the original');
+    assert.strictEqual(clone.name, 'moe', 'the clone as the attributes of the original');
 
     clone.name = 'curly';
     assert.ok(clone.name === 'curly' && moe.name === 'moe', 'clones can change shallow attributes without affecting the original');
 
     clone.lucky.push(101);
-    assert.equal(_.last(moe.lucky), 101, 'changes to deep attributes are shared with the original');
+    assert.strictEqual(_.last(moe.lucky), 101, 'changes to deep attributes are shared with the original');
 
-    assert.equal(_.clone(void 0), void 0, 'non objects should not be changed by clone');
-    assert.equal(_.clone(1), 1, 'non objects should not be changed by clone');
-    assert.equal(_.clone(null), null, 'non objects should not be changed by clone');
+    assert.strictEqual(_.clone(void 0), void 0, 'non objects should not be changed by clone');
+    assert.strictEqual(_.clone(1), 1, 'non objects should not be changed by clone');
+    assert.strictEqual(_.clone(null), null, 'non objects should not be changed by clone');
   });
 
   QUnit.test('create', function(assert) {
@@ -544,7 +544,7 @@
 
     a = _({x: 1, y: 2}).chain();
     b = _({x: 1, y: 2}).chain();
-    assert.equal(_.isEqual(a.isEqual(b), _(true)), true, '`isEqual` can be chained');
+    assert.strictEqual(_.isEqual(a.isEqual(b), _(true)), true, '`isEqual` can be chained');
 
     // Objects without a `constructor` property
     if (Object.create) {
@@ -561,10 +561,10 @@
 
 
     // Tricky object cases val comparisions
-    assert.equal(_.isEqual([0], [-0]), false);
-    assert.equal(_.isEqual({a: 0}, {a: -0}), false);
-    assert.equal(_.isEqual([NaN], [NaN]), true);
-    assert.equal(_.isEqual({a: NaN}, {a: NaN}), true);
+    assert.strictEqual(_.isEqual([0], [-0]), false);
+    assert.strictEqual(_.isEqual({a: 0}, {a: -0}), false);
+    assert.strictEqual(_.isEqual([NaN], [NaN]), true);
+    assert.strictEqual(_.isEqual({a: NaN}, {a: NaN}), true);
 
     if (typeof Symbol !== 'undefined') {
       var symbol = Symbol('x');
@@ -881,16 +881,16 @@
     var intercepted = null;
     var interceptor = function(obj) { intercepted = obj; };
     var returned = _.tap(1, interceptor);
-    assert.equal(intercepted, 1, 'passes tapped object to interceptor');
-    assert.equal(returned, 1, 'returns tapped object');
+    assert.strictEqual(intercepted, 1, 'passes tapped object to interceptor');
+    assert.strictEqual(returned, 1, 'returns tapped object');
 
     returned = _([1, 2, 3]).chain().
       map(function(n){ return n * 2; }).
       max().
       tap(interceptor).
       value();
-    assert.equal(returned, 6, 'can use tapped objects in a chain');
-    assert.equal(intercepted, returned, 'can use tapped objects in a chain');
+    assert.strictEqual(returned, 6, 'can use tapped objects in a chain');
+    assert.strictEqual(intercepted, returned, 'can use tapped objects in a chain');
   });
 
   QUnit.test('has', function(assert) {
@@ -911,14 +911,14 @@
     var moe = {name: 'Moe Howard', hair: true};
     var curly = {name: 'Curly Howard', hair: false};
 
-    assert.equal(_.isMatch(moe, {hair: true}), true, 'Returns a boolean');
-    assert.equal(_.isMatch(curly, {hair: true}), false, 'Returns a boolean');
+    assert.strictEqual(_.isMatch(moe, {hair: true}), true, 'Returns a boolean');
+    assert.strictEqual(_.isMatch(curly, {hair: true}), false, 'Returns a boolean');
 
-    assert.equal(_.isMatch(5, {__x__: void 0}), false, 'can match undefined props on primitives');
-    assert.equal(_.isMatch({__x__: void 0}, {__x__: void 0}), true, 'can match undefined props');
+    assert.strictEqual(_.isMatch(5, {__x__: void 0}), false, 'can match undefined props on primitives');
+    assert.strictEqual(_.isMatch({__x__: void 0}, {__x__: void 0}), true, 'can match undefined props');
 
-    assert.equal(_.isMatch(null, {}), true, 'Empty spec called with null object returns true');
-    assert.equal(_.isMatch(null, {a: 1}), false, 'Non-empty spec called with null object returns false');
+    assert.strictEqual(_.isMatch(null, {}), true, 'Empty spec called with null object returns true');
+    assert.strictEqual(_.isMatch(null, {a: 1}), false, 'Non-empty spec called with null object returns false');
 
     _.each([null, void 0], function(item) { assert.strictEqual(_.isMatch(item, null), true, 'null matches null'); });
     _.each([null, void 0], function(item) { assert.strictEqual(_.isMatch(item, null), true, 'null matches {}'); });
@@ -931,11 +931,11 @@
     function Prototest() {}
     Prototest.prototype.x = 1;
     var specObj = new Prototest;
-    assert.equal(_.isMatch({x: 2}, specObj), true, 'spec is restricted to own properties');
+    assert.strictEqual(_.isMatch({x: 2}, specObj), true, 'spec is restricted to own properties');
 
     specObj.y = 5;
-    assert.equal(_.isMatch({x: 1, y: 5}, specObj), true);
-    assert.equal(_.isMatch({x: 1, y: 4}, specObj), false);
+    assert.strictEqual(_.isMatch({x: 1, y: 5}, specObj), true);
+    assert.strictEqual(_.isMatch({x: 1, y: 4}, specObj), false);
 
     assert.ok(_.isMatch(specObj, {x: 1, y: 5}), 'inherited and own properties are checked on the test object');
 
@@ -952,14 +952,14 @@
     var curly = {name: 'Curly Howard', hair: false};
     var stooges = [moe, curly];
 
-    assert.equal(_.matcher({hair: true})(moe), true, 'Returns a boolean');
-    assert.equal(_.matcher({hair: true})(curly), false, 'Returns a boolean');
+    assert.strictEqual(_.matcher({hair: true})(moe), true, 'Returns a boolean');
+    assert.strictEqual(_.matcher({hair: true})(curly), false, 'Returns a boolean');
 
-    assert.equal(_.matcher({__x__: void 0})(5), false, 'can match undefined props on primitives');
-    assert.equal(_.matcher({__x__: void 0})({__x__: void 0}), true, 'can match undefined props');
+    assert.strictEqual(_.matcher({__x__: void 0})(5), false, 'can match undefined props on primitives');
+    assert.strictEqual(_.matcher({__x__: void 0})({__x__: void 0}), true, 'can match undefined props');
 
-    assert.equal(_.matcher({})(null), true, 'Empty spec called with null object returns true');
-    assert.equal(_.matcher({a: 1})(null), false, 'Non-empty spec called with null object returns false');
+    assert.strictEqual(_.matcher({})(null), true, 'Empty spec called with null object returns true');
+    assert.strictEqual(_.matcher({a: 1})(null), false, 'Non-empty spec called with null object returns false');
 
     assert.strictEqual(_.find(stooges, _.matcher({hair: false})), curly, 'returns a predicate that can be used by finding functions.');
     assert.strictEqual(_.find(stooges, _.matcher(moe)), moe, 'can be used to locate an object exists in a collection.');
@@ -970,19 +970,19 @@
     assert.deepEqual(_.filter([{b: 1}], _.matcher({a: void 0})), [], 'handles undefined values (1683)');
 
     _.each([true, 5, NaN, null, void 0], function(item) {
-      assert.equal(_.matcher(item)({a: 1}), true, 'treats primitives as empty');
+      assert.strictEqual(_.matcher(item)({a: 1}), true, 'treats primitives as empty');
     });
 
     function Prototest() {}
     Prototest.prototype.x = 1;
     var specObj = new Prototest;
     var protospec = _.matcher(specObj);
-    assert.equal(protospec({x: 2}), true, 'spec is restricted to own properties');
+    assert.strictEqual(protospec({x: 2}), true, 'spec is restricted to own properties');
 
     specObj.y = 5;
     protospec = _.matcher(specObj);
-    assert.equal(protospec({x: 1, y: 5}), true);
-    assert.equal(protospec({x: 1, y: 4}), false);
+    assert.strictEqual(protospec({x: 1, y: 5}), true);
+    assert.strictEqual(protospec({x: 1, y: 4}), false);
 
     assert.ok(_.matcher({x: 1, y: 5})(specObj), 'inherited and own properties are checked on the test object');
 
@@ -993,10 +993,10 @@
     var o = {b: 1};
     var m = _.matcher(o);
 
-    assert.equal(m({b: 1}), true);
+    assert.strictEqual(m({b: 1}), true);
     o.b = 2;
     o.a = 1;
-    assert.equal(m({b: 1}), true, 'changing spec object doesnt change matches result');
+    assert.strictEqual(m({b: 1}), true, 'changing spec object doesnt change matches result');
 
 
     //null edge cases
@@ -1015,17 +1015,17 @@
       c: {a: 2, b: 2}
     };
 
-    assert.equal(_.findKey(objects, function(obj) {
+    assert.strictEqual(_.findKey(objects, function(obj) {
       return obj.a === 0;
     }), 'a');
 
-    assert.equal(_.findKey(objects, function(obj) {
+    assert.strictEqual(_.findKey(objects, function(obj) {
       return obj.b * obj.a === 4;
     }), 'c');
 
-    assert.equal(_.findKey(objects, 'a'), 'b', 'Uses lookupIterator');
+    assert.strictEqual(_.findKey(objects, 'a'), 'b', 'Uses lookupIterator');
 
-    assert.equal(_.findKey(objects, function(obj) {
+    assert.strictEqual(_.findKey(objects, function(obj) {
       return obj.b * obj.a === 5;
     }), void 0);
 
@@ -1038,7 +1038,7 @@
     }), void 0);
 
     _.findKey({a: {a: 1}}, function(a, key, obj) {
-      assert.equal(key, 'a');
+      assert.strictEqual(key, 'a');
       assert.deepEqual(obj, {a: {a: 1}});
       assert.strictEqual(this, objects, 'called with context');
     }, objects);

--- a/test/utility.js
+++ b/test/utility.js
@@ -17,9 +17,9 @@
   if (typeof this == 'object') {
     QUnit.test('noConflict', function(assert) {
       var underscore = _.noConflict();
-      assert.equal(underscore.identity(1), 1);
+      assert.strictEqual(underscore.identity(1), 1);
       if (typeof require != 'function') {
-        assert.equal(this._, void 0, 'global underscore is removed');
+        assert.strictEqual(this._, void 0, 'global underscore is removed');
         this._ = underscore;
       } else if (typeof global !== 'undefined') {
         delete global._;
@@ -41,8 +41,8 @@
         );
         var context = {_: 'oldvalue'};
         sandbox.runInNewContext(context);
-        assert.equal(context._, 'oldvalue');
-        assert.equal(context.underscore.VERSION, _.VERSION);
+        assert.strictEqual(context._, 'oldvalue');
+        assert.strictEqual(context.underscore.VERSION, _.VERSION);
 
         done();
       });
@@ -58,12 +58,12 @@
 
   QUnit.test('identity', function(assert) {
     var stooge = {name: 'moe'};
-    assert.equal(_.identity(stooge), stooge, 'stooge is the same as his identity');
+    assert.strictEqual(_.identity(stooge), stooge, 'stooge is the same as his identity');
   });
 
   QUnit.test('constant', function(assert) {
     var stooge = {name: 'moe'};
-    assert.equal(_.constant(stooge)(), stooge, 'should create a function that returns stooge');
+    assert.strictEqual(_.constant(stooge)(), stooge, 'should create a function that returns stooge');
   });
 
   QUnit.test('noop', function(assert) {
@@ -72,27 +72,27 @@
 
   QUnit.test('property', function(assert) {
     var stooge = {name: 'moe'};
-    assert.equal(_.property('name')(stooge), 'moe', 'should return the property with the given name');
-    assert.equal(_.property('name')(null), void 0, 'should return undefined for null values');
-    assert.equal(_.property('name')(void 0), void 0, 'should return undefined for undefined values');
+    assert.strictEqual(_.property('name')(stooge), 'moe', 'should return the property with the given name');
+    assert.strictEqual(_.property('name')(null), void 0, 'should return undefined for null values');
+    assert.strictEqual(_.property('name')(void 0), void 0, 'should return undefined for undefined values');
   });
 
   QUnit.test('propertyOf', function(assert) {
     var stoogeRanks = _.propertyOf({curly: 2, moe: 1, larry: 3});
-    assert.equal(stoogeRanks('curly'), 2, 'should return the property with the given name');
-    assert.equal(stoogeRanks(null), void 0, 'should return undefined for null values');
-    assert.equal(stoogeRanks(void 0), void 0, 'should return undefined for undefined values');
+    assert.strictEqual(stoogeRanks('curly'), 2, 'should return the property with the given name');
+    assert.strictEqual(stoogeRanks(null), void 0, 'should return undefined for null values');
+    assert.strictEqual(stoogeRanks(void 0), void 0, 'should return undefined for undefined values');
 
     function MoreStooges() { this.shemp = 87; }
     MoreStooges.prototype = {curly: 2, moe: 1, larry: 3};
     var moreStoogeRanks = _.propertyOf(new MoreStooges());
-    assert.equal(moreStoogeRanks('curly'), 2, 'should return properties from further up the prototype chain');
+    assert.strictEqual(moreStoogeRanks('curly'), 2, 'should return properties from further up the prototype chain');
 
     var nullPropertyOf = _.propertyOf(null);
-    assert.equal(nullPropertyOf('curly'), void 0, 'should return undefined when obj is null');
+    assert.strictEqual(nullPropertyOf('curly'), void 0, 'should return undefined when obj is null');
 
     var undefPropertyOf = _.propertyOf(void 0);
-    assert.equal(undefPropertyOf('curly'), void 0, 'should return undefined when obj is undefined');
+    assert.strictEqual(undefPropertyOf('curly'), void 0, 'should return undefined when obj is undefined');
   });
 
   QUnit.test('random', function(assert) {
@@ -117,7 +117,7 @@
   QUnit.test('uniqueId', function(assert) {
     var ids = [], i = 0;
     while (i++ < 100) ids.push(_.uniqueId());
-    assert.equal(_.uniq(ids).length, ids.length, 'can generate a globally-unique stream of ids');
+    assert.strictEqual(_.uniq(ids).length, ids.length, 'can generate a globally-unique stream of ids');
   });
 
   QUnit.test('times', function(assert) {
@@ -142,20 +142,20 @@
         return string.split('').reverse().join('');
       }
     });
-    assert.equal(ret, _, 'returns the _ object to facilitate chaining');
-    assert.equal(_.myReverse('panacea'), 'aecanap', 'mixed in a function to _');
-    assert.equal(_('champ').myReverse(), 'pmahc', 'mixed in a function to the OOP wrapper');
+    assert.strictEqual(ret, _, 'returns the _ object to facilitate chaining');
+    assert.strictEqual(_.myReverse('panacea'), 'aecanap', 'mixed in a function to _');
+    assert.strictEqual(_('champ').myReverse(), 'pmahc', 'mixed in a function to the OOP wrapper');
   });
 
   QUnit.test('_.escape', function(assert) {
-    assert.equal(_.escape(null), '');
+    assert.strictEqual(_.escape(null), '');
   });
 
   QUnit.test('_.unescape', function(assert) {
     var string = 'Curly & Moe';
-    assert.equal(_.unescape(null), '');
-    assert.equal(_.unescape(_.escape(string)), string);
-    assert.equal(_.unescape(string), string, 'don\'t unescape unnecessarily');
+    assert.strictEqual(_.unescape(null), '');
+    assert.strictEqual(_.unescape(_.escape(string)), string);
+    assert.strictEqual(_.unescape(string), string, 'don\'t unescape unnecessarily');
   });
 
   // Don't care what they escape them to just that they're escaped and can be unescaped
@@ -167,13 +167,13 @@
       var s = 'a ' + escapeChar + ' string escaped';
       var e = _.escape(s);
       assert.notEqual(s, e, escapeChar + ' is escaped');
-      assert.equal(s, _.unescape(e), escapeChar + ' can be unescaped');
+      assert.strictEqual(s, _.unescape(e), escapeChar + ' can be unescaped');
 
       s = 'a ' + escapeChar + escapeChar + escapeChar + 'some more string' + escapeChar;
       e = _.escape(s);
 
-      assert.equal(e.indexOf(escapeChar), -1, 'can escape multiple occurances of ' + escapeChar);
-      assert.equal(_.unescape(e), s, 'multiple occurrences of ' + escapeChar + ' can be unescaped');
+      assert.strictEqual(e.indexOf(escapeChar), -1, 'can escape multiple occurances of ' + escapeChar);
+      assert.strictEqual(_.unescape(e), s, 'multiple occurrences of ' + escapeChar + ' can be unescaped');
     });
 
     // handles multiple escape characters at once
@@ -190,32 +190,32 @@
     var escaped = _.escape(str);
 
     assert.notStrictEqual(escaped.indexOf('&'), -1, 'handles & aka &amp;');
-    assert.equal(_.unescape(str), str, 'can unescape &amp;');
+    assert.strictEqual(_.unescape(str), str, 'can unescape &amp;');
   });
 
   QUnit.test('template', function(assert) {
     var basicTemplate = _.template("<%= thing %> is gettin' on my noives!");
     var result = basicTemplate({thing: 'This'});
-    assert.equal(result, "This is gettin' on my noives!", 'can do basic attribute interpolation');
+    assert.strictEqual(result, "This is gettin' on my noives!", 'can do basic attribute interpolation');
 
     var sansSemicolonTemplate = _.template('A <% this %> B');
-    assert.equal(sansSemicolonTemplate(), 'A  B');
+    assert.strictEqual(sansSemicolonTemplate(), 'A  B');
 
     var backslashTemplate = _.template('<%= thing %> is \\ridanculous');
-    assert.equal(backslashTemplate({thing: 'This'}), 'This is \\ridanculous');
+    assert.strictEqual(backslashTemplate({thing: 'This'}), 'This is \\ridanculous');
 
     var escapeTemplate = _.template('<%= a ? "checked=\\"checked\\"" : "" %>');
-    assert.equal(escapeTemplate({a: true}), 'checked="checked"', 'can handle slash escapes in interpolations.');
+    assert.strictEqual(escapeTemplate({a: true}), 'checked="checked"', 'can handle slash escapes in interpolations.');
 
     var fancyTemplate = _.template('<ul><% ' +
     '  for (var key in people) { ' +
     '%><li><%= people[key] %></li><% } %></ul>');
     result = fancyTemplate({people: {moe: 'Moe', larry: 'Larry', curly: 'Curly'}});
-    assert.equal(result, '<ul><li>Moe</li><li>Larry</li><li>Curly</li></ul>', 'can run arbitrary javascript in templates');
+    assert.strictEqual(result, '<ul><li>Moe</li><li>Larry</li><li>Curly</li></ul>', 'can run arbitrary javascript in templates');
 
     var escapedCharsInJavascriptTemplate = _.template('<ul><% _.each(numbers.split("\\n"), function(item) { %><li><%= item %></li><% }) %></ul>');
     result = escapedCharsInJavascriptTemplate({numbers: 'one\ntwo\nthree\nfour'});
-    assert.equal(result, '<ul><li>one</li><li>two</li><li>three</li><li>four</li></ul>', 'Can use escaped characters (e.g. \\n) in JavaScript');
+    assert.strictEqual(result, '<ul><li>one</li><li>two</li><li>three</li><li>four</li></ul>', 'Can use escaped characters (e.g. \\n) in JavaScript');
 
     var namespaceCollisionTemplate = _.template('<%= pageCount %> <%= thumbnails[pageCount] %> <% _.each(thumbnails, function(p) { %><div class="thumbnail" rel="<%= p %>"></div><% }); %>');
     result = namespaceCollisionTemplate({
@@ -226,32 +226,32 @@
         3: 'p3-thumbnail.gif'
       }
     });
-    assert.equal(result, '3 p3-thumbnail.gif <div class="thumbnail" rel="p1-thumbnail.gif"></div><div class="thumbnail" rel="p2-thumbnail.gif"></div><div class="thumbnail" rel="p3-thumbnail.gif"></div>');
+    assert.strictEqual(result, '3 p3-thumbnail.gif <div class="thumbnail" rel="p1-thumbnail.gif"></div><div class="thumbnail" rel="p2-thumbnail.gif"></div><div class="thumbnail" rel="p3-thumbnail.gif"></div>');
 
     var noInterpolateTemplate = _.template('<div><p>Just some text. Hey, I know this is silly but it aids consistency.</p></div>');
     result = noInterpolateTemplate();
-    assert.equal(result, '<div><p>Just some text. Hey, I know this is silly but it aids consistency.</p></div>');
+    assert.strictEqual(result, '<div><p>Just some text. Hey, I know this is silly but it aids consistency.</p></div>');
 
     var quoteTemplate = _.template("It's its, not it's");
-    assert.equal(quoteTemplate({}), "It's its, not it's");
+    assert.strictEqual(quoteTemplate({}), "It's its, not it's");
 
     var quoteInStatementAndBody = _.template('<% ' +
     "  if(foo == 'bar'){ " +
     "%>Statement quotes and 'quotes'.<% } %>");
-    assert.equal(quoteInStatementAndBody({foo: 'bar'}), "Statement quotes and 'quotes'.");
+    assert.strictEqual(quoteInStatementAndBody({foo: 'bar'}), "Statement quotes and 'quotes'.");
 
     var withNewlinesAndTabs = _.template('This\n\t\tis: <%= x %>.\n\tok.\nend.');
-    assert.equal(withNewlinesAndTabs({x: 'that'}), 'This\n\t\tis: that.\n\tok.\nend.');
+    assert.strictEqual(withNewlinesAndTabs({x: 'that'}), 'This\n\t\tis: that.\n\tok.\nend.');
 
     var template = _.template('<i><%- value %></i>');
     result = template({value: '<script>'});
-    assert.equal(result, '<i>&lt;script&gt;</i>');
+    assert.strictEqual(result, '<i>&lt;script&gt;</i>');
 
     var stooge = {
       name: 'Moe',
       template: _.template("I'm <%= this.name %>")
     };
-    assert.equal(stooge.template(), "I'm Moe");
+    assert.strictEqual(stooge.template(), "I'm Moe");
 
     template = _.template('\n ' +
     '  <%\n ' +
@@ -259,7 +259,7 @@
     '  if (data) { data += 12345; }; %>\n ' +
     '  <li><%= data %></li>\n '
     );
-    assert.equal(template({data: 12345}).replace(/\s/g, ''), '<li>24690</li>');
+    assert.strictEqual(template({data: 12345}).replace(/\s/g, ''), '<li>24690</li>');
 
     _.templateSettings = {
       evaluate: /\{\{([\s\S]+?)\}\}/g,
@@ -268,13 +268,13 @@
 
     var custom = _.template('<ul>{{ for (var key in people) { }}<li>{{= people[key] }}</li>{{ } }}</ul>');
     result = custom({people: {moe: 'Moe', larry: 'Larry', curly: 'Curly'}});
-    assert.equal(result, '<ul><li>Moe</li><li>Larry</li><li>Curly</li></ul>', 'can run arbitrary javascript in templates');
+    assert.strictEqual(result, '<ul><li>Moe</li><li>Larry</li><li>Curly</li></ul>', 'can run arbitrary javascript in templates');
 
     var customQuote = _.template("It's its, not it's");
-    assert.equal(customQuote({}), "It's its, not it's");
+    assert.strictEqual(customQuote({}), "It's its, not it's");
 
     quoteInStatementAndBody = _.template("{{ if(foo == 'bar'){ }}Statement quotes and 'quotes'.{{ } }}");
-    assert.equal(quoteInStatementAndBody({foo: 'bar'}), "Statement quotes and 'quotes'.");
+    assert.strictEqual(quoteInStatementAndBody({foo: 'bar'}), "Statement quotes and 'quotes'.");
 
     _.templateSettings = {
       evaluate: /<\?([\s\S]+?)\?>/g,
@@ -283,23 +283,23 @@
 
     var customWithSpecialChars = _.template('<ul><? for (var key in people) { ?><li><?= people[key] ?></li><? } ?></ul>');
     result = customWithSpecialChars({people: {moe: 'Moe', larry: 'Larry', curly: 'Curly'}});
-    assert.equal(result, '<ul><li>Moe</li><li>Larry</li><li>Curly</li></ul>', 'can run arbitrary javascript in templates');
+    assert.strictEqual(result, '<ul><li>Moe</li><li>Larry</li><li>Curly</li></ul>', 'can run arbitrary javascript in templates');
 
     var customWithSpecialCharsQuote = _.template("It's its, not it's");
-    assert.equal(customWithSpecialCharsQuote({}), "It's its, not it's");
+    assert.strictEqual(customWithSpecialCharsQuote({}), "It's its, not it's");
 
     quoteInStatementAndBody = _.template("<? if(foo == 'bar'){ ?>Statement quotes and 'quotes'.<? } ?>");
-    assert.equal(quoteInStatementAndBody({foo: 'bar'}), "Statement quotes and 'quotes'.");
+    assert.strictEqual(quoteInStatementAndBody({foo: 'bar'}), "Statement quotes and 'quotes'.");
 
     _.templateSettings = {
       interpolate: /\{\{(.+?)\}\}/g
     };
 
     var mustache = _.template('Hello {{planet}}!');
-    assert.equal(mustache({planet: 'World'}), 'Hello World!', 'can mimic mustache.js');
+    assert.strictEqual(mustache({planet: 'World'}), 'Hello World!', 'can mimic mustache.js');
 
     var templateWithNull = _.template('a null undefined {{planet}}');
-    assert.equal(templateWithNull({planet: 'world'}), 'a null undefined world', 'can handle missing escape and evaluate settings');
+    assert.strictEqual(templateWithNull({planet: 'world'}), 'a null undefined world', 'can handle missing escape and evaluate settings');
   });
 
   QUnit.test('_.template provides the generated function source, when a SyntaxError occurs', function(assert) {


### PR DESCRIPTION
By switching all assertions to use `strictEqual` rather than `equal` I was able to discover three worthwhile improvements to our tests:

* https://github.com/jashkenas/underscore/pull/2597
* https://github.com/jashkenas/underscore/pull/2596
* https://github.com/jashkenas/underscore/pull/2595

I think it's a good idea to have our tests generally prefer the more explicit: `strictEqual`. Not only could it help avoid some subtle bug going unnoticed, but it also gives the reader of the test suite a more concrete description of the expected behavior.

At some point, after we've upgraded to a newer version of ESLint, we might even consider enableing the rule [`qunit/https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md`](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md) (cc @platinumazure)