### PR TITLE
Update year of licensure to 2018

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2017 Jeremy Ashkenas, DocumentCloud and Investigative
+Copyright (c) 2009-2018 Jeremy Ashkenas, DocumentCloud and Investigative
 Reporters & Editors
 
 Permission is hereby granted, free of charge, to any person

--- a/underscore.js
+++ b/underscore.js
@@ -1,6 +1,6 @@
 //     Underscore.js 1.8.3
 //     http://underscorejs.org
-//     (c) 2009-2017 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+//     (c) 2009-2018 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
 //     Underscore may be freely distributed under the MIT license.
 
 (function() {


### PR DESCRIPTION
Year range in LICENSE and underscore.js have been updated to 2018. 

TODO:
Consider 2009-Present format to avoid future commits.