### PR TITLE
Don't cache Date.now

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1451,9 +1451,15 @@
   };
 
   // A (possibly faster) way to get the current timestamp as an integer.
-  _.now = Date.now || function() {
-    return new Date().getTime();
-  };
+  if (Date.now) {
+    _.now = function() {
+      return Date.now();
+    };
+  } else {
+    _.now = function() {
+      return new Date().getTime();
+    };
+  }
 
   // List of HTML entities for escaping.
   var escapeMap = {


### PR DESCRIPTION
Certain test frameworks override Date.now to match their stubbed
versions of `setTimeout`, `setInterval`, etc.  While Underscore works
well with replaced versions of those function (because it gets the
current copy each time they are used), this isn't true of the `Date.
now` function, which is cached when Underscore is first initialized.

This change ensures that Underscore uses the current version of the
`Date.now` function each time it is called for, and therefore
improves compatibility with such test libraries.