### PR TITLE
Take this from an isolated script context

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -13,7 +13,7 @@
   // instead of `window` for `WebWorker` support.
   var root = typeof self == 'object' && self.self === self && self ||
             typeof global == 'object' && global.global === global && global ||
-            this ||
+            Function('return this')() ||
             {};
 
   // Save the previous value of the `_` variable.


### PR DESCRIPTION
Fixes #2827, in a way that will continue to work after the rollup conversion from #2826. As a bonus, it will also stop rollup from complaining about `this` being undefined at module scope.

@lohriialo this is version D, but with a cleaner commit history.

@jashkenas it might be possible to skip the `self` and `global` checks and just always rely on `Function('return this')()`, but I'll leave that as an optional future step.