### PR TITLE
Wrong value for _.isEqual(0, new Number(Number.MIN_VALUE))

### DIFF
--- a/test/objects.js
+++ b/test/objects.js
@@ -331,6 +331,7 @@
     assert.ok(!_.isEqual(null, void 0), '`null` is not equal to `undefined`');
     assert.ok(!_.isEqual(void 0, null), 'Commutative equality is implemented for `null` and `undefined`');
     assert.ok(!_.isEqual(0, new Number(Number.MIN_VALUE)), '`0` is not equal to `new Number(Number.MIN_VALUE)`');
+    assert.ok(!_.isEqual(new Number(Number.MIN_VALUE), 0), '`new Number(Number.MIN_VALUE)` is not equal to `0`');
 
     // String object and primitive comparisons.
     assert.ok(_.isEqual('Curly', 'Curly'), 'Identical string primitives are equal');

--- a/test/objects.js
+++ b/test/objects.js
@@ -330,6 +330,7 @@
     assert.ok(!_.isEqual(-0, 0), 'Commutative equality is implemented for `0` and `-0`');
     assert.ok(!_.isEqual(null, void 0), '`null` is not equal to `undefined`');
     assert.ok(!_.isEqual(void 0, null), 'Commutative equality is implemented for `null` and `undefined`');
+    assert.ok(!_.isEqual(0, new Number(Number.MIN_VALUE)), '`0` is not equal to `new Number(Number.MIN_VALUE)`');
 
     // String object and primitive comparisons.
     assert.ok(_.isEqual('Curly', 'Curly'), 'Identical string primitives are equal');

--- a/underscore.js
+++ b/underscore.js
@@ -1223,7 +1223,7 @@
         // Object(NaN) is equivalent to NaN.
         if (+a !== +a) return +b !== +b;
         // An `egal` comparison is performed for other numeric values.
-        return +a === 0 ? 1 / +a === 1 / b : +a === +b;
+        return +a === 0 && +b === 0 ? 1 / +a === 1 / b : +a === +b;
       case '[object Date]':
       case '[object Boolean]':
         // Coerce dates and booleans to numeric primitive values. Dates are compared by their


### PR DESCRIPTION
The current implementation of underscore is returning an invalid answer for:

```js
_.isEqual(0, new Number(Number.MIN_VALUE))
// expected to be false but was true before the fix
```

Similar to a bug found in Jest https://github.com/facebook/jest/issues/7941

---

This bug has been discovered with the following test - property based testing test:
```js
import * as _ from "underscore";
import * as fc from "fast-check";

describe("_.toEqual", () => {
  it("should be symmetric", () => {
    fc.assert(
      fc.property(
        fc.anything({ withBoxedValues: true }),
        fc.anything({ withBoxedValues: true }),
        (a, b) => _.isEqual(a, b) === _.isEqual(b, a)
      ),
      { numRuns: 1000000 }
    );
  });
});
```

Please note that such kind of tests are currently used [within Jest](https://github.com/facebook/jest/blob/86e73f5b22e8a02b5233af78c68ef7318c59e1b3/packages/expect/src/__tests__/matchers-toEqual.property.test.ts#L26) to avoid future issues.