### PR TITLE
`this` is undefined in strict mode

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -13,7 +13,8 @@
   // instead of `window` for `WebWorker` support.
   var root = typeof self == 'object' && self.self === self && self ||
             typeof global == 'object' && global.global === global && global ||
-            this;
+            this ||
+            {};
 
   // Save the previous value of the `_` variable.
   var previousUnderscore = root._;


### PR DESCRIPTION
In some special environment, such as WeChat micro app (微信小程序  in Chinese), `window` and `global` are both undefined. And it mandatorily enables strict mode, so the `this` is also undefined.
In this situation, we give `root` an empty object value.