### PR TITLE
Remove test for edge case: _.reject(list, []);

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -344,7 +344,6 @@
     assert.deepEqual(_.reject(list, {a: 1}), [{a: 2, b: 2}]);
     assert.deepEqual(_.reject(list, {b: 2}), [{a: 1, b: 3}, {a: 1, b: 4}]);
     assert.deepEqual(_.reject(list, {}), [], 'Returns empty list given empty object');
-    assert.deepEqual(_.reject(list, []), [], 'Returns empty list given empty array');
   });
 
   QUnit.test('every', function(assert) {


### PR DESCRIPTION
I believe this test was added by accident by @megawac in #1582 (specifically https://github.com/jashkenas/underscore/pull/1582/commits/e52fd55e264394f11622522b6cc1acc061a372d6)

Given our current documentation, the behavior of this edge case is not defined.

This test currently passes because arrays are technically objects and thus `_.iteratee` treats `[]` as a `_.matches` matcher. `_.matches` casts `[]` to `{}` via `_.extendOwn({}, []);` and returns a function which always returns `true`.

The fact that this test exists in `_.reject`'s test and not in `_.iteratee`'s leads me to believe that this is not actually intended behavior, but merely an implementation detail which has been accidentally enforced in our tests.

I'm currently reworking my pull request #2494 (deep property access) and in a future where arrays are used for deep property access, `[]` will return a function that always returns `undefined`, which seems like a more reasonable behavior.

I thought it would be good to have this conversation separate from the deep property matching pull request, but removing this test is a prerequisite to implementing deep property access.