### PR TITLE
[Tests]: System time tampering effects on `_.throttle` and `_.debounce` methods

### DIFF
--- a/test/functions.js
+++ b/test/functions.js
@@ -394,7 +394,7 @@
     var originalGetTimeFunc = Date.prototype.getTime;
 
     throttledIncr();
-    assert.strictEqual(counter, 1, '_.throttle: incr was called immediately');
+    assert.strictEqual(counter, 1, 'incr was called immediately');
 
     Date.prototype.getTime = function() {
       return +(new Date(2013, 0, 1, 1, 1, 1));
@@ -405,7 +405,7 @@
 
     _.delay(function() {
       throttledIncr();
-      assert.strictEqual(counter, 2, '_.throttle: incr was called successfully, with tampered system time');
+      assert.strictEqual(counter, 2, 'incr was throttled successfully, with tampered system time');
       done();
       Date.now = originalNowFunc;
       Date.prototype.getTime = originalGetTimeFunc;
@@ -423,7 +423,7 @@
     var originalValueOfFunc = Date.prototype.valueOf;
 
     throttledIncr();
-    assert.strictEqual(counter, 1, '_.throttle: incr was called immediately');
+    assert.strictEqual(counter, 1, 'incr was called immediately');
 
     Date.prototype.valueOf = function() {
       return null;
@@ -437,7 +437,7 @@
 
     _.delay(function() {
       throttledIncr();
-      assert.strictEqual(counter, 2, '_.throttle: incr was debounced successfully, with tampered system time');
+      assert.strictEqual(counter, 2, 'incr was throttled successfully, with tampered system time');
       Date.now = originalNowFunc;
       Date.prototype.getTime = originalGetTimeFunc;
       Date.prototype.valueOf = originalValueOfFunc;
@@ -445,7 +445,7 @@
 
     _.delay(function() {
       throttledIncr();
-      assert.strictEqual(counter, 3, '_.throttle: incr was debounced successfully, after system time method restoration');
+      assert.strictEqual(counter, 3, 'incr was throttled successfully, after system time method restoration');
       done();
     }, 400);
   });
@@ -593,7 +593,7 @@
     var originalGetTimeFunc = Date.prototype.getTime;
 
     debouncedIncr();
-    assert.strictEqual(counter, 1, '_.debounce: incr was called immediately');
+    assert.strictEqual(counter, 1, 'incr was called immediately');
 
     Date.prototype.getTime = function() {
       return +(new Date(2013, 0, 1, 1, 1, 1));
@@ -604,7 +604,7 @@
 
     _.delay(function() {
       debouncedIncr();
-      assert.strictEqual(counter, 2, '_.debounce: incr was debounced successfully, with tampered system time');
+      assert.strictEqual(counter, 2, 'incr was debounced successfully, with tampered system time');
       done();
       Date.now = originalNowFunc;
       Date.prototype.getTime = originalGetTimeFunc;
@@ -623,7 +623,7 @@
     var originalValueOfFunc = Date.prototype.valueOf;
 
     debouncedIncr();
-    assert.strictEqual(counter, 1, '_.debounce: incr was called immediately');
+    assert.strictEqual(counter, 1, 'incr was called immediately');
 
     Date.prototype.valueOf = function() {
       return null;
@@ -637,7 +637,7 @@
 
     _.delay(function() {
       debouncedIncr();
-      assert.strictEqual(counter, 2, '_.debounce: incr was debounced successfully, with tampered system time');
+      assert.strictEqual(counter, 2, 'incr was debounced successfully, with tampered system time');
       Date.now = originalNowFunc;
       Date.prototype.getTime = originalGetTimeFunc;
       Date.prototype.valueOf = originalValueOfFunc;
@@ -645,7 +645,7 @@
 
     _.delay(function() {
       debouncedIncr();
-      assert.strictEqual(counter, 3, '_.debounce: incr was debounced successfully, after system time method restoration');
+      assert.strictEqual(counter, 3, 'incr was debounced successfully, after system time method restoration');
       done();
     }, 400);
   });


### PR DESCRIPTION
✅ Closes: #2883

### Changes
Tests only:
* Monkey patch `Date.prototype.getTime` and `Date.prototype.valueOf` methods and `Date.now` method in `_.debounce` and `_.throttle` test cases,
* Provide additional test case asserting the outputs before and after monkey patching,
* Remove the reference to `_.now` method in test cases as the underlying implementation of library methods don't reference the methods from the `_` object but rather call dependent methods directly.

### Checklist
After the changes I ensured that:
 * no stylistic or unwanted errors are present, by running `npm run lint`,
 * no tests are failing, by running `npm run test`,
 * build passes with no issues, by running `npm run bundle`.

### Done
- [x] Added/updated unit tests for this change
- [x] Included links to related issues/PRs

### Additional notes
The underlying changes could've been done by monkey patching the native `Date` and `Date.prototype` methods in `before` (or `beforeEach`) and `after` (or `afterEach`) hooks in the *Functions* QUnit module. However, that would require a minor changes in two other test cases from the same module (as the `valueOf` method of the `Date.prototype` would be changed for all test cases and always return the same value which would cause certain test cases to hang to the operations `new Date - date < amount` as that will always result in the `false` value in the `while` loop).

I can provide the change if necessary using `before` and `after` hooks instead.
I just wanted to assure that the implementation of `_.throttle` and `_.debounce` methods will **not** break, if the system time would be tempered (monkey patched).
I guess the test cases can be safely omitted as they're redundant @jgonggrijp?
If so, I can provide another commit to the same PR removing the obsolete test cases.