### PR TITLE
Update debounce result

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -882,7 +882,7 @@
 
     var later = function(context, args) {
       timeout = null;
-      if (args) result = func.apply(context, args);
+      if (args) func.apply(context, args);
     };
 
     var debounced = restArgs(function(args) {


### PR DESCRIPTION
In debounce function, when immediate is false, since use the
setTimeout (_.delay), when debounced function return result, the result value is always undefined.