### PR TITLE
Fix the issue with isArrayLike function

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -169,7 +169,7 @@
   var getLength = shallowProperty('length');
   var isArrayLike = function(collection) {
     var length = getLength(collection);
-    return typeof length == 'number' && length >= 0 && length <= MAX_ARRAY_INDEX;
+    return nativeIsArray(collection) && typeof length == 'number' && length >= 0 && length <= MAX_ARRAY_INDEX;
   };
 
   // Collection Functions


### PR DESCRIPTION
### Description
We have noticed that isArrayLike() function returns **true** for objects which contain **length** attribute.

### Steps to reproduce
In the browser console run the following code:
```
var shallowProperty = function(key) {
    return function(obj) {
      return obj == null ? void 0 : obj[key];
    };
  };
var MAX_ARRAY_INDEX = Math.pow(2, 53) - 1;
  var getLength = shallowProperty('length');
  var isArrayLike = function(collection) {
    var length = getLength(collection);
    return typeof length == 'number' && length >= 0 && length <= MAX_ARRAY_INDEX;
  };
isArrayLike({"id":"34","name":"Iris Workout Top-XS-Red","type":"simple","qty":"1.0000","product_id":"1421","parent_id":"33","parent_product_id":"1434","basePrice":0,"baseCurrency":"USD","price":0,"currency":"GBP","weight":13607760,"width":2032000,"length":3048000,"height":2540000,"sku":"WS03-XS-Red","is_use_box":false,"has_children":[]});
```
This code returns true for the Object which contain **length** property.

### Our solution
We have added the nativeIsArray checking and now the isArrayLike() function returns the **false** for objects with **length** property.
You can test it via the following code:
In the browser console run the following code:
```
var shallowProperty = function(key) {
    return function(obj) {
      return obj == null ? void 0 : obj[key];
    };
  };
var MAX_ARRAY_INDEX = Math.pow(2, 53) - 1;
  var getLength = shallowProperty('length');
  var isArrayLike = function(collection) {
    var length = getLength(collection);
    return Array.isArray(collection) && typeof length == 'number' && length >= 0 && length <= MAX_ARRAY_INDEX;
  };
isArrayLike({"id":"34","name":"Iris Workout Top-XS-Red","type":"simple","qty":"1.0000","product_id":"1421","parent_id":"33","parent_product_id":"1434","basePrice":0,"baseCurrency":"USD","price":0,"currency":"GBP","weight":13607760,"width":2032000,"length":3048000,"height":2540000,"sku":"WS03-XS-Red","is_use_box":false,"has_children":[]});
```