### PR TITLE
Enabled faster algorithm for _.uniq with non-function iteratee

### DIFF
--- a/modules/uniq.js
+++ b/modules/uniq.js
@@ -1,4 +1,6 @@
 import isBoolean from './isBoolean.js';
+import isString from './isString.js';
+import isArray from './isArray.js';
 import cb from './_cb.js';
 import getLength from './_getLength.js';
 import contains from './contains.js';
@@ -6,7 +8,7 @@ import contains from './contains.js';
 // Produce a duplicate-free version of the array. If the array has already
 // been sorted, you have the option of using a faster algorithm.
 // The faster algorithm will not work with an iteratee if the iteratee
-// is not a one-to-one function, so providing an iteratee will disable
+// is not a one-to-one function, so providing an iteratee function will disable
 // the faster algorithm.
 export default function uniq(array, isSorted, iteratee, context) {
   if (!isBoolean(isSorted)) {
@@ -14,13 +16,14 @@ export default function uniq(array, isSorted, iteratee, context) {
     iteratee = isSorted;
     isSorted = false;
   }
+  var faster = isSorted && (!iteratee || isString(iteratee) || isArray(iteratee));
   if (iteratee != null) iteratee = cb(iteratee, context);
   var result = [];
   var seen = [];
   for (var i = 0, length = getLength(array); i < length; i++) {
     var value = array[i],
         computed = iteratee ? iteratee(value, i, array) : value;
-    if (isSorted && !iteratee) {
+    if (faster) {
       if (!i || seen !== computed) result.push(value);
       seen = computed;
     } else if (iteratee) {


### PR DESCRIPTION
The faster algorithm on sorted array will not work for `_.uniq` with an iteratee, if the iteratee is not a one-to-one function. Because of that it was disabled for all iteratees, even for those producing one-to-one functions, such as `String` and `Array` iteratees (handled by `property()` function). This PR introduces the code that checks the iteratee type and enables faster algorithm if possible.