### PR TITLE
[BUGFIX] (Bug #2714) For _.uniq which acted incorrectly on sorted lists using a non injective iteratee

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -153,6 +153,10 @@
     assert.deepEqual(_.uniq(list), [1, 2, 3, 4], 'can find the unique values of an unsorted array');
     list = [1, 1, 1, 2, 2, 3];
     assert.deepEqual(_.uniq(list, true), [1, 2, 3], 'can find the unique values of a sorted array faster');
+	
+	list = [-2,-1,0,1,2];
+	var notInjective = function(x) {return x * x};
+	assert.deepEqual(_.uniq(list, true, notInjective), [-2, -1, 0], 'can find values of sorted array which map to unique values through a non one-to-one function by switching to slower algorithm even when isSorted=true');
 
     list = [{name: 'Moe'}, {name: 'Curly'}, {name: 'Larry'}, {name: 'Curly'}];
     var expected = [{name: 'Moe'}, {name: 'Curly'}, {name: 'Larry'}];

--- a/test/arrays.js
+++ b/test/arrays.js
@@ -153,10 +153,10 @@
     assert.deepEqual(_.uniq(list), [1, 2, 3, 4], 'can find the unique values of an unsorted array');
     list = [1, 1, 1, 2, 2, 3];
     assert.deepEqual(_.uniq(list, true), [1, 2, 3], 'can find the unique values of a sorted array faster');
-	
-	list = [-2,-1,0,1,2];
-	var notInjective = function(x) {return x * x};
-	assert.deepEqual(_.uniq(list, true, notInjective), [-2, -1, 0], 'can find values of sorted array which map to unique values through a non one-to-one function by switching to slower algorithm even when isSorted=true');
+
+    list = [-2, -1, 0, 1, 2];
+    var notInjective = function(x) {return x * x;};
+    assert.deepEqual(_.uniq(list, true, notInjective), [-2, -1, 0], 'can find values of sorted array which map to unique values through a non one-to-one function by switching to slower algorithm even when isSorted=true');
 
     list = [{name: 'Moe'}, {name: 'Curly'}, {name: 'Larry'}, {name: 'Curly'}];
     var expected = [{name: 'Moe'}, {name: 'Curly'}, {name: 'Larry'}];

--- a/underscore.js
+++ b/underscore.js
@@ -558,6 +558,8 @@
 
   // Produce a duplicate-free version of the array. If the array has already
   // been sorted, you have the option of using a faster algorithm.
+  // The faster algorithm will not work with an iteratee if the iteratee is not a one-to-one function, so providing an iteratee will disable the faster algorithm
+  // Perhaps a warning should be thrown if an iteratee is provided while isSorted is true, to warn that the faster algorithm will not be used
   // Aliased as `unique`.
   _.uniq = _.unique = function(array, isSorted, iteratee, context) {
     if (!_.isBoolean(isSorted)) {
@@ -571,7 +573,7 @@
     for (var i = 0, length = getLength(array); i < length; i++) {
       var value = array[i],
           computed = iteratee ? iteratee(value, i, array) : value;
-      if (isSorted) {
+      if (isSorted && !iteratee) {
         if (!i || seen !== computed) result.push(value);
         seen = computed;
       } else if (iteratee) {

--- a/underscore.js
+++ b/underscore.js
@@ -558,8 +558,9 @@
 
   // Produce a duplicate-free version of the array. If the array has already
   // been sorted, you have the option of using a faster algorithm.
-  // The faster algorithm will not work with an iteratee if the iteratee is not a one-to-one function, so providing an iteratee will disable the faster algorithm
-  // Perhaps a warning should be thrown if an iteratee is provided while isSorted is true, to warn that the faster algorithm will not be used
+  // The faster algorithm will not work with an iteratee if the iteratee
+  // is not a one-to-one function, so providing an iteratee will disable
+  // the faster algorithm.
   // Aliased as `unique`.
   _.uniq = _.unique = function(array, isSorted, iteratee, context) {
     if (!_.isBoolean(isSorted)) {


### PR DESCRIPTION
When using an iteratee that is not a one-to-one function, and isSorted=true, then _.uniq would attempt to use the fast algorithm which fails for non one-to-one (injective) functions, because they map to resultant values which are not sorted.