### PR TITLE
Added pickIndex, omitIndex and permute functions

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,6 +229,9 @@
         <li data-name="size">- <a href="#size">size</a></li>
         <li data-name="partition">- <a href="#partition">partition</a></li>
         <li data-name="compact">- <a href="#compact">compact</a></li>
+        <li data-name="pickIndex">- <a href="#pickIndex">pickIndex</a></li>
+        <li data-name="omitIndex">- <a href="#omitIndex">omitIndex</a></li>
+        <li data-name="permute">- <a href="#permute">permute</a></li>
       </ul>
     </div>
 
@@ -865,6 +868,40 @@ _.compact([0, 1, false, 2, '', 3]);
 =&gt; [1, 2, 3]
 </pre>
 
+      <p id="pickIndex">
+        <b class="header">pickIndex</b><code>_.pickIndex(collection, *values)</code>
+        <br />
+        Returns a copy of a given <b>collection</b> with the elements of the specified indexes.
+        Values higher than the length of the collection are ignored.
+      </p>
+      <pre>
+_.pickIndex([123, 321, {a: 1}, 'hello', 'bye'], 1, 3, 8);
+=&gt; [321, 'hello']
+</pre>
+      
+      <p id="omitIndex">
+        <b class="header">omitIndex</b><code>_.omitIndex(collection, *values)</code>
+        <span class="alias">Alias: <b>withoutIndex</b></span>
+        <br />
+        Returns a copy of a given <b>collection</b> without the elements of the specified indexes.
+        Values higher than the length of the collection are ignored.
+        Opposite to <b>_.pickIndex</b>.
+      </p>
+      <pre>
+_.omitIndex([123, 321, {a: 1}, 'hello', 'bye'], 1, 3, 8);
+=&gt; [123, {a: 1}, 'bye']
+</pre>
+      
+      <p id="permute">
+        <b class="header">permute</b><code>_.permute(collection)</code>
+        <br />
+        Returns a <b>collection</b> with all possible permutations of the elements of a given collection.
+      </p>
+      <pre>
+_.permute([1, 2, 3]);
+=&gt; [[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]
+</pre>
+      
       <h2 id="arrays">Array Functions</h2>
 
       <p>

--- a/test/collections.js
+++ b/test/collections.js
@@ -930,8 +930,8 @@
       assert.deepEqual(_.omitIndex(list, 3, 1, 2), [1, 2, 1, 15, 2354], 'handles unordered indexes');
       assert.deepEqual(_.omitIndex(list, [3, 1, 2]), [1, 2, 1, 15, 2354], 'handles an array of indexes');
       assert.deepEqual(_.omitIndex(list, 3, 1, 'hello'), [1, 234, 2, 1, 15, 2354], 'handles non-integer indexes');
-      assert.deepEqual(_.omitIndex(list, 134, 18, 1, 2), [1, 2, 1, 15, 2354], 'handles index values higher than array length');
-      assert.deepEqual(_.omitIndex(list, -2), [], 'handles negative index values');
+      assert.deepEqual(_.omitIndex(list, 134, 18, 1, 2), [1, 2356, 2, 1, 15, 2354], 'handles index values higher than array length');
+      assert.deepEqual(_.omitIndex(list, [1, 456, 234, 2356, 2, 1, 15, 2354]), [], 'handles negative index values');
   });
   
   if (typeof document != 'undefined') {

--- a/test/collections.js
+++ b/test/collections.js
@@ -931,7 +931,7 @@
       assert.deepEqual(_.omitIndex(list, [3, 1, 2]), [1, 2, 1, 15, 2354], 'handles an array of indexes');
       assert.deepEqual(_.omitIndex(list, 3, 1, 'hello'), [1, 234, 2, 1, 15, 2354], 'handles non-integer indexes');
       assert.deepEqual(_.omitIndex(list, 134, 18, 1, 2), [1, 2356, 2, 1, 15, 2354], 'handles index values higher than array length');
-      assert.deepEqual(_.omitIndex(list, [1, 456, 234, 2356, 2, 1, 15, 2354]), [], 'handles negative index values');
+      assert.deepEqual(_.omitIndex(list, -2), [1, 456, 234, 2356, 2, 1, 15, 2354], 'handles negative index values');
   });
   
   if (typeof document != 'undefined') {

--- a/test/collections.js
+++ b/test/collections.js
@@ -105,8 +105,7 @@
       'each', 'map', 'filter', 'find',
       'some', 'every', 'max', 'min', 'reject',
       'groupBy', 'countBy', 'partition', 'indexBy',
-      'reduce', 'reduceRight',
-      'pickIndex', 'omitIndex', 'permute'
+      'reduce', 'reduceRight'
     ];
     var array = [
       'findIndex', 'findLastIndex'

--- a/test/collections.js
+++ b/test/collections.js
@@ -919,19 +919,19 @@
       assert.deepEqual(_.pickIndex(list, 1, 2, 3), [456, 234, 2356], 'handles ordered indexes');
       assert.deepEqual(_.pickIndex(list, 3, 1, 2), [456, 234, 2356], 'handles unordered indexes');
       assert.deepEqual(_.pickIndex(list, [3, 1, 2]), [456, 234, 2356], 'handles an array of indexes');
-      assert.deepEqual(_.pickIndex(list, 3, 1, 'hello'), [1, 456, 234, 2356, 2, 1, 15, 2354], 'handles non-integer indexes');
+      assert.deepEqual(_.pickIndex(list, 3, 1, 'hello'), [456, 2356], 'handles non-integer indexes');
       assert.deepEqual(_.pickIndex(list, 134, 18, 1, 2), [456, 234], 'handles index values higher than array length');
-      assert.deepEqual(_.pickIndex(list, -2), [1, 456, 234, 2356, 2, 1, 15, 2354], 'handles negative index values');
+      assert.deepEqual(_.pickIndex(list, -2), [], 'handles negative index values');
   });
 
   QUnit.test('omitIndex', function (assert) {
       var list = [1, 456, 234, 2356, 2, 1, 15, 2354];
-      assert.deepEqual(_.pickIndex(list, 1, 2, 3), [1, 2, 1, 15, 2354], 'handles ordered indexes');
-      assert.deepEqual(_.pickIndex(list, 3, 1, 2), [1, 2, 1, 15, 2354], 'handles unordered indexes');
-      assert.deepEqual(_.pickIndex(list, [3, 1, 2]), [1, 2, 1, 15, 2354], 'handles an array of indexes');
-      assert.deepEqual(_.pickIndex(list, 3, 1, 'hello'), [1, 456, 234, 2356, 2, 1, 15, 2354], 'handles non-integer indexes');
-      assert.deepEqual(_.pickIndex(list, 134, 18, 1, 2), [1, 2, 1, 15, 2354], 'handles index values higher than array length');
-      assert.deepEqual(_.pickIndex(list, -2), [1, 456, 234, 2356, 2, 1, 15, 2354], 'handles negative index values');
+      assert.deepEqual(_.omitIndex(list, 1, 2, 3), [1, 2, 1, 15, 2354], 'handles ordered indexes');
+      assert.deepEqual(_.omitIndex(list, 3, 1, 2), [1, 2, 1, 15, 2354], 'handles unordered indexes');
+      assert.deepEqual(_.omitIndex(list, [3, 1, 2]), [1, 2, 1, 15, 2354], 'handles an array of indexes');
+      assert.deepEqual(_.omitIndex(list, 3, 1, 'hello'), [1, 234, 2, 1, 15, 2354], 'handles non-integer indexes');
+      assert.deepEqual(_.omitIndex(list, 134, 18, 1, 2), [1, 2, 1, 15, 2354], 'handles index values higher than array length');
+      assert.deepEqual(_.omitIndex(list, -2), [], 'handles negative index values');
   });
   
   if (typeof document != 'undefined') {

--- a/test/collections.js
+++ b/test/collections.js
@@ -914,26 +914,26 @@
     }, predicate);
   });
 
-  QUnit.test('pickIndex', function (assert) {
-      var list = [1, 456, 234, 2356, 2, 1, 15, 2354];
-      assert.deepEqual(_.pickIndex(list, 1, 2, 3), [456, 234, 2356], 'handles ordered indexes');
-      assert.deepEqual(_.pickIndex(list, 3, 1, 2), [456, 234, 2356], 'handles unordered indexes');
-      assert.deepEqual(_.pickIndex(list, [3, 1, 2]), [456, 234, 2356], 'handles an array of indexes');
-      assert.deepEqual(_.pickIndex(list, 3, 1, 'hello'), [456, 2356], 'handles non-integer indexes');
-      assert.deepEqual(_.pickIndex(list, 134, 18, 1, 2), [456, 234], 'handles index values higher than array length');
-      assert.deepEqual(_.pickIndex(list, -2), [], 'handles negative index values');
+  QUnit.test('pickIndex', function(assert) {
+    var list = [1, 456, 234, 2356, 2, 1, 15, 2354];
+    assert.deepEqual(_.pickIndex(list, 1, 2, 3), [456, 234, 2356], 'handles ordered indexes');
+    assert.deepEqual(_.pickIndex(list, 3, 1, 2), [456, 234, 2356], 'handles unordered indexes');
+    assert.deepEqual(_.pickIndex(list, [3, 1, 2]), [456, 234, 2356], 'handles an array of indexes');
+    assert.deepEqual(_.pickIndex(list, 3, 1, 'hello'), [456, 2356], 'handles non-integer indexes');
+    assert.deepEqual(_.pickIndex(list, 134, 18, 1, 2), [456, 234], 'handles index values higher than array length');
+    assert.deepEqual(_.pickIndex(list, -2), [], 'handles negative index values');
   });
 
-  QUnit.test('omitIndex', function (assert) {
-      var list = [1, 456, 234, 2356, 2, 1, 15, 2354];
-      assert.deepEqual(_.omitIndex(list, 1, 2, 3), [1, 2, 1, 15, 2354], 'handles ordered indexes');
-      assert.deepEqual(_.omitIndex(list, 3, 1, 2), [1, 2, 1, 15, 2354], 'handles unordered indexes');
-      assert.deepEqual(_.omitIndex(list, [3, 1, 2]), [1, 2, 1, 15, 2354], 'handles an array of indexes');
-      assert.deepEqual(_.omitIndex(list, 3, 1, 'hello'), [1, 234, 2, 1, 15, 2354], 'handles non-integer indexes');
-      assert.deepEqual(_.omitIndex(list, 134, 18, 1, 2), [1, 2356, 2, 1, 15, 2354], 'handles index values higher than array length');
-      assert.deepEqual(_.omitIndex(list, -2), [1, 456, 234, 2356, 2, 1, 15, 2354], 'handles negative index values');
+  QUnit.test('omitIndex', function(assert) {
+    var list = [1, 456, 234, 2356, 2, 1, 15, 2354];
+    assert.deepEqual(_.omitIndex(list, 1, 2, 3), [1, 2, 1, 15, 2354], 'handles ordered indexes');
+    assert.deepEqual(_.omitIndex(list, 3, 1, 2), [1, 2, 1, 15, 2354], 'handles unordered indexes');
+    assert.deepEqual(_.omitIndex(list, [3, 1, 2]), [1, 2, 1, 15, 2354], 'handles an array of indexes');
+    assert.deepEqual(_.omitIndex(list, 3, 1, 'hello'), [1, 234, 2, 1, 15, 2354], 'handles non-integer indexes');
+    assert.deepEqual(_.omitIndex(list, 134, 18, 1, 2), [1, 2356, 2, 1, 15, 2354], 'handles index values higher than array length');
+    assert.deepEqual(_.omitIndex(list, -2), [1, 456, 234, 2356, 2, 1, 15, 2354], 'handles negative index values');
   });
-  
+
   if (typeof document != 'undefined') {
     QUnit.test('Can use various collection methods on NodeLists', function(assert) {
       var parent = document.createElement('div');

--- a/test/collections.js
+++ b/test/collections.js
@@ -105,7 +105,8 @@
       'each', 'map', 'filter', 'find',
       'some', 'every', 'max', 'min', 'reject',
       'groupBy', 'countBy', 'partition', 'indexBy',
-      'reduce', 'reduceRight'
+      'reduce', 'reduceRight',
+      'pickIndex', 'omitIndex', 'permute'
     ];
     var array = [
       'findIndex', 'findLastIndex'
@@ -914,6 +915,26 @@
     }, predicate);
   });
 
+  QUnit.test('pickIndex', function (assert) {
+      var list = [1, 456, 234, 2356, 2, 1, 15, 2354];
+      assert.deepEqual(_.pickIndex(list, 1, 2, 3), [456, 234, 2356], 'handles ordered indexes');
+      assert.deepEqual(_.pickIndex(list, 3, 1, 2), [456, 234, 2356], 'handles unordered indexes');
+      assert.deepEqual(_.pickIndex(list, [3, 1, 2]), [456, 234, 2356], 'handles an array of indexes');
+      assert.deepEqual(_.pickIndex(list, 3, 1, 'hello'), [1, 456, 234, 2356, 2, 1, 15, 2354], 'handles non-integer indexes');
+      assert.deepEqual(_.pickIndex(list, 134, 18, 1, 2), [456, 234], 'handles index values higher than array length');
+      assert.deepEqual(_.pickIndex(list, -2), [1, 456, 234, 2356, 2, 1, 15, 2354], 'handles negative index values');
+  });
+
+  QUnit.test('omitIndex', function (assert) {
+      var list = [1, 456, 234, 2356, 2, 1, 15, 2354];
+      assert.deepEqual(_.pickIndex(list, 1, 2, 3), [1, 2, 1, 15, 2354], 'handles ordered indexes');
+      assert.deepEqual(_.pickIndex(list, 3, 1, 2), [1, 2, 1, 15, 2354], 'handles unordered indexes');
+      assert.deepEqual(_.pickIndex(list, [3, 1, 2]), [1, 2, 1, 15, 2354], 'handles an array of indexes');
+      assert.deepEqual(_.pickIndex(list, 3, 1, 'hello'), [1, 456, 234, 2356, 2, 1, 15, 2354], 'handles non-integer indexes');
+      assert.deepEqual(_.pickIndex(list, 134, 18, 1, 2), [1, 2, 1, 15, 2354], 'handles index values higher than array length');
+      assert.deepEqual(_.pickIndex(list, -2), [1, 456, 234, 2356, 2, 1, 15, 2354], 'handles negative index values');
+  });
+  
   if (typeof document != 'undefined') {
     QUnit.test('Can use various collection methods on NodeLists', function(assert) {
       var parent = document.createElement('div');

--- a/underscore.js
+++ b/underscore.js
@@ -491,7 +491,7 @@
     indexes = _.flatten(indexes);
     if (!_.isArray(input) || _.isEmpty(indexes)) return input;
     return _.filter(input, function(item, i) {
-       return _.contains(indexes, i);
+      return _.contains(indexes, i);
     });
   });
 
@@ -501,7 +501,7 @@
     indexes = _.flatten(indexes);
     if (!_.isArray(input) || _.isEmpty(indexes)) return input;
     return _.reject(input, function(item, i) {
-       return _.contains(indexes, i);
+      return _.contains(indexes, i);
     });
   });
 
@@ -509,16 +509,16 @@
   _.withoutIndex = _.omitIndex;
 
   // Returns an array with all the possible permutations of the elements.
-  _.permute = function (input) {
-    var result = _.map(input,function (item, index) {
-       var subarray = _.omitIndex(input, index);
-       var rest = _.permute(subarray);
-       return _.isEmpty(rest) ?
+  _.permute = function(input) {
+    var result = _.map(input, function(item, index) {
+      var subarray = _.omitIndex(input, index);
+      var rest = _.permute(subarray);
+      return _.isEmpty(rest) ?
           item :
           _.map(rest, function(item2) {
-             return _.flatten([item].concat(item2));
+            return _.flatten([item].concat(item2));
           });
-     });
+    });
     return _.flatten(result, true);
   };
   // Array Functions

--- a/underscore.js
+++ b/underscore.js
@@ -488,21 +488,21 @@
   // Returns an array with the specified indexes of the given array.
   // Opposite to _.omitIndex().
   _.pickIndex = restArgs(function(input, indexes) {
-     indexes = _.flatten(indexes);
-     if(!_.isArray(input) || _.isEmpty(indexes)) return input;
-     return _.filter(input, function (item, i) {
-        return _.contains(indexes, i);
-     });
+    indexes = _.flatten(indexes);
+    if (!_.isArray(input) || _.isEmpty(indexes)) return input;
+    return _.filter(input, function(item, i) {
+       return _.contains(indexes, i);
+    });
   });
 
   // Returns an array without the specified indexes of the given array.
   // Opposite to _.pickIndex().
   _.omitIndex = restArgs(function(input, indexes) {
-     indexes = _.flatten(indexes);
-     if(!_.isArray(input) || _.isEmpty(indexes)) return input;
-     return _.reject(input, function (item, i) {
-        return _.contains(indexes, i);
-     });
+    indexes = _.flatten(indexes);
+    if (!_.isArray(input) || _.isEmpty(indexes)) return input;
+    return _.reject(input, function(item, i) {
+       return _.contains(indexes, i);
+    });
   });
 
   // Alias for _.omitIndex().
@@ -510,17 +510,17 @@
 
   // Returns an array with all the possible permutations of the elements.
   _.permute = function (input) {
-     var result = _.map(input, function (item, index) {
-        var subarray = _.omitIndex(input, index);
-        var rest = _.permute(subarray);
-        return _.isEmpty(rest) ?
-           item :
-           _.map(rest, function (item2) {
-              return _.flatten([item].concat(item2));
-           });
-    });
+    var result = _.map(input,function (item, index) {
+       var subarray = _.omitIndex(input, index);
+       var rest = _.permute(subarray);
+       return _.isEmpty(rest) ?
+          item :
+          _.map(rest, function(item2) {
+             return _.flatten([item].concat(item2));
+          });
+     });
     return _.flatten(result, true);
- };
+  };
   // Array Functions
   // ---------------
 
@@ -1715,5 +1715,5 @@
     define('underscore', [], function() {
       return _;
     });
-    }
+  }
 }());

--- a/underscore.js
+++ b/underscore.js
@@ -489,7 +489,7 @@
   // Opposite to _.omitIndex().
   _.pickIndex = restArgs(function(input, indexes) {
      indexes = _.flatten(indexes);
-     if(!_.isArray(input) || _.isEmpty(indexes) || !_.every(indexes, _.isNumber)) return input;
+     if(!_.isArray(input) || _.isEmpty(indexes)) return input;
      return _.filter(input, function (item, i) {
         return _.contains(indexes, i);
      });
@@ -499,7 +499,7 @@
   // Opposite to _.pickIndex().
   _.omitIndex = restArgs(function(input, indexes) {
      indexes = _.flatten(indexes);
-     if(!_.isArray(input) || _.isEmpty(indexes) || !_.every(indexes, _.isNumber)) return input;
+     if(!_.isArray(input) || _.isEmpty(indexes)) return input;
      return _.reject(input, function (item, i) {
         return _.contains(indexes, i);
      });

--- a/underscore.js
+++ b/underscore.js
@@ -505,6 +505,9 @@
      });
   });
 
+  // Alias for _.omitIndex().
+  _.withoutIndex = _.omitIndex;
+
   // Returns an array with all the possible permutations of the elements.
   _.permute = function (input) {
      var result = _.map(input, function (item, index) {

--- a/underscore.js
+++ b/underscore.js
@@ -485,6 +485,39 @@
     result[pass ? 0 : 1].push(value);
   }, true);
 
+  // Returns an array with the specified indexes of the given array.
+  // Opposite to _.omitIndex().
+  _.pickIndex = restArgs(function(input, indexes) {
+     indexes = _.flatten(indexes);
+     if(!_.isArray(input) || _.isEmpty(indexes) || !_.every(indexes, _.isNumber)) return input;
+     return _.filter(input, function (item, i) {
+        return _.contains(indexes, i);
+     });
+  });
+
+  // Returns an array without the specified indexes of the given array.
+  // Opposite to _.pickIndex().
+  _.omitIndex = restArgs(function(input, indexes) {
+     indexes = _.flatten(indexes);
+     if(!_.isArray(input) || _.isEmpty(indexes) || !_.every(indexes, _.isNumber)) return input;
+     return _.reject(input, function (item, i) {
+        return _.contains(indexes, i);
+     });
+  });
+
+  // Returns an array with all the possible permutations of the elements.
+  _.permute = function (input) {
+     var result = _.map(input, function (item, index) {
+        var subarray = _.omitIndex(input, index);
+        var rest = _.permute(subarray);
+        return _.isEmpty(rest) ?
+           item :
+           _.map(rest, function (item2) {
+              return _.flatten([item].concat(item2));
+           });
+    });
+    return _.flatten(result, true);
+ };
   // Array Functions
   // ---------------
 
@@ -1679,5 +1712,5 @@
     define('underscore', [], function() {
       return _;
     });
-  }
+    }
 }());


### PR DESCRIPTION
Added 3 new collection functions:

- **pickIndex**: `_.pickIndex(collection, *values)`
Returns a copy of a given **collection** with the elements of the specified indexes. Values higher than the length of the collection are ignored.
```
_.pickIndex([123, 321, {a: 1}, 'hello', 'bye'], 1, 3, 8);
=> [321, 'hello']
```

- **omitIndex** (alias **withoutIndex**): `_.omitIndex(collection, *values)`
Returns a copy of a given **collection** without the elements of the specified indexes. Values higher than the length of the collection are ignored. Opposite to `_.pickIndex`.
```
_.omitIndex([123, 321, {a: 1}, 'hello', 'bye'], 1, 3, 8);
=> [123, {a: 1}, 'bye']
```

- **permute**: `_.permute(collection)`
Returns a **collection** with all possible permutations of the elements of a given collection.
```
_.permute([1, 2, 3]);
=> [[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]
```