### PR TITLE
[bugfix] min and max bug with iteratee and infinities fixed. Fixes #2688

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -343,10 +343,11 @@
         }
       }
     } else {
+      result = null;
       iteratee = cb(iteratee, context);
       _.each(obj, function(v, index, list) {
         computed = iteratee(v, index, list);
-        if (computed > lastComputed || computed === -Infinity && result === -Infinity) {
+        if (computed > lastComputed || result === null) {
           result = v;
           lastComputed = computed;
         }
@@ -368,10 +369,11 @@
         }
       }
     } else {
+      result = null;
       iteratee = cb(iteratee, context);
       _.each(obj, function(v, index, list) {
         computed = iteratee(v, index, list);
-        if (computed < lastComputed || computed === Infinity && result === Infinity) {
+        if (computed < lastComputed || result === null) {
           result = v;
           lastComputed = computed;
         }

--- a/underscore.js
+++ b/underscore.js
@@ -347,7 +347,7 @@
       iteratee = cb(iteratee, context);
       _.each(obj, function(v, index, list) {
         computed = iteratee(v, index, list);
-        if (computed > lastComputed || result === null && computed != null) {
+        if (computed > lastComputed || result === null && computed !== null) {
           result = v;
           lastComputed = computed;
         }
@@ -373,7 +373,7 @@
       iteratee = cb(iteratee, context);
       _.each(obj, function(v, index, list) {
         computed = iteratee(v, index, list);
-        if (computed < lastComputed || result === null && computed != null) {
+        if (computed < lastComputed || result === null && computed !== null) {
           result = v;
           lastComputed = computed;
         }

--- a/underscore.js
+++ b/underscore.js
@@ -347,7 +347,7 @@
       iteratee = cb(iteratee, context);
       _.each(obj, function(v, index, list) {
         computed = iteratee(v, index, list);
-        if (computed > lastComputed || result === null) {
+        if (computed > lastComputed || result === null && computed != null) {
           result = v;
           lastComputed = computed;
         }
@@ -373,7 +373,7 @@
       iteratee = cb(iteratee, context);
       _.each(obj, function(v, index, list) {
         computed = iteratee(v, index, list);
-        if (computed < lastComputed || result === null) {
+        if (computed < lastComputed || result === null && computed != null) {
           result = v;
           lastComputed = computed;
         }


### PR DESCRIPTION
'is first element min/max borders (infinities)' check simplified. these changes also fixed the bug between iteratee and Infinity/-Infinity. 

[#2688](https://github.com/jashkenas/underscore/issues/2688)