### PR TITLE
remove needless statement

### DIFF
--- a/underscore.js
+++ b/underscore.js
@@ -852,7 +852,7 @@
       previous = options.leading === false ? 0 : _.now();
       timeout = null;
       result = func.apply(context, args);
-      if (!timeout) context = args = null;
+      context = args = null;
     };
 
     var throttled = function() {


### PR DESCRIPTION
`!timeout` must be `true`, so we can remove this needless statement