### PR TITLE
fixed bug in test case

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -905,8 +905,9 @@
     assert.ok(_.has(obj, 'func'), 'works for functions too.');
     obj.hasOwnProperty = null;
     assert.ok(_.has(obj, 'foo'), 'works even when the hasOwnProperty method is deleted.');
-    var child = {};
-    child.prototype = obj;
+    function Child() {}
+    Child.prototype = obj;
+    var child = new Child();
     assert.notOk(_.has(child, 'foo'), 'does not check the prototype chain for a property.');
     assert.strictEqual(_.has(null, 'foo'), false, 'returns false for null');
     assert.strictEqual(_.has(void 0, 'foo'), false, 'returns false for undefined');


### PR DESCRIPTION
```
var child = {}
child.prototype = obj
// child: { prototype: obj, __proto__: Object }
```
This is not a prototype chain case.
```
function Child() {}
Child.prototype = obj
var child = new Child()
// child: { __proto__: obj }
```