### PR TITLE
Add missing function alias to documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@
         <li data-name="reject">- <a href="#reject">reject</a></li>
         <li data-name="every" data-aliases="all">- <a href="#every">every</a></li>
         <li data-name="some" data-aliases="any">- <a href="#some">some</a></li>
-        <li data-name="contains" data-aliases="includes">- <a href="#contains">contains</a></li>
+        <li data-name="contains" data-aliases="include includes">- <a href="#contains">contains</a></li>
         <li data-name="invoke">- <a href="#invoke">invoke</a></li>
         <li data-name="pluck">- <a href="#pluck">pluck</a></li>
         <li data-name="max">- <a href="#max">max</a></li>
@@ -662,7 +662,7 @@ _.some([null, 0, 'yes', false]);
 
       <p id="contains">
         <b class="header">contains</b><code>_.contains(list, value, [fromIndex])</code>
-        <span class="alias">Alias: <b>includes</b></span>
+        <span class="alias">Aliases: <b>include</b>, <b>includes</b></span>
         <br />
         Returns <i>true</i> if the <b>value</b> is present in the <b>list</b>.
         Uses <b>indexOf</b> internally, if <b>list</b> is an Array.


### PR DESCRIPTION
[`contains` has two aliases `include` and `includes`](https://github.com/jashkenas/underscore/blob/master/underscore.js#L288)
This patch adds `include` to documentation
