### PR TITLE
Fix documentation entry for "sortedIndex" function

### DIFF
--- a/index.html
+++ b/index.html
@@ -1091,7 +1091,7 @@ _.lastIndexOf([1, 2, 3, 1, 2, 3], 2);
       <p id="sortedIndex">
         <b class="header">sortedIndex</b><code>_.sortedIndex(array, value, [iteratee], [context])</code>
         <br />
-        Uses a binary search to determine the index at which the <b>value</b>
+        Uses a binary search to determine the smallest index at which the <b>value</b>
         <i>should</i> be inserted into the <b>array</b> in order to maintain the <b>array</b>'s
         sorted order. If an <a href="#iteratee"><b>iteratee</b></a> function is provided,
         it will be used to compute the sort ranking of each value, including the <b>value</b> you pass.

--- a/test/arrays.js
+++ b/test/arrays.js
@@ -130,9 +130,9 @@
   });
 
   QUnit.test('sortedIndex', function(assert) {
-    var numbers = [10, 20, 30, 40, 50];
+    var numbers = [10, 20, 30, 30, 30, 40, 50, 60];
     var indexFor35 = _.sortedIndex(numbers, 35);
-    assert.strictEqual(indexFor35, 3, 'finds the index at which a value should be inserted to retain order');
+    assert.strictEqual(indexFor35, 5, 'finds the index at which a value should be inserted to retain order');
     var indexFor30 = _.sortedIndex(numbers, 30);
     assert.strictEqual(indexFor30, 2, 'finds the smallest index at which a value could be inserted to retain order');
 


### PR DESCRIPTION
Documentation for the `sortedIndex()` was at least ambiguous at this point, or even wrong, consider for example `let m = [ 1, 2, 4, 4, 4, 5, 6, 7 ];` array, if we are searching for `4`, like so: `_.sortedIndex(m, 4);`, it actually returns `2` which is a **smallest** index of 4 between all it's occurences, not simply the index found by binary search, at this point true binary search could return `3` instead of `2`. So, it is important to state explicitly in the documentation that the index returned is indeed **the smallest index**, as I corrected here. Please apply this update.