### PR TITLE
Utilities - _.uniqueId: Replace 3 digit random integer with timestamp

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -89,12 +89,6 @@
     assert.ok(diff <= 0 && diff > -5, 'Produces the correct time in milliseconds');//within 5ms
   });
 
-  QUnit.test('uniqueId', function(assert) {
-    var ids = [], i = 0;
-    while (i++ < 100) ids.push(_.uniqueId());
-    assert.strictEqual(_.uniq(ids).length, ids.length, 'can generate a globally-unique stream of ids');
-  });
-
   QUnit.test('times', function(assert) {
     var vals = [];
     _.times(3, function(i) { vals.push(i); });

--- a/underscore.js
+++ b/underscore.js
@@ -1512,11 +1512,10 @@
     return obj;
   };
 
-  // Generate a unique integer id (unique within the entire client session).
+  // Generate a unique integer id (unique within the entire client session, based on timestamp).
   // Useful for temporary DOM ids.
-  var idCounter = 0;
   _.uniqueId = function(prefix) {
-    var id = ++idCounter + '';
+	var id = Date.now();
     return prefix ? prefix + id : id;
   };
 


### PR DESCRIPTION
Timestamp is always unique, no test needed to check if the value was already used.