### PR TITLE
Added lodash compat

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -40,9 +40,9 @@
 
   // Create a safe reference to the Underscore object for use below.
   var _ = function(obj) {
-    if (obj instanceof _) return obj;
+    if ('__wrapped__' in obj && '_wrapped' in obj) return obj;
     if (!(this instanceof _)) return new _(obj);
-    this._wrapped = obj;
+    this._wrapped = this.__wrapped__ = obj;
   };
 
   // Export the Underscore object for **Node.js**, with


### PR DESCRIPTION
Added lodash chain compatability, because if you look at the source:

```js
    function lodash(value) {
      if (isObjectLike(value) && !isArray(value) && !(value instanceof LazyWrapper)) {
        if (value instanceof LodashWrapper) {
          return value;
        }
        if (hasOwnProperty.call(value, '__wrapped__')) {
          return wrapperClone(value);
        }
      }
      return new LodashWrapper(value);
    }
```

It checks for the `__wrapped__` property, so this would add Lodash compatability.