### PR TITLE
[Request for feedback] Add deep property access via dot notation

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -451,7 +451,7 @@
 
 
   QUnit.test('invoke', function(assert) {
-    assert.expect(13);
+    assert.expect(14);
     var list = [[5, 1, 7], [3, 2, 1]];
     var result = _.invoke(list, 'sort');
     assert.deepEqual(result[0], [1, 5, 7], 'first array sorted');
@@ -487,6 +487,7 @@
     };
     var arr = [item];
     assert.deepEqual(_.invoke(arr, ['a', 'b']), ['foo'], 'supports deep method access via an array syntax');
+    assert.deepEqual(_.invoke(arr, 'a.b'), ['foo'], 'supports deep method access via a string dot syntax');
     assert.deepEqual(_.invoke(arr, ['a', 'c']), [item.a], 'executes deep methods on their direct parent');
     assert.deepEqual(_.invoke(arr, ['a', 'd', 'z']), [void 0], 'does not try to access attributes of non-objects');
     assert.deepEqual(_.invoke(arr, ['a', 'd']), [null], 'handles deep null values');
@@ -532,6 +533,10 @@
     var people = [{name: 'moe', age: 30}, {name: 'curly', age: 50}];
     assert.deepEqual(_.pluck(people, 'name'), ['moe', 'curly'], 'pulls names out of objects');
     assert.deepEqual(_.pluck(people, 'address'), [void 0, void 0], 'missing properties are returned as undefined');
+
+    var posts = [{author: {name: 'moe', age: 30}}, {author: {name: 'curly', age: 50}}];
+    assert.deepEqual(_.pluck(posts, ['author', 'name']), ['moe', 'curly'], 'pulls nested names out of objects');
+    assert.deepEqual(_.pluck(posts, 'author.name'), ['moe', 'curly'], 'pulls nested names using dot notation');
     //compat: most flexible handling of edge cases
     assert.deepEqual(_.pluck([{'[object Object]': 1}], {}), [1]);
   });

--- a/test/utility.js
+++ b/test/utility.js
@@ -122,6 +122,18 @@
     assert.strictEqual(_('champ').myReverse(), 'pmahc', 'mixed in a function to the OOP wrapper');
   });
 
+  QUnit.test('_.toPath', function(assert) {
+    var path = ['a', 'b', 'c'];
+    assert.deepEqual(_.toPath(path), path, 'passes arrays through directly');
+    assert.deepEqual(_.toPath('a.b.c'), path, 'can parse simple dot-separated strings');
+    assert.deepEqual(_.toPath('a'), ['a'], 'can parse simple keys');
+
+    var originalToPath = _.toPath;
+    _.toPath = function(str) { return [str]; };
+    assert.deepEqual(_.pluck([{'a.b.c': true}], 'a.b.c'), [true], 'can be replaced with a custom function');
+    _.toPath = originalToPath;
+  });
+
   QUnit.test('_.escape', function(assert) {
     assert.strictEqual(_.escape(null), '');
   });

--- a/test/utility.js
+++ b/test/utility.js
@@ -342,6 +342,7 @@
 
     assert.strictEqual(_.result({a: 1}, 'a'), 1, 'can get a direct property');
     assert.strictEqual(_.result({a: {b: 2}}, ['a', 'b']), 2, 'can get a nested property');
+    assert.strictEqual(_.result({a: {b: 2}}, 'a.b'), 2, 'can get a nested property using dot notation');
     assert.strictEqual(_.result({a: 1}, 'b', 2), 2, 'uses the fallback value when property is missing');
     assert.strictEqual(_.result({a: 1}, ['b', 'c'], 2), 2, 'uses the fallback value when any property is missing');
     assert.strictEqual(_.result({a: void 0}, ['a'], 1), 1, 'uses the fallback when value is undefined');

--- a/underscore.js
+++ b/underscore.js
@@ -146,7 +146,7 @@
     };
   };
 
-  var parsePath = function(path) {
+  _.toPath = function(path) {
     if (_.isArray(path)) return path;
     if (_.isString(path)) return path.split('.');
     return [path];
@@ -302,7 +302,7 @@
     if (_.isFunction(path)) {
       func = path;
     } else {
-      path = parsePath(path);
+      path = _.toPath(path);
       contextPath = path.slice(0, -1);
       path = path[path.length - 1];
     }
@@ -1179,7 +1179,7 @@
     var obj = Object(object);
     for (var i = 0; i < length; i++) {
       var pathString = keys[i];
-      var path = parsePath(pathString);
+      var path = _.toPath(pathString);
       var key = path.pop();
       var parent = path.length ? deepGet(obj, path) : obj;
       if (parent == null || attrs[pathString] !== parent[key] || !(key in parent)) return false;
@@ -1376,7 +1376,7 @@
   // Shortcut function for checking if an object has a given property directly
   // on itself (in other words, not on a prototype).
   _.has = function(obj, path) {
-    path = parsePath(path);
+    path = _.toPath(path);
     if (path.length === 1) {
       return obj != null && hasOwnProperty.call(obj, path[0]);
     }
@@ -1416,11 +1416,11 @@
   _.noop = function(){};
 
   _.get = function(obj, path, fallback) {
-    return deepGet(obj, parsePath(path), fallback);
+    return deepGet(obj, _.toPath(path), fallback);
   };
 
   _.property = function(path) {
-    path = parsePath(path);
+    path = _.toPath(path);
     if (path.length === 1) {
       return shallowProperty(path[0]);
     }
@@ -1435,7 +1435,7 @@
       return function(){};
     }
     return function(path) {
-      path = parsePath(path);
+      path = _.toPath(path);
       return path.length === 1 ? obj[path[0]] : deepGet(obj, path);
     };
   };
@@ -1503,7 +1503,7 @@
   // is invoked with its parent as context. Returns the value of the final
   // child, or `fallback` if any child is undefined.
   _.result = function(obj, path, fallback) {
-    path = parsePath(path);
+    path = _.toPath(path);
     var length = path.length;
     if (!length) {
       return _.isFunction(fallback) ? fallback.call(obj) : fallback;


### PR DESCRIPTION
This pull request should be safe to merge, but it lacks support for escaping characters in path strings. In most cases this is fine, since the more explicit array syntax can be used as a fallback. However, in the case of `_.matches` and friends, there is no such fallback available.

Should we explore an escape syntax (similar to Lodash's) which allows for complex paths via a string syntax? If so, should it be solved as part of this pull request?

As part of this pull request we get `_.get` essentially for free.