### PR TITLE
fix: typo in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ node_js:
   - "6.14.1"
   - "8.11.1"
   - "9.11.1"
- matrix:
-   include:
-     - node_js: "4.0"
-       env: BROWSER=true
+matrix:
+  include:
+    - node_js: "4.0"
+      env: BROWSER=true
 before_install:
   - npm install -g npm@2.6
   - npm install -g karma-cli


### PR DESCRIPTION
When I pass the current version through js-yaml, it tells me that the whitespace there is unexpected.

Could this be why the [CI no longer works](https://github.com/jashkenas/underscore/issues/2847)?

Then again, this might just need a migration to travis-ci.com, etc