### PR TITLE
Add license annotation

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -1,7 +1,11 @@
-//     Underscore.js 1.9.1
-//     http://underscorejs.org
-//     (c) 2009-2018 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
-//     Underscore may be freely distributed under the MIT license.
+/**
+ *  @license
+ *
+ *  Underscore.js 1.9.1
+ *  http://underscorejs.org
+ *  (c) 2009-2018 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ *  Underscore may be freely distributed under the MIT license.
+ */
 
 (function() {
 


### PR DESCRIPTION
When bundling a project with Webpack, all comments are removed by default except license annotated ones.
This is required in some companies for legal reasons.
It would be nice to have it in this project too.