### PR TITLE
Support for typed array, DataView and ArrayBuffer in isEquals

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -585,7 +585,6 @@
     var i8 = new Int8Array([1,2]);
     var u16 = new Uint16Array([1,2]);
     var u16one = new Uint16Array([3]);
-    b = new Uint8Array([5,6,10]);
     
     assert.ok(_.isEqual(u8, u8b), 'Identical typed array data are equal');
     assert.ok(_.isEqual(u8.buffer, u8b.buffer), 'Identical ArrayBuffers are equal');

--- a/test/objects.js
+++ b/test/objects.js
@@ -588,13 +588,18 @@
     b = new Uint8Array([5,6,10]);
     
     assert.ok(_.isEqual(u8, u8b), 'Identical typed array data are equal');
+    assert.ok(_.isEqual(u8.buffer, u8b.buffer), 'Identical ArrayBuffers are equal');
     assert.ok(_.isEqual(new DataView(u8.buffer), new DataView(u8b.buffer)), 'Identical DataViews are equal');
-    assert.ok(_.isEqual(u8, i8), 'Different types of typed arrays with the same byte data are equal');
-    // same values, but different byte values
+    assert.ok(_.isEqual(new DataView(u8.buffer), new DataView(i8.buffer)), 'Identical DataViews of different typed arrays are equal');
+    assert.ok(_.isEqual(u8.buffer, i8.buffer), 'Identical ArrayBuffers of different typed arrays are equal');
+
+    assert.notOk(_.isEqual(u8, i8), 'Different types of typed arrays with the same byte data are not equal');
     assert.notOk(_.isEqual(u8, u16), 'Typed arrays with different types and different byte length are not equal');
     assert.notOk(_.isEqual(u8, u16one), 'Typed arrays with different types, same byte length but different byte data are not equal');
     assert.notOk(_.isEqual(new DataView(u8.buffer), new DataView(u16.buffer)), 'Different DataViews with different length are not equal');
     assert.notOk(_.isEqual(new DataView(u8.buffer), new DataView(u16one.buffer)), 'Different DataViews with different byte data are not equal');
+    assert.notOk(_.isEqual(u8.buffer, u16.buffer), 'Different ArrayBuffers with different length are not equal');
+    assert.notOk(_.isEqual(u8.buffer, u16one.buffer), 'Different ArrayBuffers with different byte data are not equal');
 
 
     //assert.ok(_.isEqual(new DataView(u8.buffer)), new DataView(u8b.buffer))

--- a/test/objects.js
+++ b/test/objects.js
@@ -578,6 +578,27 @@
       var sameStringSymbol = Symbol('x');
       assert.strictEqual(_.isEqual(symbol, sameStringSymbol), false, 'Different symbols of same string are not equal');
     }
+
+    // typed arrays
+    var u8 = new Uint8Array([1,2]);
+    var u8b = new Uint8Array([1,2]);
+    var i8 = new Int8Array([1,2]);
+    var u16 = new Uint16Array([1,2]);
+    var u16one = new Uint16Array([3]);
+    b = new Uint8Array([5,6,10]);
+    
+    assert.ok(_.isEqual(u8, u8b), 'Identical typed array data are equal');
+    assert.ok(_.isEqual(new DataView(u8.buffer), new DataView(u8b.buffer)), 'Identical DataViews are equal');
+    assert.ok(_.isEqual(u8, i8), 'Different types of typed arrays with the same byte data are equal');
+    // same values, but different byte values
+    assert.notOk(_.isEqual(u8, u16), 'Typed arrays with different types and different byte length are not equal');
+    assert.notOk(_.isEqual(u8, u16one), 'Typed arrays with different types, same byte length but different byte data are not equal');
+    assert.notOk(_.isEqual(new DataView(u8.buffer), new DataView(u16.buffer)), 'Different DataViews with different length are not equal');
+    assert.notOk(_.isEqual(new DataView(u8.buffer), new DataView(u16one.buffer)), 'Different DataViews with different byte data are not equal');
+
+
+    //assert.ok(_.isEqual(new DataView(u8.buffer)), new DataView(u8b.buffer))
+    //assert.notOk(_.isEqual(new DataView((new Uint8Array([1,2])).buffer), new DataView((new Uint8Array([5,6,10])).buffer));
   });
 
   QUnit.test('isEmpty', function(assert) {

--- a/underscore.js
+++ b/underscore.js
@@ -1201,19 +1201,21 @@
     if (a instanceof _) a = a._wrapped;
     if (b instanceof _) b = b._wrapped;
     // typed arrays are compared by byte content, try to get a DataView
-    try {
-      a = new DataView(a.buffer)
-    } catch(ee) {
-    }
-    try {
-      b = new DataView(b.buffer)
-    } catch(err) {
-    }
     // Compare `[[Class]]` names.
     var className = toString.call(a);
     if (className !== toString.call(b)) return false;
+
+    // If a and b are of the same typed array, we compare them as DataView
+    try {
+      a = new DataView(a.buffer)
+      b = new DataView(b.buffer)
+    } catch(err) {
+    }
+
     switch (className) {
-      // typed arrays we check by value
+      // DataView we check by value
+      case '[object ArrayBuffer]':
+        return deepEq(new DataView(a), new DataView(b), aStack, bStack)
       case '[object DataView]':
         if(a.byteLength !== b.byteLength) {
           return false

--- a/underscore.js
+++ b/underscore.js
@@ -1200,10 +1200,29 @@
     // Unwrap any wrapped objects.
     if (a instanceof _) a = a._wrapped;
     if (b instanceof _) b = b._wrapped;
+    // typed arrays are compared by byte content, try to get a DataView
+    try {
+      a = new DataView(a.buffer)
+    } catch(ee) {
+    }
+    try {
+      b = new DataView(b.buffer)
+    } catch(err) {
+    }
     // Compare `[[Class]]` names.
     var className = toString.call(a);
     if (className !== toString.call(b)) return false;
     switch (className) {
+      // typed arrays we check by value
+      case '[object DataView]':
+        if(a.byteLength !== b.byteLength) {
+          return false
+        }
+        for(var i = 0; i < a.byteLength; i++) {
+          if(a.getUint8(i) != b.getUint8(i)) {
+            return false
+          }
+        }
       // Strings, numbers, regular expressions, dates, and booleans are compared by value.
       case '[object RegExp]':
       // RegExps are coerced to strings for comparison (Note: '' + /a/i === '/a/i')

--- a/underscore.js
+++ b/underscore.js
@@ -1225,6 +1225,7 @@
             return false
           }
         }
+        return true;
       // Strings, numbers, regular expressions, dates, and booleans are compared by value.
       case '[object RegExp]':
       // RegExps are coerced to strings for comparison (Note: '' + /a/i === '/a/i')


### PR DESCRIPTION
Types much match for typed arrays, and for all of them the byte content must be equal. Fixes #2692