### PR TITLE
Add specs to Symbol 

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -571,8 +571,13 @@
       assert.strictEqual(_.isEqual(symbol, symbol), true, 'A symbol is equal to itself');
       assert.strictEqual(_.isEqual(symbol, Object(symbol)), true, 'Even when wrapped in Object()');
       assert.strictEqual(_.isEqual(symbol, null), false, 'Different types are not equal');
-    }
 
+      var symbolY = Symbol('y');
+      assert.strictEqual(_.isEqual(symbol, symbolY), false, 'Different symbols are not equal');
+
+      var sameStringSymbol = Symbol('x');
+      assert.strictEqual(_.isEqual(symbol, sameStringSymbol), false, 'Different symbols of same string are not equal');
+    }
   });
 
   QUnit.test('isEmpty', function(assert) {


### PR DESCRIPTION
Adds tests that @jdalton and @megawac [mentioned in this PR](https://github.com/jashkenas/underscore/pull/2452#r54429238)

> jdalton on Feb 29, 2016 Contributor
> Should add a test for _.isEqual(Symbol('x'), Symbol('y')) of false.

> megawac on Feb 29, 2016 Collaborator
> Yeah probably for _.isEqual(Symbol('a'), Symbol('a')) as false as well