### PR TITLE
Remove unneeded Xvfb from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
-services:
-  - xvfb
 sudo: false
 jobs:
   include:


### PR DESCRIPTION
Remove the "xvfb" service. This was no longer used since browser testing was moved to SauceLabs. Also, for Firefox Headless or PhantomJS, Xvfb wouldn't be needed (mainly for pre-headless era of browser testing.)