### PR TITLE
correct _.times example in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1911,7 +1911,7 @@ obj.initialize = _.noop;
         <i>Note: this example uses the <a href="#oop">object-oriented syntax</a></i>.
       </p>
       <pre>
-_(3).times(function(n){ genie.grantWishNumber(n); });</pre>
+_.times(3, function(n){ genie.grantWishNumber(n); });</pre>
 
       <p id="random">
         <b class="header">random</b><code>_.random(min, max)</code>


### PR DESCRIPTION
hello :) I've discovered issue of example _.times method in index.html file.

I just have changed
<pre>_(3).times(function(n){ genie.grantWishNumber(n); });</pre>
to
<pre>_.times(3, function(n){ genie.grantWishNumber(n); });</pre>.

Always thanks to underscore. :)