### PR TITLE
Update docs w/info on how templateSettings overrides are prioritized

### DIFF
--- a/index.html
+++ b/index.html
@@ -2225,9 +2225,9 @@ compiled({epithet: "stooge"});
         be inserted after being HTML-escaped, and an <b>evaluate</b> regex to match
         expressions that should be evaluated without insertion into the resulting
         string. Note that if part of your template matches more than one of these
-        regexes, the first of the following priority order will be applied:
-        <b>escape</b>, <b>interpolate</b>, or <b>evaluate</b>. You may also define or 
-        omit any combination of the three. For example, to perform
+        regexes, the first will be applied by the following order of priority:
+        (1) <b>escape</b>, (2) <b>interpolate</b>, (3) <b>evaluate</b>. You may
+        define or omit any combination of the three. For example, to perform
         <a href="https://github.com/janl/mustache.js#readme">Mustache.js</a>-style
         templating:
       </p>

--- a/index.html
+++ b/index.html
@@ -2224,8 +2224,10 @@ compiled({epithet: "stooge"});
         interpolated verbatim, an <b>escape</b> regex to match expressions that should
         be inserted after being HTML-escaped, and an <b>evaluate</b> regex to match
         expressions that should be evaluated without insertion into the resulting
-        string. You may define or omit any combination of the three.
-        For example, to perform
+        string. Note that if part of your template matches more than one of these
+        regexes, the first of the following priority order will be applied:
+        <b>escape</b>, <b>interpolate</b>, or <b>evaluate</b>. You may also define or 
+        omit any combination of the three. For example, to perform
         <a href="https://github.com/janl/mustache.js#readme">Mustache.js</a>-style
         templating:
       </p>


### PR DESCRIPTION
A coworker and I were stumped on why our template settings weren't working the the other day. This adds a line to the docs about how the template settings regexes are prioritized. For example, the default interpolation regex `<%= etc %>` matches a subset of the default evaluation regex `<% etc %>`, but if you switch those two regexes, things break because then the interpolation regex is prioritized and the evaluation regex never matches.