### PR TITLE
Ensure all _.random values are integers as said in documentation

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -74,6 +74,7 @@
     var array = _.range(1000);
     var min = Math.pow(2, 31);
     var max = Math.pow(2, 62);
+    var nonIntegerMin = min + 0.1;
 
     assert.ok(_.every(array, function() {
       return _.random(min, max) >= min;
@@ -82,6 +83,11 @@
     assert.ok(_.some(array, function() {
       return _.random(Number.MAX_VALUE) > 0;
     }), 'should produce a random number when passed `Number.MAX_VALUE`');
+
+    assert.ok(_.every(array, function() {
+      var randomValue = _.random(nonIntegerMin, max);
+      return randomValue === parseInt(randomValue, 10);
+    }), 'should produce only Integer values');
   });
 
   QUnit.test('now', function(assert) {

--- a/underscore.js
+++ b/underscore.js
@@ -1447,7 +1447,7 @@
       max = min;
       min = 0;
     }
-    return min + Math.floor(Math.random() * (max - min + 1));
+    return Math.round(min) + Math.floor(Math.random() * (max - min + 1));
   };
 
   // A (possibly faster) way to get the current timestamp as an integer.


### PR DESCRIPTION
Fixes #2695 

In the current approach, if `min` value is, for example `1.3`, `_.random` can produce values starting at `1.3`, it's an edge case, but with smaller ranges it's more probable.

I used `Math.round` to change the `min` value into an integer, but if this is not the best behavior I'm happy to change it :).

Current implementation:
```
  _.random = function(min, max) {
    if (max == null) {
      max = min;
      min = 0;
    }
    return min + Math.floor(Math.random() * (max - min + 1));
  };
```

New implementation:
```
  _.random = function(min, max) {
    if (max == null) {
      max = min;
      min = 0;
    }
    return Math.round(min) + Math.floor(Math.random() * (max - min + 1));
  };
```

Another approach I thought of was:
`return Math.round(min + Math.floor(Math.random() * (max - min + 1)));`
but I would like to hear your thoughts.

Here are some jsperf snippets: https://jsperf.com/underscore-random2