### PR TITLE
Spelling

### DIFF
--- a/docs/underscore.html
+++ b/docs/underscore.html
@@ -3517,7 +3517,7 @@ NB: <code>oldSettings</code> only exists for backwards compatibility.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-171">&#182;</a>
               </div>
-              <p>Adobe VMs need the match returned to produce the correct offest.</p>
+              <p>Adobe VMs need the match returned to produce the correct offset.</p>
 
             </div>
             

--- a/index.html
+++ b/index.html
@@ -2428,7 +2428,7 @@ _.chain([1, 2, 3]).reverse().value();
             <tt>_.extend</tt> only iterates over the object's own properties.
           </li>
           <li>
-            Falsey guards are no longer needed in <tt>_.extend</tt> and
+            Falsy guards are no longer needed in <tt>_.extend</tt> and
             <tt>_.defaults</tt>&mdash;if the passed in argument isn't a JavaScript
             object it's just returned.
           </li>

--- a/test/arrays.js
+++ b/test/arrays.js
@@ -167,7 +167,7 @@
     assert.deepEqual(_.uniq(list, true, iterator), expected, 'uses the result of `iterator` for uniqueness comparisons (sorted case)');
     assert.deepEqual(_.uniq(list, true, 'score'), expected, 'when `iterator` is a string, uses that key for comparisons (sorted case)');
 
-    assert.deepEqual(_.uniq([{0: 1}, {0: 1}, {0: 1}, {0: 2}], 0), [{0: 1}, {0: 2}], 'can use falsey pluck like iterator');
+    assert.deepEqual(_.uniq([{0: 1}, {0: 1}, {0: 1}, {0: 2}], 0), [{0: 1}, {0: 2}], 'can use falsy pluck like iterator');
 
     var result = (function(){ return _.uniq(arguments); }(1, 2, 1, 3, 1, 4));
     assert.deepEqual(result, [1, 2, 3, 4], 'works on an arguments object');
@@ -370,7 +370,7 @@
 
   QUnit.test('lastIndexOf', function(assert) {
     var numbers = [1, 0, 1];
-    var falsey = [void 0, '', 0, false, NaN, null, void 0];
+    var falsy = [void 0, '', 0, false, NaN, null, void 0];
     assert.strictEqual(_.lastIndexOf(numbers, 1), 2);
 
     numbers = [1, 0, 1, 0, 0, 1, 0, 0, 0];
@@ -406,15 +406,15 @@
       assert.strictEqual(_.lastIndexOf(array, '', fromIndex), -1);
     });
 
-    var expected = _.map(falsey, function(value) {
+    var expected = _.map(falsy, function(value) {
       return typeof value == 'number' ? -1 : 5;
     });
 
-    var actual = _.map(falsey, function(fromIndex) {
+    var actual = _.map(falsy, function(fromIndex) {
       return _.lastIndexOf(array, 3, fromIndex);
     });
 
-    assert.deepEqual(actual, expected, 'should treat falsey `fromIndex` values, except `0` and `NaN`, as `array.length`');
+    assert.deepEqual(actual, expected, 'should treat falsy `fromIndex` values, except `0` and `NaN`, as `array.length`');
     assert.strictEqual(_.lastIndexOf(array, 3, '1'), 5, 'should treat non-number `fromIndex` values as `array.length`');
     assert.strictEqual(_.lastIndexOf(array, 3, true), 5, 'should treat non-number `fromIndex` values as `array.length`');
 

--- a/test/objects.js
+++ b/test/objects.js
@@ -922,7 +922,7 @@
     // Deep property access
     assert.strictEqual(_.property('a')({a: 1}), 1, 'can get a direct property');
     assert.strictEqual(_.property(['a', 'b'])({a: {b: 2}}), 2, 'can get a nested property');
-    assert.strictEqual(_.property(['a'])({a: false}), false, 'can fetch falsey values');
+    assert.strictEqual(_.property(['a'])({a: false}), false, 'can fetch falsy values');
     assert.strictEqual(_.property(['x', 'y'])({x: {y: null}}), null, 'can fetch null values deeply');
     assert.strictEqual(_.property(['x', 'y'])({x: null}), void 0, 'does not crash on property access of nested non-objects');
     assert.strictEqual(_.property([])({x: 'y'}), void 0, 'returns `undefined` for a path that is an empty array');
@@ -988,7 +988,7 @@
 
     //null edge cases
     var oCon = {constructor: Object};
-    assert.deepEqual(_.map([null, void 0, 5, {}], _.partial(_.isMatch, _, oCon)), [false, false, false, true], 'doesnt falsey match constructor on undefined/null');
+    assert.deepEqual(_.map([null, void 0, 5, {}], _.partial(_.isMatch, _, oCon)), [false, false, false, true], 'doesnt falsy match constructor on undefined/null');
   });
 
   QUnit.test('matcher', function(assert) {
@@ -1045,7 +1045,7 @@
 
     //null edge cases
     var oCon = _.matcher({constructor: Object});
-    assert.deepEqual(_.map([null, void 0, 5, {}], oCon), [false, false, false, true], 'doesnt falsey match constructor on undefined/null');
+    assert.deepEqual(_.map([null, void 0, 5, {}], oCon), [false, false, false, true], 'doesnt falsy match constructor on undefined/null');
   });
 
   QUnit.test('matches', function(assert) {

--- a/test/objects.js
+++ b/test/objects.js
@@ -109,7 +109,7 @@
     var result;
     assert.strictEqual(_.extend({}, {a: 'b'}).a, 'b', 'can extend an object with the attributes of another');
     assert.strictEqual(_.extend({a: 'x'}, {a: 'b'}).a, 'b', 'properties in source override destination');
-    assert.strictEqual(_.extend({x: 'x'}, {a: 'b'}).x, 'x', "properties not in source don't get overriden");
+    assert.strictEqual(_.extend({x: 'x'}, {a: 'b'}).x, 'x', "properties not in source don't get overridden");
     result = _.extend({x: 'x'}, {a: 'a'}, {b: 'b'});
     assert.deepEqual(result, {x: 'x', a: 'a', b: 'b'}, 'can extend from multiple source objects');
     result = _.extend({x: 'x'}, {a: 'a', x: 2}, {a: 'b'});
@@ -140,7 +140,7 @@
     var result;
     assert.strictEqual(_.extendOwn({}, {a: 'b'}).a, 'b', 'can extend an object with the attributes of another');
     assert.strictEqual(_.extendOwn({a: 'x'}, {a: 'b'}).a, 'b', 'properties in source override destination');
-    assert.strictEqual(_.extendOwn({x: 'x'}, {a: 'b'}).x, 'x', "properties not in source don't get overriden");
+    assert.strictEqual(_.extendOwn({x: 'x'}, {a: 'b'}).x, 'x', "properties not in source don't get overridden");
     result = _.extendOwn({x: 'x'}, {a: 'a'}, {b: 'b'});
     assert.deepEqual(result, {x: 'x', a: 'a', b: 'b'}, 'can extend from multiple source objects');
     result = _.extendOwn({x: 'x'}, {a: 'a', x: 2}, {a: 'b'});

--- a/test/objects.js
+++ b/test/objects.js
@@ -560,7 +560,7 @@
     assert.strictEqual(_.isEqual(new Foo, other), false, 'Objects from different constructors are not equal');
 
 
-    // Tricky object cases val comparisions
+    // Tricky object cases val comparisons
     assert.strictEqual(_.isEqual([0], [-0]), false);
     assert.strictEqual(_.isEqual({a: 0}, {a: -0}), false);
     assert.strictEqual(_.isEqual([NaN], [NaN]), true);

--- a/test/utility.js
+++ b/test/utility.js
@@ -443,7 +443,7 @@
     assert.deepEqual(settings, {});
   });
 
-  QUnit.test('#779 - delimeters are applied to unescaped text.', function(assert) {
+  QUnit.test('#779 - delimiters are applied to unescaped text.', function(assert) {
     assert.expect(1);
     var template = _.template('<<\nx\n>>', null, {evaluate: /<<(.*?)>>/g});
     assert.strictEqual(template(), '<<\nx\n>>');

--- a/test/utility.js
+++ b/test/utility.js
@@ -349,7 +349,7 @@
 
     assert.strictEqual(_.result({a: func}, 'a'), 'f', 'can get a direct method');
     assert.strictEqual(_.result({a: {b: func}}, ['a', 'b']), 'f', 'can get a nested method');
-    assert.strictEqual(_.result(), void 0, 'returns udefined if obj is not passed');
+    assert.strictEqual(_.result(), void 0, 'returns undefined if obj is not passed');
     assert.strictEqual(_.result(void 1, 'a', 2), 2, 'returns default if obj is not passed');
     assert.strictEqual(_.result(void 1, 'a', func), 'f', 'executes default if obj is not passed');
     assert.strictEqual(_.result({}, void 0, 2), 2, 'returns default if prop is not passed');

--- a/test/utility.js
+++ b/test/utility.js
@@ -147,7 +147,7 @@
       s = 'a ' + escapeChar + escapeChar + escapeChar + 'some more string' + escapeChar;
       e = _.escape(s);
 
-      assert.strictEqual(e.indexOf(escapeChar), -1, 'can escape multiple occurances of ' + escapeChar);
+      assert.strictEqual(e.indexOf(escapeChar), -1, 'can escape multiple occurrences of ' + escapeChar);
       assert.strictEqual(_.unescape(e), s, 'multiple occurrences of ' + escapeChar + ' can be unescaped');
     });
 

--- a/test/utility.js
+++ b/test/utility.js
@@ -135,7 +135,7 @@
 
   // Don't care what they escape them to just that they're escaped and can be unescaped
   QUnit.test('_.escape & unescape', function(assert) {
-    // test & (&amp;) seperately obviously
+    // test & (&amp;) separately obviously
     var escapeCharacters = ['<', '>', '"', '\'', '`'];
 
     _.each(escapeCharacters, function(escapeChar) {

--- a/test/utility.js
+++ b/test/utility.js
@@ -345,7 +345,7 @@
     assert.strictEqual(_.result({a: 1}, 'b', 2), 2, 'uses the fallback value when property is missing');
     assert.strictEqual(_.result({a: 1}, ['b', 'c'], 2), 2, 'uses the fallback value when any property is missing');
     assert.strictEqual(_.result({a: void 0}, ['a'], 1), 1, 'uses the fallback when value is undefined');
-    assert.strictEqual(_.result({a: false}, ['a'], 'foo'), false, 'can fetch falsey values');
+    assert.strictEqual(_.result({a: false}, ['a'], 'foo'), false, 'can fetch falsy values');
 
     assert.strictEqual(_.result({a: func}, 'a'), 'f', 'can get a direct method');
     assert.strictEqual(_.result({a: {b: func}}, ['a', 'b']), 'f', 'can get a nested method');

--- a/test/utility.js
+++ b/test/utility.js
@@ -188,8 +188,8 @@
     result = fancyTemplate({people: {moe: 'Moe', larry: 'Larry', curly: 'Curly'}});
     assert.strictEqual(result, '<ul><li>Moe</li><li>Larry</li><li>Curly</li></ul>', 'can run arbitrary javascript in templates');
 
-    var escapedCharsInJavascriptTemplate = _.template('<ul><% _.each(numbers.split("\\n"), function(item) { %><li><%= item %></li><% }) %></ul>');
-    result = escapedCharsInJavascriptTemplate({numbers: 'one\ntwo\nthree\nfour'});
+    var escapedCharsInJavaScriptTemplate = _.template('<ul><% _.each(numbers.split("\\n"), function(item) { %><li><%= item %></li><% }) %></ul>');
+    result = escapedCharsInJavaScriptTemplate({numbers: 'one\ntwo\nthree\nfour'});
     assert.strictEqual(result, '<ul><li>one</li><li>two</li><li>three</li><li>four</li></ul>', 'Can use escaped characters (e.g. \\n) in JavaScript');
 
     var namespaceCollisionTemplate = _.template('<%= pageCount %> <%= thumbnails[pageCount] %> <% _.each(thumbnails, function(p) { %><div class="thumbnail" rel="<%= p %>"></div><% }); %>');


### PR DESCRIPTION
I haven't run any tests.

I know that some downstreams have expectations of spellings in the underscore test output. I believe it's reasonable for them to update their spelling expectations when they update this library.

Some words in underscore are intentionally misspelled (`gettin`, `ridanculous`) and I've left them alone.

Before this pr, both `falsy` and `falsey` were used (roughly evenly). I'm trying to push underscore to a single spelling. I have no particular preference as to which spelling it uses, but it's really helpful if it standardizes on a single spelling.

My spell checker objects to `Javascript`, and as it's brand (`JavaScript`), I happen to agree with it. There shouldn't be much harm in making this change. But you can certainly drop this change if you object strongly.