### PR TITLE
Clean up superfluous "exclusive" in _.range doc after #2035

### DIFF
--- a/index.html
+++ b/index.html
@@ -1179,12 +1179,13 @@ _.findLastIndex(users, {
         <b class="header">range</b><code>_.range([start], stop, [step])</code>
         <br />
         A function to create flexibly-numbered lists of integers, handy for
-        <tt>each</tt> and <tt>map</tt> loops. <b>start</b>, if omitted, defaults
-        to <i>0</i>; <b>step</b> defaults to <i>1</i>. Returns a list of integers
-        from <b>start</b> (inclusive) to <b>stop</b> (exclusive), incremented (or decremented) by <b>step</b>,
-        exclusive. Note that ranges that <b>stop</b> before they <b>start</b>
-        are considered to be zero-length instead of negative — if you'd like a
-        negative range, use a negative <b>step</b>.
+        <tt>each</tt> and <tt>map</tt> loops. <b>start</b>, if omitted,
+        defaults to <i>0</i>; <b>step</b> defaults to <i>1</i>. Returns a list
+        of integers from <b>start</b> (inclusive) to <b>stop</b> (exclusive),
+        incremented (or decremented) by <b>step</b>. Note that ranges that
+        <b>stop</b> before they <b>start</b> are considered to be zero-length
+        instead of negative — if you'd like a negative range, use a negative
+        <b>step</b>.
       </p>
       <pre>
 _.range(10);


### PR DESCRIPTION
Thanks to @reubenrybnik for bringing this to my attention in
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46189#discussion_r458423129.

I'm just removing the word "exclusive" after "step".

I don't really think this needs a review, but I'll leave this open for a few days just in case.