### PR TITLE
perf(isObject): Don't cache typeof & check value first

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1310,8 +1310,7 @@
 
   // Is a given variable an object?
   _.isObject = function(obj) {
-    var type = typeof obj;
-    return type === 'function' || type === 'object' && !!obj;
+    return obj !== null && (typeof obj === 'function' || typeof obj === 'object');
   };
 
   // Add some isType methods: isArguments, isFunction, isString, isNumber, isDate, isRegExp, isError, isMap, isWeakMap, isSet, isWeakSet.


### PR DESCRIPTION
Hi, from this [benchmark](https://gist.run/?id=680c1d0d904fad05549ab93fa033897d), avoid caching can help improve performance around 25 - 30% 