### PR TITLE
add sideEffects false to modules/package.json

### DIFF
--- a/modules/package.json
+++ b/modules/package.json
@@ -1,3 +1,4 @@
 {
-  "type": "module"
+  "type": "module",
+  "sideEffects": false
 }


### PR DESCRIPTION
Thanks for all the work done on this project.

I've been trying to use tree-shacking with the module. Looks that the current convention among bundler is to assume all code has side effects (cannot be removed, even if not used directly), unless there is `sideEffect: false` set on `package.json` (https://github.com/evanw/esbuild/issues/50#issuecomment-634107700)

The solution I'm proposing here can be see in action here:
* https://github.com/marcin-wosinek/underscore-tree-shaking/commit/ec894eb66d0d20b4f32048e128f800fd21cbed31 build has **19.7 KiB**:
```sh
$ npm ci; npm run webpack

...

asset main.js 19.7 KiB [emitted] [minimized] (name: main)
orphan modules 83.1 KiB [orphan] 161 modules
runtime modules 670 bytes 3 modules
./src/index.js + 161 modules 83.2 KiB [built] [code generated]
webpack 5.50.0 compiled successfully in 1252 ms
```

while https://github.com/marcin-wosinek/underscore-tree-shaking/commit/9a52666b8cdbe2dc9f8939ef9361fffdc11d05a3 build to **2.9 KiB**:
```sh
$ npm ci; npm run webpack

...

asset main.js 2.9 KiB [emitted] [minimized] (name: main)
orphan modules 83.1 KiB [orphan] 161 modules
./src/index.js + 26 modules 12.4 KiB [built] [code generated]
webpack 5.50.0 compiled successfully in 754 ms
```