### PR TITLE
Clarify order of operations in cross-document test

### DIFF
--- a/test/cross-document.js
+++ b/test/cross-document.js
@@ -10,7 +10,8 @@
   var iframe = document.createElement('iframe');
   iframe.frameBorder = iframe.height = iframe.width = 0;
   document.body.appendChild(iframe);
-  var iDoc = (iDoc = iframe.contentDocument || iframe.contentWindow).document || iDoc;
+  var iframeContent = iframe.contentDocument || iframe.contentWindow;
+  var iDoc = iframeContent.document || iframeContent;
   iDoc.write(
     [
       '<script>',


### PR DESCRIPTION
The previous code (introduced in #1424) used the `iDoc` variable name for two purposes on the
same line. Not only was that very confusing, it meant `iDoc` was being
used before it was actually assigned.