### PR TITLE
Should functions be iterated as arrays?

### DIFF
--- a/test/collections.js
+++ b/test/collections.js
@@ -1,5 +1,11 @@
 (function() {
   var _ = typeof require == 'function' ? require('..') : window._;
+  var functions = [
+    'each', 'map', 'filter', 'find',
+    'some', 'every', 'max', 'min',
+    'groupBy', 'countBy', 'partition', 'indexBy'
+  ];
+  var reducers = ['reduce', 'reduceRight'];
 
   QUnit.module('Collections');
 
@@ -60,13 +66,6 @@
   });
 
   QUnit.test('Iterating objects with sketchy length properties', function(assert) {
-    var functions = [
-      'each', 'map', 'filter', 'find',
-      'some', 'every', 'max', 'min',
-      'groupBy', 'countBy', 'partition', 'indexBy'
-    ];
-    var reducers = ['reduce', 'reduceRight'];
-
     var tricks = [
       {length: '5'},
       {length: {valueOf: _.constant(5)}},
@@ -96,6 +95,28 @@
       _.each(reducers, function(method) {
         assert.strictEqual(_[method](trick), trick.length, method);
       });
+    });
+  });
+
+  QUnit.test('Iterating functions', function(assert) {
+    var func = function(a, b, c) {};
+    var prop = func.prop = 'd';
+    var length = func.length;
+    assert.expect(functions.length + reducers.length + 4);
+
+    assert.strictEqual(_.size(func), 1, 'size on func with length: ' + length);
+    assert.deepEqual(_.toArray(func), [prop], 'toArray on func with length: ' + length);
+    assert.deepEqual(_.shuffle(func), [prop], 'shuffle on func with length: ' + length);
+    assert.deepEqual(_.sample(func), prop, 'sample on func with length: ' + length);
+
+    _.each(functions, function(method) {
+      _[method](func, function(val, key) {
+        assert.strictEqual(key, 'prop', method + ': ran with prop = ' + val);
+      });
+    });
+
+    _.each(reducers, function(method) {
+      assert.strictEqual(_[method](func), func.prop, method);
     });
   });
 

--- a/underscore.js
+++ b/underscore.js
@@ -173,7 +173,8 @@
   var getLength = shallowProperty('length');
   var isArrayLike = function(collection) {
     var length = getLength(collection);
-    return typeof length == 'number' && length >= 0 && length <= MAX_ARRAY_INDEX;
+    return typeof collection != 'function' &&
+      typeof length == 'number' && length >= 0 && length <= MAX_ARRAY_INDEX;
   };
 
   // Collection Functions


### PR DESCRIPTION
@jashkenas The current behaviour, as implemented in the internal `isArrayLike` function, reflects "yes", based on the fact that functions have a numerical `length` property within safe bounds. However, I think the answer should be "no", for reasons I'll give below, and the current PR could be used to change the behaviour accordingly.

My case for adding a check against functions and iterating them object-like, rather than array-like, is as follows:

- Functions do not follow the convention of using `length` to indicate the number of integer keys. One could argue that this function property should have a different name, such as `numArgs`.
- Functions, especially constructors, often have nonnumeric keys that one may want to iterate over. For example `_`.
- Functions are common enough that a targeted check may be warranted.

The way `isArrayLike` arrives at its conclusion has been subject of debate in the past (for example in #1590). Opponents often took the stance that checking for a numerical `length` property is wrong altogether, sometimes suggesting radical changes in the way Underscore iteration should work. I would like to emphasize that I'm not in that school of thought. To the contrary; I think checking for a numerical `length` is essentially correct. However, I do think that the `length` property of functions has the wrong name for what it represents, which means that it should be disregarded when iterating a function.

Edit to add acknowledgement: I found one comment (https://github.com/jashkenas/underscore/issues/1590#issuecomment-42617297) which suggested the same approach. At the time, it drowned in the heated debate.