### PR TITLE
Fix a bug in _collectNonEnumProps.js

### DIFF
--- a/modules/_collectNonEnumProps.js
+++ b/modules/_collectNonEnumProps.js
@@ -10,7 +10,7 @@ function emulatedSet(keys) {
   var hash = {};
   for (var l = keys.length, i = 0; i < l; ++i) hash[keys[i]] = true;
   return {
-    contains: function(key) { return hash[key]; },
+    contains: function(key) { return hash[key]===true; },
     push: function(key) {
       hash[key] = true;
       return keys.push(key);


### PR DESCRIPTION
As hash inherit Object.prototype, when we call "contains", property keys of Object.prototype will return true. This isn't our expectation. Using "hash[key]===true" can exclude these keys.