### PR TITLE
Fixing CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+services:
+  - xvfb
 sudo: false
 node_js:
   - "4.9.1"
@@ -13,8 +15,6 @@ before_install:
   - npm install -g karma-cli
 before_script:
   - npm install karma-sauce-launcher
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 script:
   - npm test
   - "[ $BROWSER == false ] || npm run test-browser"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,22 @@ language: node_js
 services:
   - xvfb
 sudo: false
-node_js:
-  - "4.9.1"
-  - "6.14.1"
-  - "8.11.1"
-  - "9.11.1"
-matrix:
+jobs:
   include:
-    - node_js: "4.0"
+    - node_js: 8
+      env: BROWSER=false
+    - node_js: 10
       env: BROWSER=true
+    - node_js: 14
+      env: BROWSER=false
 before_install:
   - npm install -g karma-cli
 before_script:
   - npm install karma-sauce-launcher
 script:
   - npm test
-  - "[ $BROWSER == false ] || npm run test-browser"
-  - "[ $BROWSER == false ] || karma start karma.conf-sauce.js"
+  - "[ $BROWSER = false ] || npm run test-browser"
+  - "[ $BROWSER = false ] || karma start karma.conf-sauce.js"
 notifications:
   email: false
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
     - node_js: "4.0"
       env: BROWSER=true
 before_install:
-  - npm install -g npm@2.6
   - npm install -g karma-cli
 before_script:
   - npm install karma-sauce-launcher

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test-node": "npm run prepare-tests && qunit-cli test/*.js",
     "test-browser": "npm run prepare-tests && npm i karma-phantomjs-launcher && karma start",
     "bundle": "rollup --config && eslint underscore.js",
-    "bundle-treeshake": "cd test-treeshake && npx rollup@latest --config",
+    "bundle-treeshake": "cd test-treeshake && rollup --config",
     "prepare-tests": "npm run bundle && npm run bundle-treeshake",
     "minify-umd": "terser underscore.js -c \"evaluate=false\" --comments \"/    .*/\" -m",
     "minify-esm": "terser underscore-esm.js -c \"evaluate=false\" --comments \"/    .*/\" -m",


### PR DESCRIPTION
This is a side branch with several experimental commits aiming to fix #2847. I succeeded in the end, so we'll have working CI checks again after I merge this.

The Travis build matrix now covers Node.js versions 8, 10 and 14. I'm skipping version 12 in order to reduce our carbon footprint, on the assumption that if 10 and 14 both work, 12 will probably work as well. If this turns out to be problematic, people are welcome to submit an issue or pull request.

The Sauce Labs integration doesn't work yet due to missing configuration. I consider this a separate issue.