### PR TITLE
Speed up _.clone() on arrays

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1162,7 +1162,7 @@
   // Create a (shallow-cloned) duplicate of an object.
   _.clone = function(obj) {
     if (!_.isObject(obj)) return obj;
-    return _.isArray(obj) ? obj.slice() : _.extend({}, obj);
+    return _.isArray(obj) ? obj.concat() : _.extend({}, obj);
   };
 
   // Invokes interceptor with the obj, and then returns obj.


### PR DESCRIPTION
This is my test：
![image](https://user-images.githubusercontent.com/25007676/40180489-86f0e310-5a19-11e8-9dde-69a3536f561d.png)
arr.concat() has better performance than arr.slice().