### PR TITLE
find and replace usage of blacklist and whitelist with disallow and allow

### DIFF
--- a/docs/underscore-esm.html
+++ b/docs/underscore-esm.html
@@ -2725,7 +2725,7 @@ The opposite of object.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-122">&#182;</a>
               </div>
-              <p>Return a copy of the object only containing the whitelisted properties.</p>
+              <p>Return a copy of the object only containing the allowed properties.</p>
 
             </div>
             
@@ -2757,7 +2757,7 @@ The opposite of object.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-123">&#182;</a>
               </div>
-              <p>Return a copy of the object without the blacklisted properties.</p>
+              <p>Return a copy of the object without the disallowed properties.</p>
 
             </div>
             

--- a/index.html
+++ b/index.html
@@ -1602,7 +1602,7 @@ _.extend({name: 'moe'}, {age: 50});
         <b class="header">pick</b><code>_.pick(object, *keys)</code>
         <br />
         Return a copy of the <b>object</b>, filtered to only have values for
-        the whitelisted <b>keys</b> (or array of valid keys).  Alternatively
+        the allowed <b>keys</b> (or array of valid keys).  Alternatively
         accepts a predicate indicating which keys to pick.
       </p>
       <pre>
@@ -1617,7 +1617,7 @@ _.pick({name: 'moe', age: 50, userid: 'moe1'}, function(value, key, object) {
       <p id="omit">
         <b class="header">omit</b><code>_.omit(object, *keys)</code>
         <br />
-        Return a copy of the <b>object</b>, filtered to omit the blacklisted
+        Return a copy of the <b>object</b>, filtered to omit the disallowed
         <b>keys</b> (or array of keys).  Alternatively accepts a predicate
         indicating which keys to omit.
       </p>
@@ -2882,7 +2882,7 @@ _.chain([1, 2, 3]).reverse().value();
           </li>
           <li>
             Removed the ability to call <tt>_.bindAll</tt> with no method name
-            arguments. It's pretty much always wiser to white-list the names of
+            arguments. It's pretty much always wiser to allow the names of
             the methods you'd like to bind.
           </li>
           <li>
@@ -3042,7 +3042,7 @@ _.chain([1, 2, 3]).reverse().value();
           </li>
           <li>
             Added the <tt>pick</tt> function, which allows you to filter an
-            object literal with a whitelist of allowed property names.
+            object literal with a list of allowed property names.
           </li>
           <li>
             Added the <tt>result</tt> function, for convenience when working

--- a/modules/omit.js
+++ b/modules/omit.js
@@ -6,7 +6,7 @@ import flatten from './_flatten.js';
 import contains from './contains.js';
 import pick from './pick.js';
 
-// Return a copy of the object without the blacklisted properties.
+// Return a copy of the object without the disallowed properties.
 export default restArguments(function(obj, keys) {
   var iteratee = keys[0], context;
   if (isFunction(iteratee)) {

--- a/modules/pick.js
+++ b/modules/pick.js
@@ -5,7 +5,7 @@ import allKeys from './allKeys.js';
 import keyInObj from './_keyInObj.js';
 import flatten from './_flatten.js';
 
-// Return a copy of the object only containing the whitelisted properties.
+// Return a copy of the object only containing the allowed properties.
 export default restArguments(function(obj, keys) {
   var result = {}, iteratee = keys[0];
   if (obj == null) return result;

--- a/underscore-esm.js
+++ b/underscore-esm.js
@@ -1509,7 +1509,7 @@ function keyInObj(value, key, obj) {
   return key in obj;
 }
 
-// Return a copy of the object only containing the whitelisted properties.
+// Return a copy of the object only containing the allowed properties.
 var pick = restArguments(function(obj, keys) {
   var result = {}, iteratee = keys[0];
   if (obj == null) return result;
@@ -1529,7 +1529,7 @@ var pick = restArguments(function(obj, keys) {
   return result;
 });
 
-// Return a copy of the object without the blacklisted properties.
+// Return a copy of the object without the disallowed properties.
 var omit = restArguments(function(obj, keys) {
   var iteratee = keys[0], context;
   if (isFunction$1(iteratee)) {

--- a/underscore.js
+++ b/underscore.js
@@ -1518,7 +1518,7 @@
     return key in obj;
   }
 
-  // Return a copy of the object only containing the whitelisted properties.
+  // Return a copy of the object only containing the allowed properties.
   var pick = restArguments(function(obj, keys) {
     var result = {}, iteratee = keys[0];
     if (obj == null) return result;
@@ -1538,7 +1538,7 @@
     return result;
   });
 
-  // Return a copy of the object without the blacklisted properties.
+  // Return a copy of the object without the disallowed properties.
   var omit = restArguments(function(obj, keys) {
     var iteratee = keys[0], context;
     if (isFunction$1(iteratee)) {


### PR DESCRIPTION
This issue aims to bring the underscore codebase and documentation in line with the [Code of Conduct. ](https://github.com/jashkenas/underscore/blob/master/CODE_OF_CONDUCT.md)

Short: Provide terminology to package users that does not perpetuate white supremacy and racism against Black people

Long: There has been a much-needed shift in the tech industry to transition our naming conventions away from problematic racist terminology. For example, [Github is replacing the convention of having a master branch to remove any master/slave reference. ](https://www.cnet.com/news/microsofts-github-is-removing-coding-terms-like-master-and-slave/)