### PR TITLE
Test: Use same QUnit version in CI as on website

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "underscore",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6042,9 +6042,9 @@
       "dev": true
     },
     "qunit": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.10.0.tgz",
-      "integrity": "sha512-EP9Q9Kf45z4l/X02ZJtyTQU9DBc82pEWAncSNx7Weo/73BDpX71xqbsdDAQrtEeeilK70cib7CY/lniJV6Cwwg==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.10.1.tgz",
+      "integrity": "sha512-6ntXpabAW+ycodADqsC2QWPr6xLubag3WBujaAfOlltgwkBVDmM0gkB5dS2Mc4RAszmvtYzyYDSMZX5ibwkNWw==",
       "dev": true,
       "requires": {
         "commander": "2.12.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "karma-sauce-launcher": "^1.2.0",
     "nyc": "^2.1.3",
     "pretty-bytes-cli": "^1.0.0",
-    "qunit": "^2.10.0",
+    "qunit": "2.10.1",
     "rollup": "^2.40.0",
     "terser": "^4.6.13"
   },

--- a/test/vendor/qunit.css
+++ b/test/vendor/qunit.css
@@ -1,15 +1,26 @@
 /*!
- * QUnit 2.6.0
+ * QUnit 2.10.1
  * https://qunitjs.com/
  *
  * Copyright jQuery Foundation and other contributors
  * Released under the MIT license
  * https://jquery.org/license
  *
- * Date: 2018-03-27T02:18Z
+ * Date: 2020-07-04T23:21Z
  */
 
 /** Font Family and Sizes */
+
+/* Style our buttons in a simple way, uninfluenced by the styles
+   the tested app might load. Don't affect buttons in #qunit-fixture!
+   https://github.com/qunitjs/qunit/pull/1395
+   https://github.com/qunitjs/qunit/issues/1437 */
+#qunit-testrunner-toolbar button,
+#qunit-testresult button {
+	font-size: initial;
+	border: initial;
+	background-color: buttonface;
+}
 
 #qunit-tests, #qunit-header, #qunit-banner, #qunit-testrunner-toolbar, #qunit-filteredTest, #qunit-userAgent, #qunit-testresult {
 	font-family: "Helvetica Neue Light", "HelveticaNeue-Light", "Helvetica Neue", Calibri, Helvetica, Arial, sans-serif;
@@ -98,6 +109,10 @@
 	height: 1.6em;
 }
 
+#qunit-toolbar-filters {
+	float: right;
+}
+
 .qunit-url-config,
 .qunit-filter,
 #qunit-modulefilter {
@@ -107,7 +122,6 @@
 
 .qunit-filter,
 #qunit-modulefilter {
-	float: right;
 	position: relative;
 	margin-left: 1em;
 }
@@ -118,7 +132,7 @@
 
 #qunit-modulefilter-search {
 	box-sizing: border-box;
-	width: 400px;
+	min-width: 400px;
 }
 
 #qunit-modulefilter-search-container:after {
@@ -131,7 +145,7 @@
 #qunit-modulefilter-dropdown {
 	/* align with #qunit-modulefilter-search */
 	box-sizing: border-box;
-	width: 400px;
+	min-width: 400px;
 	position: absolute;
 	right: 0;
 	top: 50%;
@@ -204,6 +218,7 @@
 #qunit-modulefilter-dropdown-list .clickable {
 	display: block;
 	padding-left: 0.15em;
+	padding-right: 0.5em;
 }
 
 

--- a/test/vendor/qunit.js
+++ b/test/vendor/qunit.js
@@ -1,26 +1,26 @@
 /*!
- * QUnit 2.6.0
+ * QUnit 2.10.1
  * https://qunitjs.com/
  *
  * Copyright jQuery Foundation and other contributors
  * Released under the MIT license
  * https://jquery.org/license
  *
- * Date: 2018-03-27T02:18Z
+ * Date: 2020-07-04T23:21Z
  */
 (function (global$1) {
   'use strict';
 
   global$1 = global$1 && global$1.hasOwnProperty('default') ? global$1['default'] : global$1;
 
-  var window = global$1.window;
+  var window$1 = global$1.window;
   var self$1 = global$1.self;
   var console = global$1.console;
-  var setTimeout = global$1.setTimeout;
+  var setTimeout$1 = global$1.setTimeout;
   var clearTimeout = global$1.clearTimeout;
 
-  var document = window && window.document;
-  var navigator = window && window.navigator;
+  var document$1 = window$1 && window$1.document;
+  var navigator = window$1 && window$1.navigator;
 
   var localSessionStorage = function () {
   	var x = "qunit-test-string";
@@ -32,6 +32,24 @@
   		return undefined;
   	}
   }();
+
+  /**
+   * Returns a function that proxies to the given method name on the globals
+   * console object. The proxy will also detect if the console doesn't exist and
+   * will appropriately no-op. This allows support for IE9, which doesn't have a
+   * console if the developer tools are not open.
+   */
+  function consoleProxy(method) {
+  	return function () {
+  		if (console) {
+  			console[method].apply(console, arguments);
+  		}
+  	};
+  }
+
+  var Logger = {
+  	warn: consoleProxy("warn")
+  };
 
   var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) {
     return typeof obj;
@@ -129,9 +147,28 @@
   	return new Date().getTime();
   };
 
+  var hasPerformanceApi = detectPerformanceApi();
+  var performance = hasPerformanceApi ? window$1.performance : undefined;
+  var performanceNow = hasPerformanceApi ? performance.now.bind(performance) : now;
+
+  function detectPerformanceApi() {
+  	return window$1 && typeof window$1.performance !== "undefined" && typeof window$1.performance.mark === "function" && typeof window$1.performance.measure === "function";
+  }
+
+  function measure(comment, startMark, endMark) {
+
+  	// `performance.measure` may fail if the mark could not be found.
+  	// reasons a specific mark could not be found include: outside code invoking `performance.clearMarks()`
+  	try {
+  		performance.measure(comment, startMark, endMark);
+  	} catch (ex) {
+  		Logger.warn("performance.measure could not be executed because of ", ex.message);
+  	}
+  }
+
   var defined = {
-  	document: window && window.document !== undefined,
-  	setTimeout: setTimeout !== undefined
+  	document: window$1 && window$1.document !== undefined,
+  	setTimeout: setTimeout$1 !== undefined
   };
 
   // Returns a new Array with the elements that are in a but not in b
@@ -656,10 +693,10 @@
   };
 
   // take a predefined QUnit.config and extend the defaults
-  var globalConfig = window && window.QUnit && window.QUnit.config;
+  var globalConfig = window$1 && window$1.QUnit && window$1.QUnit.config;
 
   // only extend the global config if there is no QUnit overload
-  if (window && window.QUnit && !window.QUnit.version) {
+  if (window$1 && window$1.QUnit && !window$1.QUnit.version) {
   	extend(config, globalConfig);
   }
 
@@ -950,6 +987,271 @@
   	return dump;
   })();
 
+  var SuiteReport = function () {
+  	function SuiteReport(name, parentSuite) {
+  		classCallCheck(this, SuiteReport);
+
+  		this.name = name;
+  		this.fullName = parentSuite ? parentSuite.fullName.concat(name) : [];
+
+  		this.tests = [];
+  		this.childSuites = [];
+
+  		if (parentSuite) {
+  			parentSuite.pushChildSuite(this);
+  		}
+  	}
+
+  	createClass(SuiteReport, [{
+  		key: "start",
+  		value: function start(recordTime) {
+  			if (recordTime) {
+  				this._startTime = performanceNow();
+
+  				if (performance) {
+  					var suiteLevel = this.fullName.length;
+  					performance.mark("qunit_suite_" + suiteLevel + "_start");
+  				}
+  			}
+
+  			return {
+  				name: this.name,
+  				fullName: this.fullName.slice(),
+  				tests: this.tests.map(function (test) {
+  					return test.start();
+  				}),
+  				childSuites: this.childSuites.map(function (suite) {
+  					return suite.start();
+  				}),
+  				testCounts: {
+  					total: this.getTestCounts().total
+  				}
+  			};
+  		}
+  	}, {
+  		key: "end",
+  		value: function end(recordTime) {
+  			if (recordTime) {
+  				this._endTime = performanceNow();
+
+  				if (performance) {
+  					var suiteLevel = this.fullName.length;
+  					performance.mark("qunit_suite_" + suiteLevel + "_end");
+
+  					var suiteName = this.fullName.join(" – ");
+
+  					measure(suiteLevel === 0 ? "QUnit Test Run" : "QUnit Test Suite: " + suiteName, "qunit_suite_" + suiteLevel + "_start", "qunit_suite_" + suiteLevel + "_end");
+  				}
+  			}
+
+  			return {
+  				name: this.name,
+  				fullName: this.fullName.slice(),
+  				tests: this.tests.map(function (test) {
+  					return test.end();
+  				}),
+  				childSuites: this.childSuites.map(function (suite) {
+  					return suite.end();
+  				}),
+  				testCounts: this.getTestCounts(),
+  				runtime: this.getRuntime(),
+  				status: this.getStatus()
+  			};
+  		}
+  	}, {
+  		key: "pushChildSuite",
+  		value: function pushChildSuite(suite) {
+  			this.childSuites.push(suite);
+  		}
+  	}, {
+  		key: "pushTest",
+  		value: function pushTest(test) {
+  			this.tests.push(test);
+  		}
+  	}, {
+  		key: "getRuntime",
+  		value: function getRuntime() {
+  			return this._endTime - this._startTime;
+  		}
+  	}, {
+  		key: "getTestCounts",
+  		value: function getTestCounts() {
+  			var counts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : { passed: 0, failed: 0, skipped: 0, todo: 0, total: 0 };
+
+  			counts = this.tests.reduce(function (counts, test) {
+  				if (test.valid) {
+  					counts[test.getStatus()]++;
+  					counts.total++;
+  				}
+
+  				return counts;
+  			}, counts);
+
+  			return this.childSuites.reduce(function (counts, suite) {
+  				return suite.getTestCounts(counts);
+  			}, counts);
+  		}
+  	}, {
+  		key: "getStatus",
+  		value: function getStatus() {
+  			var _getTestCounts = this.getTestCounts(),
+  			    total = _getTestCounts.total,
+  			    failed = _getTestCounts.failed,
+  			    skipped = _getTestCounts.skipped,
+  			    todo = _getTestCounts.todo;
+
+  			if (failed) {
+  				return "failed";
+  			} else {
+  				if (skipped === total) {
+  					return "skipped";
+  				} else if (todo === total) {
+  					return "todo";
+  				} else {
+  					return "passed";
+  				}
+  			}
+  		}
+  	}]);
+  	return SuiteReport;
+  }();
+
+  var focused = false;
+
+  var moduleStack = [];
+
+  function isParentModuleInQueue() {
+  	var modulesInQueue = config.modules.map(function (module) {
+  		return module.moduleId;
+  	});
+  	return moduleStack.some(function (module) {
+  		return modulesInQueue.includes(module.moduleId);
+  	});
+  }
+
+  function createModule(name, testEnvironment, modifiers) {
+  	var parentModule = moduleStack.length ? moduleStack.slice(-1)[0] : null;
+  	var moduleName = parentModule !== null ? [parentModule.name, name].join(" > ") : name;
+  	var parentSuite = parentModule ? parentModule.suiteReport : globalSuite;
+
+  	var skip = parentModule !== null && parentModule.skip || modifiers.skip;
+  	var todo = parentModule !== null && parentModule.todo || modifiers.todo;
+
+  	var module = {
+  		name: moduleName,
+  		parentModule: parentModule,
+  		tests: [],
+  		moduleId: generateHash(moduleName),
+  		testsRun: 0,
+  		unskippedTestsRun: 0,
+  		childModules: [],
+  		suiteReport: new SuiteReport(name, parentSuite),
+
+  		// Pass along `skip` and `todo` properties from parent module, in case
+  		// there is one, to childs. And use own otherwise.
+  		// This property will be used to mark own tests and tests of child suites
+  		// as either `skipped` or `todo`.
+  		skip: skip,
+  		todo: skip ? false : todo
+  	};
+
+  	var env = {};
+  	if (parentModule) {
+  		parentModule.childModules.push(module);
+  		extend(env, parentModule.testEnvironment);
+  	}
+  	extend(env, testEnvironment);
+  	module.testEnvironment = env;
+
+  	config.modules.push(module);
+  	return module;
+  }
+
+  function processModule(name, options, executeNow) {
+  	var modifiers = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+
+  	if (objectType(options) === "function") {
+  		executeNow = options;
+  		options = undefined;
+  	}
+
+  	var module = createModule(name, options, modifiers);
+
+  	// Move any hooks to a 'hooks' object
+  	var testEnvironment = module.testEnvironment;
+  	var hooks = module.hooks = {};
+
+  	setHookFromEnvironment(hooks, testEnvironment, "before");
+  	setHookFromEnvironment(hooks, testEnvironment, "beforeEach");
+  	setHookFromEnvironment(hooks, testEnvironment, "afterEach");
+  	setHookFromEnvironment(hooks, testEnvironment, "after");
+
+  	var moduleFns = {
+  		before: setHookFunction(module, "before"),
+  		beforeEach: setHookFunction(module, "beforeEach"),
+  		afterEach: setHookFunction(module, "afterEach"),
+  		after: setHookFunction(module, "after")
+  	};
+
+  	var currentModule = config.currentModule;
+  	if (objectType(executeNow) === "function") {
+  		moduleStack.push(module);
+  		config.currentModule = module;
+  		executeNow.call(module.testEnvironment, moduleFns);
+  		moduleStack.pop();
+  		module = module.parentModule || currentModule;
+  	}
+
+  	config.currentModule = module;
+
+  	function setHookFromEnvironment(hooks, environment, name) {
+  		var potentialHook = environment[name];
+  		hooks[name] = typeof potentialHook === "function" ? [potentialHook] : [];
+  		delete environment[name];
+  	}
+
+  	function setHookFunction(module, hookName) {
+  		return function setHook(callback) {
+  			module.hooks[hookName].push(callback);
+  		};
+  	}
+  }
+
+  function module$1(name, options, executeNow) {
+  	if (focused && !isParentModuleInQueue()) {
+  		return;
+  	}
+
+  	processModule(name, options, executeNow);
+  }
+
+  module$1.only = function () {
+  	if (!focused) {
+  		config.modules.length = 0;
+  		config.queue.length = 0;
+  	}
+
+  	processModule.apply(undefined, arguments);
+
+  	focused = true;
+  };
+
+  module$1.skip = function (name, options, executeNow) {
+  	if (focused) {
+  		return;
+  	}
+
+  	processModule(name, options, executeNow, { skip: true });
+  };
+
+  module$1.todo = function (name, options, executeNow) {
+  	if (focused) {
+  		return;
+  	}
+
+  	processModule(name, options, executeNow, { todo: true });
+  };
+
   var LISTENERS = Object.create(null);
   var SUPPORTED_EVENTS = ["runStart", "suiteStart", "testStart", "assertion", "testEnd", "suiteEnd", "runEnd"];
 
@@ -1008,6 +1310,1173 @@
   	}
   }
 
+  function objectOrFunction(x) {
+    var type = typeof x === 'undefined' ? 'undefined' : _typeof(x);
+    return x !== null && (type === 'object' || type === 'function');
+  }
+
+  function isFunction(x) {
+    return typeof x === 'function';
+  }
+
+
+
+  var _isArray = void 0;
+  if (Array.isArray) {
+    _isArray = Array.isArray;
+  } else {
+    _isArray = function _isArray(x) {
+      return Object.prototype.toString.call(x) === '[object Array]';
+    };
+  }
+
+  var isArray = _isArray;
+
+  var len = 0;
+  var vertxNext = void 0;
+  var customSchedulerFn = void 0;
+
+  var asap = function asap(callback, arg) {
+    queue[len] = callback;
+    queue[len + 1] = arg;
+    len += 2;
+    if (len === 2) {
+      // If len is 2, that means that we need to schedule an async flush.
+      // If additional callbacks are queued before the queue is flushed, they
+      // will be processed by this flush that we are scheduling.
+      if (customSchedulerFn) {
+        customSchedulerFn(flush);
+      } else {
+        scheduleFlush();
+      }
+    }
+  };
+
+  function setScheduler(scheduleFn) {
+    customSchedulerFn = scheduleFn;
+  }
+
+  function setAsap(asapFn) {
+    asap = asapFn;
+  }
+
+  var browserWindow = typeof window !== 'undefined' ? window : undefined;
+  var browserGlobal = browserWindow || {};
+  var BrowserMutationObserver = browserGlobal.MutationObserver || browserGlobal.WebKitMutationObserver;
+  var isNode = typeof self === 'undefined' && typeof process !== 'undefined' && {}.toString.call(process) === '[object process]';
+
+  // test for web worker but not in IE10
+  var isWorker = typeof Uint8ClampedArray !== 'undefined' && typeof importScripts !== 'undefined' && typeof MessageChannel !== 'undefined';
+
+  // node
+  function useNextTick() {
+    // node version 0.10.x displays a deprecation warning when nextTick is used recursively
+    // see https://github.com/cujojs/when/issues/410 for details
+    return function () {
+      return process.nextTick(flush);
+    };
+  }
+
+  // vertx
+  function useVertxTimer() {
+    if (typeof vertxNext !== 'undefined') {
+      return function () {
+        vertxNext(flush);
+      };
+    }
+
+    return useSetTimeout();
+  }
+
+  function useMutationObserver() {
+    var iterations = 0;
+    var observer = new BrowserMutationObserver(flush);
+    var node = document.createTextNode('');
+    observer.observe(node, { characterData: true });
+
+    return function () {
+      node.data = iterations = ++iterations % 2;
+    };
+  }
+
+  // web worker
+  function useMessageChannel() {
+    var channel = new MessageChannel();
+    channel.port1.onmessage = flush;
+    return function () {
+      return channel.port2.postMessage(0);
+    };
+  }
+
+  function useSetTimeout() {
+    // Store setTimeout reference so es6-promise will be unaffected by
+    // other code modifying setTimeout (like sinon.useFakeTimers())
+    var globalSetTimeout = setTimeout;
+    return function () {
+      return globalSetTimeout(flush, 1);
+    };
+  }
+
+  var queue = new Array(1000);
+  function flush() {
+    for (var i = 0; i < len; i += 2) {
+      var callback = queue[i];
+      var arg = queue[i + 1];
+
+      callback(arg);
+
+      queue[i] = undefined;
+      queue[i + 1] = undefined;
+    }
+
+    len = 0;
+  }
+
+  function attemptVertx() {
+    try {
+      var vertx = Function('return this')().require('vertx');
+      vertxNext = vertx.runOnLoop || vertx.runOnContext;
+      return useVertxTimer();
+    } catch (e) {
+      return useSetTimeout();
+    }
+  }
+
+  var scheduleFlush = void 0;
+  // Decide what async method to use to triggering processing of queued callbacks:
+  if (isNode) {
+    scheduleFlush = useNextTick();
+  } else if (BrowserMutationObserver) {
+    scheduleFlush = useMutationObserver();
+  } else if (isWorker) {
+    scheduleFlush = useMessageChannel();
+  } else if (browserWindow === undefined && typeof require === 'function') {
+    scheduleFlush = attemptVertx();
+  } else {
+    scheduleFlush = useSetTimeout();
+  }
+
+  function then(onFulfillment, onRejection) {
+    var parent = this;
+
+    var child = new this.constructor(noop);
+
+    if (child[PROMISE_ID] === undefined) {
+      makePromise(child);
+    }
+
+    var _state = parent._state;
+
+
+    if (_state) {
+      var callback = arguments[_state - 1];
+      asap(function () {
+        return invokeCallback(_state, child, callback, parent._result);
+      });
+    } else {
+      subscribe(parent, child, onFulfillment, onRejection);
+    }
+
+    return child;
+  }
+
+  /**
+    `Promise.resolve` returns a promise that will become resolved with the
+    passed `value`. It is shorthand for the following:
+
+    ```javascript
+    let promise = new Promise(function(resolve, reject){
+      resolve(1);
+    });
+
+    promise.then(function(value){
+      // value === 1
+    });
+    ```
+
+    Instead of writing the above, your code now simply becomes the following:
+
+    ```javascript
+    let promise = Promise.resolve(1);
+
+    promise.then(function(value){
+      // value === 1
+    });
+    ```
+
+    @method resolve
+    @static
+    @param {Any} value value that the returned promise will be resolved with
+    Useful for tooling.
+    @return {Promise} a promise that will become fulfilled with the given
+    `value`
+  */
+  function resolve$1(object) {
+    /*jshint validthis:true */
+    var Constructor = this;
+
+    if (object && (typeof object === 'undefined' ? 'undefined' : _typeof(object)) === 'object' && object.constructor === Constructor) {
+      return object;
+    }
+
+    var promise = new Constructor(noop);
+    resolve(promise, object);
+    return promise;
+  }
+
+  var PROMISE_ID = Math.random().toString(36).substring(2);
+
+  function noop() {}
+
+  var PENDING = void 0;
+  var FULFILLED = 1;
+  var REJECTED = 2;
+
+  function selfFulfillment() {
+    return new TypeError("You cannot resolve a promise with itself");
+  }
+
+  function cannotReturnOwn() {
+    return new TypeError('A promises callback cannot return that same promise.');
+  }
+
+  function tryThen(then$$1, value, fulfillmentHandler, rejectionHandler) {
+    try {
+      then$$1.call(value, fulfillmentHandler, rejectionHandler);
+    } catch (e) {
+      return e;
+    }
+  }
+
+  function handleForeignThenable(promise, thenable, then$$1) {
+    asap(function (promise) {
+      var sealed = false;
+      var error = tryThen(then$$1, thenable, function (value) {
+        if (sealed) {
+          return;
+        }
+        sealed = true;
+        if (thenable !== value) {
+          resolve(promise, value);
+        } else {
+          fulfill(promise, value);
+        }
+      }, function (reason) {
+        if (sealed) {
+          return;
+        }
+        sealed = true;
+
+        reject(promise, reason);
+      }, 'Settle: ' + (promise._label || ' unknown promise'));
+
+      if (!sealed && error) {
+        sealed = true;
+        reject(promise, error);
+      }
+    }, promise);
+  }
+
+  function handleOwnThenable(promise, thenable) {
+    if (thenable._state === FULFILLED) {
+      fulfill(promise, thenable._result);
+    } else if (thenable._state === REJECTED) {
+      reject(promise, thenable._result);
+    } else {
+      subscribe(thenable, undefined, function (value) {
+        return resolve(promise, value);
+      }, function (reason) {
+        return reject(promise, reason);
+      });
+    }
+  }
+
+  function handleMaybeThenable(promise, maybeThenable, then$$1) {
+    if (maybeThenable.constructor === promise.constructor && then$$1 === then && maybeThenable.constructor.resolve === resolve$1) {
+      handleOwnThenable(promise, maybeThenable);
+    } else {
+      if (then$$1 === undefined) {
+        fulfill(promise, maybeThenable);
+      } else if (isFunction(then$$1)) {
+        handleForeignThenable(promise, maybeThenable, then$$1);
+      } else {
+        fulfill(promise, maybeThenable);
+      }
+    }
+  }
+
+  function resolve(promise, value) {
+    if (promise === value) {
+      reject(promise, selfFulfillment());
+    } else if (objectOrFunction(value)) {
+      var then$$1 = void 0;
+      try {
+        then$$1 = value.then;
+      } catch (error) {
+        reject(promise, error);
+        return;
+      }
+      handleMaybeThenable(promise, value, then$$1);
+    } else {
+      fulfill(promise, value);
+    }
+  }
+
+  function publishRejection(promise) {
+    if (promise._onerror) {
+      promise._onerror(promise._result);
+    }
+
+    publish(promise);
+  }
+
+  function fulfill(promise, value) {
+    if (promise._state !== PENDING) {
+      return;
+    }
+
+    promise._result = value;
+    promise._state = FULFILLED;
+
+    if (promise._subscribers.length !== 0) {
+      asap(publish, promise);
+    }
+  }
+
+  function reject(promise, reason) {
+    if (promise._state !== PENDING) {
+      return;
+    }
+    promise._state = REJECTED;
+    promise._result = reason;
+
+    asap(publishRejection, promise);
+  }
+
+  function subscribe(parent, child, onFulfillment, onRejection) {
+    var _subscribers = parent._subscribers;
+    var length = _subscribers.length;
+
+
+    parent._onerror = null;
+
+    _subscribers[length] = child;
+    _subscribers[length + FULFILLED] = onFulfillment;
+    _subscribers[length + REJECTED] = onRejection;
+
+    if (length === 0 && parent._state) {
+      asap(publish, parent);
+    }
+  }
+
+  function publish(promise) {
+    var subscribers = promise._subscribers;
+    var settled = promise._state;
+
+    if (subscribers.length === 0) {
+      return;
+    }
+
+    var child = void 0,
+        callback = void 0,
+        detail = promise._result;
+
+    for (var i = 0; i < subscribers.length; i += 3) {
+      child = subscribers[i];
+      callback = subscribers[i + settled];
+
+      if (child) {
+        invokeCallback(settled, child, callback, detail);
+      } else {
+        callback(detail);
+      }
+    }
+
+    promise._subscribers.length = 0;
+  }
+
+  function invokeCallback(settled, promise, callback, detail) {
+    var hasCallback = isFunction(callback),
+        value = void 0,
+        error = void 0,
+        succeeded = true;
+
+    if (hasCallback) {
+      try {
+        value = callback(detail);
+      } catch (e) {
+        succeeded = false;
+        error = e;
+      }
+
+      if (promise === value) {
+        reject(promise, cannotReturnOwn());
+        return;
+      }
+    } else {
+      value = detail;
+    }
+
+    if (promise._state !== PENDING) {
+      // noop
+    } else if (hasCallback && succeeded) {
+      resolve(promise, value);
+    } else if (succeeded === false) {
+      reject(promise, error);
+    } else if (settled === FULFILLED) {
+      fulfill(promise, value);
+    } else if (settled === REJECTED) {
+      reject(promise, value);
+    }
+  }
+
+  function initializePromise(promise, resolver) {
+    try {
+      resolver(function resolvePromise(value) {
+        resolve(promise, value);
+      }, function rejectPromise(reason) {
+        reject(promise, reason);
+      });
+    } catch (e) {
+      reject(promise, e);
+    }
+  }
+
+  var id = 0;
+  function nextId() {
+    return id++;
+  }
+
+  function makePromise(promise) {
+    promise[PROMISE_ID] = id++;
+    promise._state = undefined;
+    promise._result = undefined;
+    promise._subscribers = [];
+  }
+
+  function validationError() {
+    return new Error('Array Methods must be provided an Array');
+  }
+
+  var Enumerator = function () {
+    function Enumerator(Constructor, input) {
+      classCallCheck(this, Enumerator);
+
+      this._instanceConstructor = Constructor;
+      this.promise = new Constructor(noop);
+
+      if (!this.promise[PROMISE_ID]) {
+        makePromise(this.promise);
+      }
+
+      if (isArray(input)) {
+        this.length = input.length;
+        this._remaining = input.length;
+
+        this._result = new Array(this.length);
+
+        if (this.length === 0) {
+          fulfill(this.promise, this._result);
+        } else {
+          this.length = this.length || 0;
+          this._enumerate(input);
+          if (this._remaining === 0) {
+            fulfill(this.promise, this._result);
+          }
+        }
+      } else {
+        reject(this.promise, validationError());
+      }
+    }
+
+    createClass(Enumerator, [{
+      key: '_enumerate',
+      value: function _enumerate(input) {
+        for (var i = 0; this._state === PENDING && i < input.length; i++) {
+          this._eachEntry(input[i], i);
+        }
+      }
+    }, {
+      key: '_eachEntry',
+      value: function _eachEntry(entry, i) {
+        var c = this._instanceConstructor;
+        var resolve$$1 = c.resolve;
+
+
+        if (resolve$$1 === resolve$1) {
+          var _then = void 0;
+          var error = void 0;
+          var didError = false;
+          try {
+            _then = entry.then;
+          } catch (e) {
+            didError = true;
+            error = e;
+          }
+
+          if (_then === then && entry._state !== PENDING) {
+            this._settledAt(entry._state, i, entry._result);
+          } else if (typeof _then !== 'function') {
+            this._remaining--;
+            this._result[i] = entry;
+          } else if (c === Promise$2) {
+            var promise = new c(noop);
+            if (didError) {
+              reject(promise, error);
+            } else {
+              handleMaybeThenable(promise, entry, _then);
+            }
+            this._willSettleAt(promise, i);
+          } else {
+            this._willSettleAt(new c(function (resolve$$1) {
+              return resolve$$1(entry);
+            }), i);
+          }
+        } else {
+          this._willSettleAt(resolve$$1(entry), i);
+        }
+      }
+    }, {
+      key: '_settledAt',
+      value: function _settledAt(state, i, value) {
+        var promise = this.promise;
+
+
+        if (promise._state === PENDING) {
+          this._remaining--;
+
+          if (state === REJECTED) {
+            reject(promise, value);
+          } else {
+            this._result[i] = value;
+          }
+        }
+
+        if (this._remaining === 0) {
+          fulfill(promise, this._result);
+        }
+      }
+    }, {
+      key: '_willSettleAt',
+      value: function _willSettleAt(promise, i) {
+        var enumerator = this;
+
+        subscribe(promise, undefined, function (value) {
+          return enumerator._settledAt(FULFILLED, i, value);
+        }, function (reason) {
+          return enumerator._settledAt(REJECTED, i, reason);
+        });
+      }
+    }]);
+    return Enumerator;
+  }();
+
+  /**
+    `Promise.all` accepts an array of promises, and returns a new promise which
+    is fulfilled with an array of fulfillment values for the passed promises, or
+    rejected with the reason of the first passed promise to be rejected. It casts all
+    elements of the passed iterable to promises as it runs this algorithm.
+
+    Example:
+
+    ```javascript
+    let promise1 = resolve(1);
+    let promise2 = resolve(2);
+    let promise3 = resolve(3);
+    let promises = [ promise1, promise2, promise3 ];
+
+    Promise.all(promises).then(function(array){
+      // The array here would be [ 1, 2, 3 ];
+    });
+    ```
+
+    If any of the `promises` given to `all` are rejected, the first promise
+    that is rejected will be given as an argument to the returned promises's
+    rejection handler. For example:
+
+    Example:
+
+    ```javascript
+    let promise1 = resolve(1);
+    let promise2 = reject(new Error("2"));
+    let promise3 = reject(new Error("3"));
+    let promises = [ promise1, promise2, promise3 ];
+
+    Promise.all(promises).then(function(array){
+      // Code here never runs because there are rejected promises!
+    }, function(error) {
+      // error.message === "2"
+    });
+    ```
+
+    @method all
+    @static
+    @param {Array} entries array of promises
+    @param {String} label optional string for labeling the promise.
+    Useful for tooling.
+    @return {Promise} promise that is fulfilled when all `promises` have been
+    fulfilled, or rejected if any of them become rejected.
+    @static
+  */
+  function all(entries) {
+    return new Enumerator(this, entries).promise;
+  }
+
+  /**
+    `Promise.race` returns a new promise which is settled in the same way as the
+    first passed promise to settle.
+
+    Example:
+
+    ```javascript
+    let promise1 = new Promise(function(resolve, reject){
+      setTimeout(function(){
+        resolve('promise 1');
+      }, 200);
+    });
+
+    let promise2 = new Promise(function(resolve, reject){
+      setTimeout(function(){
+        resolve('promise 2');
+      }, 100);
+    });
+
+    Promise.race([promise1, promise2]).then(function(result){
+      // result === 'promise 2' because it was resolved before promise1
+      // was resolved.
+    });
+    ```
+
+    `Promise.race` is deterministic in that only the state of the first
+    settled promise matters. For example, even if other promises given to the
+    `promises` array argument are resolved, but the first settled promise has
+    become rejected before the other promises became fulfilled, the returned
+    promise will become rejected:
+
+    ```javascript
+    let promise1 = new Promise(function(resolve, reject){
+      setTimeout(function(){
+        resolve('promise 1');
+      }, 200);
+    });
+
+    let promise2 = new Promise(function(resolve, reject){
+      setTimeout(function(){
+        reject(new Error('promise 2'));
+      }, 100);
+    });
+
+    Promise.race([promise1, promise2]).then(function(result){
+      // Code here never runs
+    }, function(reason){
+      // reason.message === 'promise 2' because promise 2 became rejected before
+      // promise 1 became fulfilled
+    });
+    ```
+
+    An example real-world use case is implementing timeouts:
+
+    ```javascript
+    Promise.race([ajax('foo.json'), timeout(5000)])
+    ```
+
+    @method race
+    @static
+    @param {Array} promises array of promises to observe
+    Useful for tooling.
+    @return {Promise} a promise which settles in the same way as the first passed
+    promise to settle.
+  */
+  function race(entries) {
+    /*jshint validthis:true */
+    var Constructor = this;
+
+    if (!isArray(entries)) {
+      return new Constructor(function (_, reject) {
+        return reject(new TypeError('You must pass an array to race.'));
+      });
+    } else {
+      return new Constructor(function (resolve, reject) {
+        var length = entries.length;
+        for (var i = 0; i < length; i++) {
+          Constructor.resolve(entries[i]).then(resolve, reject);
+        }
+      });
+    }
+  }
+
+  /**
+    `Promise.reject` returns a promise rejected with the passed `reason`.
+    It is shorthand for the following:
+
+    ```javascript
+    let promise = new Promise(function(resolve, reject){
+      reject(new Error('WHOOPS'));
+    });
+
+    promise.then(function(value){
+      // Code here doesn't run because the promise is rejected!
+    }, function(reason){
+      // reason.message === 'WHOOPS'
+    });
+    ```
+
+    Instead of writing the above, your code now simply becomes the following:
+
+    ```javascript
+    let promise = Promise.reject(new Error('WHOOPS'));
+
+    promise.then(function(value){
+      // Code here doesn't run because the promise is rejected!
+    }, function(reason){
+      // reason.message === 'WHOOPS'
+    });
+    ```
+
+    @method reject
+    @static
+    @param {Any} reason value that the returned promise will be rejected with.
+    Useful for tooling.
+    @return {Promise} a promise rejected with the given `reason`.
+  */
+  function reject$1(reason) {
+    /*jshint validthis:true */
+    var Constructor = this;
+    var promise = new Constructor(noop);
+    reject(promise, reason);
+    return promise;
+  }
+
+  function needsResolver() {
+    throw new TypeError('You must pass a resolver function as the first argument to the promise constructor');
+  }
+
+  function needsNew() {
+    throw new TypeError("Failed to construct 'Promise': Please use the 'new' operator, this object constructor cannot be called as a function.");
+  }
+
+  /**
+    Promise objects represent the eventual result of an asynchronous operation. The
+    primary way of interacting with a promise is through its `then` method, which
+    registers callbacks to receive either a promise's eventual value or the reason
+    why the promise cannot be fulfilled.
+
+    Terminology
+    -----------
+
+    - `promise` is an object or function with a `then` method whose behavior conforms to this specification.
+    - `thenable` is an object or function that defines a `then` method.
+    - `value` is any legal JavaScript value (including undefined, a thenable, or a promise).
+    - `exception` is a value that is thrown using the throw statement.
+    - `reason` is a value that indicates why a promise was rejected.
+    - `settled` the final resting state of a promise, fulfilled or rejected.
+
+    A promise can be in one of three states: pending, fulfilled, or rejected.
+
+    Promises that are fulfilled have a fulfillment value and are in the fulfilled
+    state.  Promises that are rejected have a rejection reason and are in the
+    rejected state.  A fulfillment value is never a thenable.
+
+    Promises can also be said to *resolve* a value.  If this value is also a
+    promise, then the original promise's settled state will match the value's
+    settled state.  So a promise that *resolves* a promise that rejects will
+    itself reject, and a promise that *resolves* a promise that fulfills will
+    itself fulfill.
+
+
+    Basic Usage:
+    ------------
+
+    ```js
+    let promise = new Promise(function(resolve, reject) {
+      // on success
+      resolve(value);
+
+      // on failure
+      reject(reason);
+    });
+
+    promise.then(function(value) {
+      // on fulfillment
+    }, function(reason) {
+      // on rejection
+    });
+    ```
+
+    Advanced Usage:
+    ---------------
+
+    Promises shine when abstracting away asynchronous interactions such as
+    `XMLHttpRequest`s.
+
+    ```js
+    function getJSON(url) {
+      return new Promise(function(resolve, reject){
+        let xhr = new XMLHttpRequest();
+
+        xhr.open('GET', url);
+        xhr.onreadystatechange = handler;
+        xhr.responseType = 'json';
+        xhr.setRequestHeader('Accept', 'application/json');
+        xhr.send();
+
+        function handler() {
+          if (this.readyState === this.DONE) {
+            if (this.status === 200) {
+              resolve(this.response);
+            } else {
+              reject(new Error('getJSON: `' + url + '` failed with status: [' + this.status + ']'));
+            }
+          }
+        };
+      });
+    }
+
+    getJSON('/posts.json').then(function(json) {
+      // on fulfillment
+    }, function(reason) {
+      // on rejection
+    });
+    ```
+
+    Unlike callbacks, promises are great composable primitives.
+
+    ```js
+    Promise.all([
+      getJSON('/posts'),
+      getJSON('/comments')
+    ]).then(function(values){
+      values[0] // => postsJSON
+      values[1] // => commentsJSON
+
+      return values;
+    });
+    ```
+
+    @class Promise
+    @param {Function} resolver
+    Useful for tooling.
+    @constructor
+  */
+
+  var Promise$2 = function () {
+    function Promise(resolver) {
+      classCallCheck(this, Promise);
+
+      this[PROMISE_ID] = nextId();
+      this._result = this._state = undefined;
+      this._subscribers = [];
+
+      if (noop !== resolver) {
+        typeof resolver !== 'function' && needsResolver();
+        this instanceof Promise ? initializePromise(this, resolver) : needsNew();
+      }
+    }
+
+    /**
+    The primary way of interacting with a promise is through its `then` method,
+    which registers callbacks to receive either a promise's eventual value or the
+    reason why the promise cannot be fulfilled.
+     ```js
+    findUser().then(function(user){
+      // user is available
+    }, function(reason){
+      // user is unavailable, and you are given the reason why
+    });
+    ```
+     Chaining
+    --------
+     The return value of `then` is itself a promise.  This second, 'downstream'
+    promise is resolved with the return value of the first promise's fulfillment
+    or rejection handler, or rejected if the handler throws an exception.
+     ```js
+    findUser().then(function (user) {
+      return user.name;
+    }, function (reason) {
+      return 'default name';
+    }).then(function (userName) {
+      // If `findUser` fulfilled, `userName` will be the user's name, otherwise it
+      // will be `'default name'`
+    });
+     findUser().then(function (user) {
+      throw new Error('Found user, but still unhappy');
+    }, function (reason) {
+      throw new Error('`findUser` rejected and we're unhappy');
+    }).then(function (value) {
+      // never reached
+    }, function (reason) {
+      // if `findUser` fulfilled, `reason` will be 'Found user, but still unhappy'.
+      // If `findUser` rejected, `reason` will be '`findUser` rejected and we're unhappy'.
+    });
+    ```
+    If the downstream promise does not specify a rejection handler, rejection reasons will be propagated further downstream.
+     ```js
+    findUser().then(function (user) {
+      throw new PedagogicalException('Upstream error');
+    }).then(function (value) {
+      // never reached
+    }).then(function (value) {
+      // never reached
+    }, function (reason) {
+      // The `PedgagocialException` is propagated all the way down to here
+    });
+    ```
+     Assimilation
+    ------------
+     Sometimes the value you want to propagate to a downstream promise can only be
+    retrieved asynchronously. This can be achieved by returning a promise in the
+    fulfillment or rejection handler. The downstream promise will then be pending
+    until the returned promise is settled. This is called *assimilation*.
+     ```js
+    findUser().then(function (user) {
+      return findCommentsByAuthor(user);
+    }).then(function (comments) {
+      // The user's comments are now available
+    });
+    ```
+     If the assimliated promise rejects, then the downstream promise will also reject.
+     ```js
+    findUser().then(function (user) {
+      return findCommentsByAuthor(user);
+    }).then(function (comments) {
+      // If `findCommentsByAuthor` fulfills, we'll have the value here
+    }, function (reason) {
+      // If `findCommentsByAuthor` rejects, we'll have the reason here
+    });
+    ```
+     Simple Example
+    --------------
+     Synchronous Example
+     ```javascript
+    let result;
+     try {
+      result = findResult();
+      // success
+    } catch(reason) {
+      // failure
+    }
+    ```
+     Errback Example
+     ```js
+    findResult(function(result, err){
+      if (err) {
+        // failure
+      } else {
+        // success
+      }
+    });
+    ```
+     Promise Example;
+     ```javascript
+    findResult().then(function(result){
+      // success
+    }, function(reason){
+      // failure
+    });
+    ```
+     Advanced Example
+    --------------
+     Synchronous Example
+     ```javascript
+    let author, books;
+     try {
+      author = findAuthor();
+      books  = findBooksByAuthor(author);
+      // success
+    } catch(reason) {
+      // failure
+    }
+    ```
+     Errback Example
+     ```js
+     function foundBooks(books) {
+     }
+     function failure(reason) {
+     }
+     findAuthor(function(author, err){
+      if (err) {
+        failure(err);
+        // failure
+      } else {
+        try {
+          findBoooksByAuthor(author, function(books, err) {
+            if (err) {
+              failure(err);
+            } else {
+              try {
+                foundBooks(books);
+              } catch(reason) {
+                failure(reason);
+              }
+            }
+          });
+        } catch(error) {
+          failure(err);
+        }
+        // success
+      }
+    });
+    ```
+     Promise Example;
+     ```javascript
+    findAuthor().
+      then(findBooksByAuthor).
+      then(function(books){
+        // found books
+    }).catch(function(reason){
+      // something went wrong
+    });
+    ```
+     @method then
+    @param {Function} onFulfilled
+    @param {Function} onRejected
+    Useful for tooling.
+    @return {Promise}
+    */
+
+    /**
+    `catch` is simply sugar for `then(undefined, onRejection)` which makes it the same
+    as the catch block of a try/catch statement.
+    ```js
+    function findAuthor(){
+    throw new Error('couldn't find that author');
+    }
+    // synchronous
+    try {
+    findAuthor();
+    } catch(reason) {
+    // something went wrong
+    }
+    // async with promises
+    findAuthor().catch(function(reason){
+    // something went wrong
+    });
+    ```
+    @method catch
+    @param {Function} onRejection
+    Useful for tooling.
+    @return {Promise}
+    */
+
+
+    createClass(Promise, [{
+      key: 'catch',
+      value: function _catch(onRejection) {
+        return this.then(null, onRejection);
+      }
+
+      /**
+        `finally` will be invoked regardless of the promise's fate just as native
+        try/catch/finally behaves
+      
+        Synchronous example:
+      
+        ```js
+        findAuthor() {
+          if (Math.random() > 0.5) {
+            throw new Error();
+          }
+          return new Author();
+        }
+      
+        try {
+          return findAuthor(); // succeed or fail
+        } catch(error) {
+          return findOtherAuther();
+        } finally {
+          // always runs
+          // doesn't affect the return value
+        }
+        ```
+      
+        Asynchronous example:
+      
+        ```js
+        findAuthor().catch(function(reason){
+          return findOtherAuther();
+        }).finally(function(){
+          // author was either found, or not
+        });
+        ```
+      
+        @method finally
+        @param {Function} callback
+        @return {Promise}
+      */
+
+    }, {
+      key: 'finally',
+      value: function _finally(callback) {
+        var promise = this;
+        var constructor = promise.constructor;
+
+        if (isFunction(callback)) {
+          return promise.then(function (value) {
+            return constructor.resolve(callback()).then(function () {
+              return value;
+            });
+          }, function (reason) {
+            return constructor.resolve(callback()).then(function () {
+              throw reason;
+            });
+          });
+        }
+
+        return promise.then(callback, callback);
+      }
+    }]);
+    return Promise;
+  }();
+
+  Promise$2.prototype.then = then;
+  Promise$2.all = all;
+  Promise$2.race = race;
+  Promise$2.resolve = resolve$1;
+  Promise$2.reject = reject$1;
+  Promise$2._setScheduler = setScheduler;
+  Promise$2._setAsap = setAsap;
+  Promise$2._asap = asap;
+
+  /*global self*/
+  function polyfill() {
+    var local = void 0;
+
+    if (typeof global !== 'undefined') {
+      local = global;
+    } else if (typeof self !== 'undefined') {
+      local = self;
+    } else {
+      try {
+        local = Function('return this')();
+      } catch (e) {
+        throw new Error('polyfill failed because global object is unavailable in this environment');
+      }
+    }
+
+    var P = local.Promise;
+
+    if (P) {
+      var promiseToString = null;
+      try {
+        promiseToString = Object.prototype.toString.call(P.resolve());
+      } catch (e) {
+        // silently ignored
+      }
+
+      if (promiseToString === '[object Promise]' && !P.cast) {
+        return;
+      }
+    }
+
+    local.Promise = Promise$2;
+  }
+
+  // Strange compat..
+  Promise$2.polyfill = polyfill;
+  Promise$2.Promise = Promise$2;
+
+  var Promise$1 = typeof Promise !== "undefined" ? Promise : Promise$2;
+
   // Register logging callbacks
   function registerLoggingCallbacks(obj) {
   	var i,
@@ -1040,12 +2509,25 @@
   }
 
   function runLoggingCallbacks(key, args) {
-  	var i, l, callbacks;
+  	var callbacks = config.callbacks[key];
 
-  	callbacks = config.callbacks[key];
-  	for (i = 0, l = callbacks.length; i < l; i++) {
-  		callbacks[i](args);
+  	// Handling 'log' callbacks separately. Unlike the other callbacks,
+  	// the log callback is not controlled by the processing queue,
+  	// but rather used by asserts. Hence to promisfy the 'log' callback
+  	// would mean promisfying each step of a test
+  	if (key === "log") {
+  		callbacks.map(function (callback) {
+  			return callback(args);
+  		});
+  		return;
   	}
+
+  	// ensure that each callback is executed serially
+  	return callbacks.reduce(function (promiseChain, callback) {
+  		return promiseChain.then(function () {
+  			return Promise$1.resolve(callback(args));
+  		});
+  	}, Promise$1.resolve([]));
   }
 
   // Doesn't support IE9, it will return undefined on these browsers
@@ -1109,31 +2591,44 @@
   function advance() {
   	advanceTaskQueue();
 
-  	if (!taskQueue.length) {
+  	if (!taskQueue.length && !config.blocking && !config.current) {
   		advanceTestQueue();
   	}
   }
 
   /**
-   * Advances the taskQueue to the next task if it is ready and not empty.
+   * Advances the taskQueue with an increased depth
    */
   function advanceTaskQueue() {
   	var start = now();
   	config.depth = (config.depth || 0) + 1;
 
-  	while (taskQueue.length && !config.blocking) {
+  	processTaskQueue(start);
+
+  	config.depth--;
+  }
+
+  /**
+   * Process the first task on the taskQueue as a promise.
+   * Each task is a function returned by https://github.com/qunitjs/qunit/blob/master/src/test.js#L381
+   */
+  function processTaskQueue(start) {
+  	if (taskQueue.length && !config.blocking) {
   		var elapsedTime = now() - start;
 
   		if (!defined.setTimeout || config.updateRate <= 0 || elapsedTime < config.updateRate) {
   			var task = taskQueue.shift();
-  			task();
+  			Promise$1.resolve(task()).then(function () {
+  				if (!taskQueue.length) {
+  					advance();
+  				} else {
+  					processTaskQueue(start);
+  				}
+  			});
   		} else {
-  			setTimeout(advance);
-  			break;
+  			setTimeout$1(advance);
   		}
   	}
-
-  	config.depth--;
   }
 
   /**
@@ -1254,18 +2749,19 @@
   		failed: config.stats.bad,
   		total: config.stats.all,
   		runtime: runtime
-  	});
+  	}).then(function () {
 
-  	// Clear own storage items if all tests passed
-  	if (storage && config.stats.bad === 0) {
-  		for (var i = storage.length - 1; i >= 0; i--) {
-  			var key = storage.key(i);
+  		// Clear own storage items if all tests passed
+  		if (storage && config.stats.bad === 0) {
+  			for (var i = storage.length - 1; i >= 0; i--) {
+  				var key = storage.key(i);
 
-  			if (key.indexOf("qunit-test-") === 0) {
-  				storage.removeItem(key);
+  				if (key.indexOf("qunit-test-") === 0) {
+  					storage.removeItem(key);
+  				}
   			}
   		}
-  	}
+  	});
   }
 
   var ProcessingQueue = {
@@ -1300,7 +2796,10 @@
   		key: "start",
   		value: function start(recordTime) {
   			if (recordTime) {
-  				this._startTime = Date.now();
+  				this._startTime = performanceNow();
+  				if (performance) {
+  					performance.mark("qunit_test_start");
+  				}
   			}
 
   			return {
@@ -1313,7 +2812,14 @@
   		key: "end",
   		value: function end(recordTime) {
   			if (recordTime) {
-  				this._endTime = Date.now();
+  				this._endTime = performanceNow();
+  				if (performance) {
+  					performance.mark("qunit_test_end");
+
+  					var testName = this.fullName.join(" – ");
+
+  					measure("QUnit Test: " + testName, "qunit_test_start", "qunit_test_end");
+  				}
   			}
 
   			return extend(this.start(), {
@@ -1390,9 +2896,9 @@
   	this.assertions = [];
   	this.semaphore = 0;
   	this.module = config.currentModule;
-  	this.stack = sourceFromStacktrace(3);
   	this.steps = [];
   	this.timeout = undefined;
+  	this.errorForStack = new Error();
 
   	// If a module is skipped, all its tests and the tests of the child suites
   	// should be treated as skipped even if they are defined as `only` or `todo`.
@@ -1462,42 +2968,54 @@
   		module = module.parentModule;
   	}
 
-  	return modules;
+  	// The above push modules from the child to the parent
+  	// return a reversed order with the top being the top most parent module
+  	return modules.reverse();
   }
 
   Test.prototype = {
+
+  	// generating a stack trace can be expensive, so using a getter defers this until we need it
+  	get stack() {
+  		return extractStacktrace(this.errorForStack, 2);
+  	},
+
   	before: function before() {
-  		var i,
-  		    startModule,
-  		    module = this.module,
+  		var _this = this;
+
+  		var module = this.module,
   		    notStartedModules = getNotStartedModules(module);
 
-  		for (i = notStartedModules.length - 1; i >= 0; i--) {
-  			startModule = notStartedModules[i];
-  			startModule.stats = { all: 0, bad: 0, started: now() };
-  			emit("suiteStart", startModule.suiteReport.start(true));
-  			runLoggingCallbacks("moduleStart", {
-  				name: startModule.name,
-  				tests: startModule.tests
+  		// ensure the callbacks are executed serially for each module
+  		var callbackPromises = notStartedModules.reduce(function (promiseChain, startModule) {
+  			return promiseChain.then(function () {
+  				startModule.stats = { all: 0, bad: 0, started: now() };
+  				emit("suiteStart", startModule.suiteReport.start(true));
+  				return runLoggingCallbacks("moduleStart", {
+  					name: startModule.name,
+  					tests: startModule.tests
+  				});
   			});
-  		}
+  		}, Promise$1.resolve([]));
 
-  		config.current = this;
+  		return callbackPromises.then(function () {
+  			config.current = _this;
 
-  		this.testEnvironment = extend({}, module.testEnvironment);
+  			_this.testEnvironment = extend({}, module.testEnvironment);
 
-  		this.started = now();
-  		emit("testStart", this.testReport.start(true));
-  		runLoggingCallbacks("testStart", {
-  			name: this.testName,
-  			module: module.name,
-  			testId: this.testId,
-  			previousFailure: this.previousFailure
+  			_this.started = now();
+  			emit("testStart", _this.testReport.start(true));
+  			return runLoggingCallbacks("testStart", {
+  				name: _this.testName,
+  				module: module.name,
+  				testId: _this.testId,
+  				previousFailure: _this.previousFailure
+  			}).then(function () {
+  				if (!config.pollution) {
+  					saveGlobal();
+  				}
+  			});
   		});
-
-  		if (!config.pollution) {
-  			saveGlobal();
-  		}
   	},
 
   	run: function run() {
@@ -1543,11 +3061,11 @@
   	},
 
   	queueHook: function queueHook(hook, hookName, hookOwner) {
-  		var _this = this;
+  		var _this2 = this;
 
   		var callHook = function callHook() {
-  			var promise = hook.call(_this.testEnvironment, _this.assert);
-  			_this.resolvePromise(promise, hookName);
+  			var promise = hook.call(_this2.testEnvironment, _this2.assert);
+  			_this2.resolvePromise(promise, hookName);
   		};
 
   		var runHook = function runHook() {
@@ -1556,7 +3074,7 @@
   					return;
   				}
 
-  				_this.preserveEnvironment = true;
+  				_this2.preserveEnvironment = true;
   			}
 
   			// The 'after' hook should only execute when there are not tests left and
@@ -1565,7 +3083,7 @@
   				return;
   			}
 
-  			config.current = _this;
+  			config.current = _this2;
   			if (config.notrycatch) {
   				callHook();
   				return;
@@ -1573,7 +3091,7 @@
   			try {
   				callHook();
   			} catch (error) {
-  				_this.pushFailure(hookName + " failed on " + _this.testName + ": " + (error.message || error), extractStacktrace(error, 0));
+  				_this2.pushFailure(hookName + " failed on " + _this2.testName + ": " + (error.message || error), extractStacktrace(error, 0));
   			}
   		};
 
@@ -1608,6 +3126,10 @@
 
   	finish: function finish() {
   		config.current = this;
+
+  		// Release the test callback to ensure that anything referenced has been
+  		// released to be garbage collected.
+  		this.callback = undefined;
 
   		if (this.steps.length) {
   			var stepsList = this.steps.join(", ");
@@ -1659,8 +3181,9 @@
   		// avoid leaking it. It is not used by the legacy testDone callbacks.
   		emit("testEnd", this.testReport.end(true));
   		this.testReport.slimAssertions();
+  		var test = this;
 
-  		runLoggingCallbacks("testDone", {
+  		return runLoggingCallbacks("testDone", {
   			name: testName,
   			module: moduleName,
   			skipped: skipped,
@@ -1675,26 +3198,40 @@
   			testId: this.testId,
 
   			// Source of Test
-  			source: this.stack
+  			// generating stack trace is expensive, so using a getter will help defer this until we need it
+  			get source() {
+  				return test.stack;
+  			}
+  		}).then(function () {
+  			if (module.testsRun === numberOfTests(module)) {
+  				var completedModules = [module];
+
+  				// Check if the parent modules, iteratively, are done. If that the case,
+  				// we emit the `suiteEnd` event and trigger `moduleDone` callback.
+  				var parent = module.parentModule;
+  				while (parent && parent.testsRun === numberOfTests(parent)) {
+  					completedModules.push(parent);
+  					parent = parent.parentModule;
+  				}
+
+  				return completedModules.reduce(function (promiseChain, completedModule) {
+  					return promiseChain.then(function () {
+  						return logSuiteEnd(completedModule);
+  					});
+  				}, Promise$1.resolve([]));
+  			}
+  		}).then(function () {
+  			config.current = undefined;
   		});
 
-  		if (module.testsRun === numberOfTests(module)) {
-  			logSuiteEnd(module);
-
-  			// Check if the parent modules, iteratively, are done. If that the case,
-  			// we emit the `suiteEnd` event and trigger `moduleDone` callback.
-  			var parent = module.parentModule;
-  			while (parent && parent.testsRun === numberOfTests(parent)) {
-  				logSuiteEnd(parent);
-  				parent = parent.parentModule;
-  			}
-  		}
-
-  		config.current = undefined;
-
   		function logSuiteEnd(module) {
+
+  			// Reset `module.hooks` to ensure that anything referenced in these hooks
+  			// has been released to be garbage collected.
+  			module.hooks = {};
+
   			emit("suiteEnd", module.suiteReport.end(true));
-  			runLoggingCallbacks("moduleDone", {
+  			return runLoggingCallbacks("moduleDone", {
   				name: module.name,
   				tests: module.tests,
   				failed: module.stats.bad,
@@ -1721,7 +3258,7 @@
 
   		function runTest() {
   			return [function () {
-  				test.before();
+  				return test.before();
   			}].concat(toConsumableArray(test.hooks("before")), [function () {
   				test.preserveTestEnvironment();
   			}], toConsumableArray(test.hooks("beforeEach")), [function () {
@@ -1729,7 +3266,7 @@
   			}], toConsumableArray(test.hooks("afterEach").reverse()), toConsumableArray(test.hooks("after").reverse()), [function () {
   				test.after();
   			}, function () {
-  				test.finish();
+  				return test.finish();
   			}]);
   		}
 
@@ -2017,12 +3554,10 @@
 
   // Will be exposed as QUnit.only
   function only(testName, callback) {
-  	if (focused$1) {
-  		return;
+  	if (!focused$1) {
+  		config.queue.length = 0;
+  		focused$1 = true;
   	}
-
-  	config.queue.length = 0;
-  	focused$1 = true;
 
   	var newTest = new Test({
   		testName: testName,
@@ -2032,8 +3567,15 @@
   	newTest.queue();
   }
 
+  // Resets config.timeout with a new timeout duration.
+  function resetTestTimeout(timeoutDuration) {
+  	clearTimeout(config.timeout);
+  	config.timeout = setTimeout$1(config.timeoutHandler(timeoutDuration), timeoutDuration);
+  }
+
   // Put a hold on processing and return a function that will release it.
   function internalStop(test) {
+  	var released = false;
   	test.semaphore += 1;
   	config.blocking = true;
 
@@ -2049,14 +3591,17 @@
 
   		if (typeof timeoutDuration === "number" && timeoutDuration > 0) {
   			clearTimeout(config.timeout);
-  			config.timeout = setTimeout(function () {
-  				pushFailure("Test took longer than " + timeoutDuration + "ms; test timed out.", sourceFromStacktrace(2));
-  				internalRecover(test);
-  			}, timeoutDuration);
+  			config.timeoutHandler = function (timeout) {
+  				return function () {
+  					pushFailure("Test took longer than " + timeout + "ms; test timed out.", sourceFromStacktrace(2));
+  					released = true;
+  					internalRecover(test);
+  				};
+  			};
+  			config.timeout = setTimeout$1(config.timeoutHandler(timeoutDuration), timeoutDuration);
   		}
   	}
 
-  	var released = false;
   	return function resume() {
   		if (released) {
   			return;
@@ -2103,7 +3648,7 @@
   		if (config.timeout) {
   			clearTimeout(config.timeout);
   		}
-  		config.timeout = setTimeout(function () {
+  		config.timeout = setTimeout$1(function () {
   			if (test.semaphore > 0) {
   				return;
   			}
@@ -2156,24 +3701,6 @@
   	}
   }
 
-  /**
-   * Returns a function that proxies to the given method name on the globals
-   * console object. The proxy will also detect if the console doesn't exist and
-   * will appropriately no-op. This allows support for IE9, which doesn't have a
-   * console if the developer tools are not open.
-   */
-  function consoleProxy(method) {
-  	return function () {
-  		if (console) {
-  			console[method].apply(console, arguments);
-  		}
-  	};
-  }
-
-  var Logger = {
-  	warn: consoleProxy("warn")
-  };
-
   var Assert = function () {
   	function Assert(testContext) {
   		classCallCheck(this, Assert);
@@ -2191,6 +3718,15 @@
   			}
 
   			this.test.timeout = duration;
+
+  			// If a timeout has been set, clear it and reset with the new duration
+  			if (config.timeout) {
+  				clearTimeout(config.timeout);
+
+  				if (config.timeoutHandler && this.test.timeout > 0) {
+  					resetTestTimeout(this.test.timeout);
+  				}
+  			}
   		}
 
   		// Documents a "step", which is a string value, in a test as a passing assertion
@@ -2210,7 +3746,7 @@
   				result = false;
   			}
 
-  			return this.pushResult({
+  			this.pushResult({
   				result: result,
   				message: assertionMessage
   			});
@@ -2475,11 +4011,13 @@
   				// We don't want to validate thrown error
   				if (!expected) {
   					result = true;
-  					expected = null;
 
   					// Expected is a regexp
   				} else if (expectedType === "regexp") {
   					result = expected.test(errorString(actual));
+
+  					// Log the string form of the regexp
+  					expected = String(expected);
 
   					// Expected is a constructor, maybe an Error constructor
   				} else if (expectedType === "function" && actual instanceof expected) {
@@ -2488,6 +4026,9 @@
   					// Expected is an Error object
   				} else if (expectedType === "object") {
   					result = actual instanceof expected.constructor && actual.name === expected.name && actual.message === expected.message;
+
+  					// Log the string form of the Error object
+  					expected = errorString(expected);
 
   					// Expected is a validation function which returns true if validation passed
   				} else if (expectedType === "function" && expected.call({}, actual) === true) {
@@ -2498,7 +4039,9 @@
 
   			currentTest.assert.pushResult({
   				result: result,
-  				actual: actual,
+
+  				// undefined if it didn't throw
+  				actual: actual && errorString(actual),
   				expected: expected,
   				message: message
   			});
@@ -2558,11 +4101,13 @@
   				// We don't want to validate
   				if (expected === undefined) {
   					result = true;
-  					expected = actual;
 
   					// Expected is a regexp
   				} else if (expectedType === "regexp") {
   					result = expected.test(errorString(actual));
+
+  					// Log the string form of the regexp
+  					expected = String(expected);
 
   					// Expected is a constructor, maybe an Error constructor
   				} else if (expectedType === "function" && actual instanceof expected) {
@@ -2571,6 +4116,9 @@
   					// Expected is an Error object
   				} else if (expectedType === "object") {
   					result = actual instanceof expected.constructor && actual.name === expected.name && actual.message === expected.message;
+
+  					// Log the string form of the Error object
+  					expected = errorString(expected);
 
   					// Expected is a validation function which returns true if validation passed
   				} else {
@@ -2587,7 +4135,9 @@
 
   				currentTest.assert.pushResult({
   					result: result,
-  					actual: actual,
+
+  					// leave rejection value of undefined as-is
+  					actual: actual && errorString(actual),
   					expected: expected,
   					message: message
   				});
@@ -2609,12 +4159,14 @@
   /**
    * Converts an error into a simple string for comparisons.
    *
-   * @param {Error} error
+   * @param {Error|Object} error
    * @return {String}
    */
   function errorString(error) {
   	var resultErrorString = error.toString();
 
+  	// If the error wasn't a subclass of Error but something like
+  	// an object literal with name and message properties...
   	if (resultErrorString.substring(0, 7) === "[object") {
   		var name = error.name ? error.name.toString() : "Error";
   		var message = error.message ? error.message.toString() : "";
@@ -2639,11 +4191,11 @@
   	if (defined.document) {
 
   		// QUnit may be defined when it is preconfigured but then only QUnit and QUnit.config may be defined.
-  		if (window.QUnit && window.QUnit.version) {
+  		if (window$1.QUnit && window$1.QUnit.version) {
   			throw new Error("QUnit has already been defined.");
   		}
 
-  		window.QUnit = QUnit;
+  		window$1.QUnit = QUnit;
   	}
 
   	// For nodejs
@@ -2672,121 +4224,6 @@
   	}
   }
 
-  var SuiteReport = function () {
-  	function SuiteReport(name, parentSuite) {
-  		classCallCheck(this, SuiteReport);
-
-  		this.name = name;
-  		this.fullName = parentSuite ? parentSuite.fullName.concat(name) : [];
-
-  		this.tests = [];
-  		this.childSuites = [];
-
-  		if (parentSuite) {
-  			parentSuite.pushChildSuite(this);
-  		}
-  	}
-
-  	createClass(SuiteReport, [{
-  		key: "start",
-  		value: function start(recordTime) {
-  			if (recordTime) {
-  				this._startTime = Date.now();
-  			}
-
-  			return {
-  				name: this.name,
-  				fullName: this.fullName.slice(),
-  				tests: this.tests.map(function (test) {
-  					return test.start();
-  				}),
-  				childSuites: this.childSuites.map(function (suite) {
-  					return suite.start();
-  				}),
-  				testCounts: {
-  					total: this.getTestCounts().total
-  				}
-  			};
-  		}
-  	}, {
-  		key: "end",
-  		value: function end(recordTime) {
-  			if (recordTime) {
-  				this._endTime = Date.now();
-  			}
-
-  			return {
-  				name: this.name,
-  				fullName: this.fullName.slice(),
-  				tests: this.tests.map(function (test) {
-  					return test.end();
-  				}),
-  				childSuites: this.childSuites.map(function (suite) {
-  					return suite.end();
-  				}),
-  				testCounts: this.getTestCounts(),
-  				runtime: this.getRuntime(),
-  				status: this.getStatus()
-  			};
-  		}
-  	}, {
-  		key: "pushChildSuite",
-  		value: function pushChildSuite(suite) {
-  			this.childSuites.push(suite);
-  		}
-  	}, {
-  		key: "pushTest",
-  		value: function pushTest(test) {
-  			this.tests.push(test);
-  		}
-  	}, {
-  		key: "getRuntime",
-  		value: function getRuntime() {
-  			return this._endTime - this._startTime;
-  		}
-  	}, {
-  		key: "getTestCounts",
-  		value: function getTestCounts() {
-  			var counts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : { passed: 0, failed: 0, skipped: 0, todo: 0, total: 0 };
-
-  			counts = this.tests.reduce(function (counts, test) {
-  				if (test.valid) {
-  					counts[test.getStatus()]++;
-  					counts.total++;
-  				}
-
-  				return counts;
-  			}, counts);
-
-  			return this.childSuites.reduce(function (counts, suite) {
-  				return suite.getTestCounts(counts);
-  			}, counts);
-  		}
-  	}, {
-  		key: "getStatus",
-  		value: function getStatus() {
-  			var _getTestCounts = this.getTestCounts(),
-  			    total = _getTestCounts.total,
-  			    failed = _getTestCounts.failed,
-  			    skipped = _getTestCounts.skipped,
-  			    todo = _getTestCounts.todo;
-
-  			if (failed) {
-  				return "failed";
-  			} else {
-  				if (skipped === total) {
-  					return "skipped";
-  				} else if (todo === total) {
-  					return "todo";
-  				} else {
-  					return "passed";
-  				}
-  			}
-  		}
-  	}]);
-  	return SuiteReport;
-  }();
-
   // Handle an unhandled exception. By convention, returns true if further
   // error handling should be suppressed and false otherwise.
   // In this case, we will only suppress further error handling if the
@@ -2800,10 +4237,10 @@
   		if (config.current.ignoreGlobalErrors) {
   			return true;
   		}
-  		pushFailure.apply(undefined, [error.message, error.fileName + ":" + error.lineNumber].concat(args));
+  		pushFailure.apply(undefined, [error.message, error.stacktrace || error.fileName + ":" + error.lineNumber].concat(args));
   	} else {
   		test("global failure", extend(function () {
-  			pushFailure.apply(undefined, [error.message, error.fileName + ":" + error.lineNumber].concat(args));
+  			pushFailure.apply(undefined, [error.message, error.stacktrace || error.fileName + ":" + error.lineNumber].concat(args));
   		}, { validTest: true }));
   	}
 
@@ -2829,7 +4266,6 @@
   	}
   }
 
-  var focused = false;
   var QUnit = {};
   var globalSuite = new SuiteReport();
 
@@ -2838,151 +4274,14 @@
   // it since each module has a suiteReport associated with it.
   config.currentModule.suiteReport = globalSuite;
 
-  var moduleStack = [];
   var globalStartCalled = false;
   var runStarted = false;
 
   // Figure out if we're running the tests from a server or not
-  QUnit.isLocal = !(defined.document && window.location.protocol !== "file:");
+  QUnit.isLocal = !(defined.document && window$1.location.protocol !== "file:");
 
   // Expose the current QUnit version
-  QUnit.version = "2.6.0";
-
-  function createModule(name, testEnvironment, modifiers) {
-  	var parentModule = moduleStack.length ? moduleStack.slice(-1)[0] : null;
-  	var moduleName = parentModule !== null ? [parentModule.name, name].join(" > ") : name;
-  	var parentSuite = parentModule ? parentModule.suiteReport : globalSuite;
-
-  	var skip$$1 = parentModule !== null && parentModule.skip || modifiers.skip;
-  	var todo$$1 = parentModule !== null && parentModule.todo || modifiers.todo;
-
-  	var module = {
-  		name: moduleName,
-  		parentModule: parentModule,
-  		tests: [],
-  		moduleId: generateHash(moduleName),
-  		testsRun: 0,
-  		unskippedTestsRun: 0,
-  		childModules: [],
-  		suiteReport: new SuiteReport(name, parentSuite),
-
-  		// Pass along `skip` and `todo` properties from parent module, in case
-  		// there is one, to childs. And use own otherwise.
-  		// This property will be used to mark own tests and tests of child suites
-  		// as either `skipped` or `todo`.
-  		skip: skip$$1,
-  		todo: skip$$1 ? false : todo$$1
-  	};
-
-  	var env = {};
-  	if (parentModule) {
-  		parentModule.childModules.push(module);
-  		extend(env, parentModule.testEnvironment);
-  	}
-  	extend(env, testEnvironment);
-  	module.testEnvironment = env;
-
-  	config.modules.push(module);
-  	return module;
-  }
-
-  function processModule(name, options, executeNow) {
-  	var modifiers = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
-
-  	var module = createModule(name, options, modifiers);
-
-  	// Move any hooks to a 'hooks' object
-  	var testEnvironment = module.testEnvironment;
-  	var hooks = module.hooks = {};
-
-  	setHookFromEnvironment(hooks, testEnvironment, "before");
-  	setHookFromEnvironment(hooks, testEnvironment, "beforeEach");
-  	setHookFromEnvironment(hooks, testEnvironment, "afterEach");
-  	setHookFromEnvironment(hooks, testEnvironment, "after");
-
-  	function setHookFromEnvironment(hooks, environment, name) {
-  		var potentialHook = environment[name];
-  		hooks[name] = typeof potentialHook === "function" ? [potentialHook] : [];
-  		delete environment[name];
-  	}
-
-  	var moduleFns = {
-  		before: setHookFunction(module, "before"),
-  		beforeEach: setHookFunction(module, "beforeEach"),
-  		afterEach: setHookFunction(module, "afterEach"),
-  		after: setHookFunction(module, "after")
-  	};
-
-  	var currentModule = config.currentModule;
-  	if (objectType(executeNow) === "function") {
-  		moduleStack.push(module);
-  		config.currentModule = module;
-  		executeNow.call(module.testEnvironment, moduleFns);
-  		moduleStack.pop();
-  		module = module.parentModule || currentModule;
-  	}
-
-  	config.currentModule = module;
-  }
-
-  // TODO: extract this to a new file alongside its related functions
-  function module$1(name, options, executeNow) {
-  	if (focused) {
-  		return;
-  	}
-
-  	if (arguments.length === 2) {
-  		if (objectType(options) === "function") {
-  			executeNow = options;
-  			options = undefined;
-  		}
-  	}
-
-  	processModule(name, options, executeNow);
-  }
-
-  module$1.only = function () {
-  	if (focused) {
-  		return;
-  	}
-
-  	config.modules.length = 0;
-  	config.queue.length = 0;
-
-  	module$1.apply(undefined, arguments);
-
-  	focused = true;
-  };
-
-  module$1.skip = function (name, options, executeNow) {
-  	if (focused) {
-  		return;
-  	}
-
-  	if (arguments.length === 2) {
-  		if (objectType(options) === "function") {
-  			executeNow = options;
-  			options = undefined;
-  		}
-  	}
-
-  	processModule(name, options, executeNow, { skip: true });
-  };
-
-  module$1.todo = function (name, options, executeNow) {
-  	if (focused) {
-  		return;
-  	}
-
-  	if (arguments.length === 2) {
-  		if (objectType(options) === "function") {
-  			executeNow = options;
-  			options = undefined;
-  		}
-  	}
-
-  	processModule(name, options, executeNow, { todo: true });
-  };
+  QUnit.version = "2.10.1";
 
   extend(QUnit, {
   	on: on,
@@ -3082,12 +4381,17 @@
 
   	// Add a slight delay to allow definition of more modules and tests.
   	if (defined.setTimeout) {
-  		setTimeout(function () {
+  		setTimeout$1(function () {
   			begin();
   		});
   	} else {
   		begin();
   	}
+  }
+
+  function unblockAndAdvanceQueue() {
+  	config.blocking = false;
+  	ProcessingQueue.advance();
   }
 
   function begin() {
@@ -3119,24 +4423,17 @@
   		runLoggingCallbacks("begin", {
   			totalTests: Test.count,
   			modules: modulesLog
-  		});
+  		}).then(unblockAndAdvanceQueue);
+  	} else {
+  		unblockAndAdvanceQueue();
   	}
-
-  	config.blocking = false;
-  	ProcessingQueue.advance();
-  }
-
-  function setHookFunction(module, hookName) {
-  	return function setHook(callback) {
-  		module.hooks[hookName].push(callback);
-  	};
   }
 
   exportQUnit(QUnit);
 
   (function () {
 
-  	if (typeof window === "undefined" || typeof document === "undefined") {
+  	if (typeof window$1 === "undefined" || typeof document$1 === "undefined") {
   		return;
   	}
 
@@ -3151,7 +4448,7 @@
   			return;
   		}
 
-  		var fixture = document.getElementById("qunit-fixture");
+  		var fixture = document$1.getElementById("qunit-fixture");
   		if (fixture) {
   			config.fixture = fixture.cloneNode(true);
   		}
@@ -3165,12 +4462,12 @@
   			return;
   		}
 
-  		var fixture = document.getElementById("qunit-fixture");
+  		var fixture = document$1.getElementById("qunit-fixture");
   		var resetFixtureType = _typeof(config.fixture);
   		if (resetFixtureType === "string") {
 
   			// support user defined values for `config.fixture`
-  			var newFixture = document.createElement("div");
+  			var newFixture = document$1.createElement("div");
   			newFixture.setAttribute("id", "qunit-fixture");
   			newFixture.innerHTML = config.fixture;
   			fixture.parentNode.replaceChild(newFixture, fixture);
@@ -3186,7 +4483,7 @@
   (function () {
 
   	// Only interact with URLs via window.location
-  	var location = typeof window !== "undefined" && window.location;
+  	var location = typeof window$1 !== "undefined" && window$1.location;
   	if (!location) {
   		return;
   	}
@@ -3311,14 +4608,15 @@
   (function () {
 
   	// Don't load the HTML Reporter on non-browser environments
-  	if (typeof window === "undefined" || !window.document) {
+  	if (typeof window$1 === "undefined" || !window$1.document) {
   		return;
   	}
 
   	var config = QUnit.config,
-  	    document$$1 = window.document,
+  	    hiddenTests = [],
+  	    document = window$1.document,
   	    collapseNext = false,
-  	    hasOwn = Object.prototype.hasOwnProperty,
+  	    hasOwn$$1 = Object.prototype.hasOwnProperty,
   	    unfilteredUrl = setUrl({ filter: undefined, module: undefined,
   		moduleId: undefined, testId: undefined }),
   	    modulesList = [];
@@ -3369,7 +4667,7 @@
   	}
 
   	function id(name) {
-  		return document$$1.getElementById && document$$1.getElementById(name);
+  		return document.getElementById && document.getElementById(name);
   	}
 
   	function abortTests() {
@@ -3428,7 +4726,7 @@
   					}
   				} else {
   					for (j in val.value) {
-  						if (hasOwn.call(val.value, j)) {
+  						if (hasOwn$$1.call(val.value, j)) {
   							urlConfigHtml += "<option value='" + escapeText(j) + "'" + (config[val.id] === j ? (selection = true) && " selected='selected'" : "") + ">" + escapeText(val.value[j]) + "</option>";
   						}
   					}
@@ -3464,16 +4762,56 @@
   		updatedUrl = setUrl(params);
 
   		// Check if we can apply the change without a page refresh
-  		if ("hidepassed" === field.name && "replaceState" in window.history) {
+  		if ("hidepassed" === field.name && "replaceState" in window$1.history) {
   			QUnit.urlParams[field.name] = value;
   			config[field.name] = value || false;
   			tests = id("qunit-tests");
   			if (tests) {
-  				toggleClass(tests, "hidepass", value || false);
+  				var length = tests.children.length;
+  				var children = tests.children;
+
+  				if (field.checked) {
+  					for (var i = 0; i < length; i++) {
+  						var test$$1 = children[i];
+
+  						if (test$$1 && test$$1.className.indexOf("pass") > -1) {
+  							hiddenTests.push(test$$1);
+  						}
+  					}
+
+  					var _iteratorNormalCompletion = true;
+  					var _didIteratorError = false;
+  					var _iteratorError = undefined;
+
+  					try {
+  						for (var _iterator = hiddenTests[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+  							var hiddenTest = _step.value;
+
+  							tests.removeChild(hiddenTest);
+  						}
+  					} catch (err) {
+  						_didIteratorError = true;
+  						_iteratorError = err;
+  					} finally {
+  						try {
+  							if (!_iteratorNormalCompletion && _iterator.return) {
+  								_iterator.return();
+  							}
+  						} finally {
+  							if (_didIteratorError) {
+  								throw _iteratorError;
+  							}
+  						}
+  					}
+  				} else {
+  					while ((test$$1 = hiddenTests.pop()) != null) {
+  						tests.appendChild(test$$1);
+  					}
+  				}
   			}
-  			window.history.replaceState(null, "", updatedUrl);
+  			window$1.history.replaceState(null, "", updatedUrl);
   		} else {
-  			window.location = updatedUrl;
+  			window$1.location = updatedUrl;
   		}
   	}
 
@@ -3482,14 +4820,14 @@
   		    arrValue,
   		    i,
   		    querystring = "?",
-  		    location = window.location;
+  		    location = window$1.location;
 
   		params = QUnit.extend(QUnit.extend({}, QUnit.urlParams), params);
 
   		for (key in params) {
 
   			// Skip inherited or undefined properties
-  			if (hasOwn.call(params, key) && params[key] !== undefined) {
+  			if (hasOwn$$1.call(params, key) && params[key] !== undefined) {
 
   				// Output a parameter for each value of this key
   				// (but usually just one)
@@ -3518,7 +4856,7 @@
   			}
   		}
 
-  		window.location = setUrl({
+  		window$1.location = setUrl({
   			filter: filter === "" ? undefined : filter,
   			moduleId: selectedModules.length === 0 ? undefined : selectedModules,
 
@@ -3529,7 +4867,7 @@
   	}
 
   	function toolbarUrlConfigContainer() {
-  		var urlConfigContainer = document$$1.createElement("span");
+  		var urlConfigContainer = document.createElement("span");
 
   		urlConfigContainer.innerHTML = getUrlConfigHtml();
   		addClass(urlConfigContainer, "qunit-url-config");
@@ -3541,7 +4879,7 @@
   	}
 
   	function abortTestsButton() {
-  		var button = document$$1.createElement("button");
+  		var button = document.createElement("button");
   		button.id = "qunit-abort-tests-button";
   		button.innerHTML = "Abort";
   		addEvent(button, "click", abortTests);
@@ -3549,10 +4887,10 @@
   	}
 
   	function toolbarLooseFilter() {
-  		var filter = document$$1.createElement("form"),
-  		    label = document$$1.createElement("label"),
-  		    input = document$$1.createElement("input"),
-  		    button = document$$1.createElement("button");
+  		var filter = document.createElement("form"),
+  		    label = document.createElement("label"),
+  		    input = document.createElement("input"),
+  		    button = document.createElement("button");
 
   		addClass(filter, "qunit-filter");
 
@@ -3568,7 +4906,7 @@
   		label.appendChild(input);
 
   		filter.appendChild(label);
-  		filter.appendChild(document$$1.createTextNode(" "));
+  		filter.appendChild(document.createTextNode(" "));
   		filter.appendChild(button);
   		addEvent(filter, "submit", interceptNavigation);
 
@@ -3591,18 +4929,22 @@
   	}
 
   	function toolbarModuleFilter() {
-  		var allCheckbox,
-  		    commit,
+  		var commit,
   		    reset,
-  		    moduleFilter = document$$1.createElement("form"),
-  		    label = document$$1.createElement("label"),
-  		    moduleSearch = document$$1.createElement("input"),
-  		    dropDown = document$$1.createElement("div"),
-  		    actions = document$$1.createElement("span"),
-  		    dropDownList = document$$1.createElement("ul"),
+  		    moduleFilter = document.createElement("form"),
+  		    label = document.createElement("label"),
+  		    moduleSearch = document.createElement("input"),
+  		    dropDown = document.createElement("div"),
+  		    actions = document.createElement("span"),
+  		    applyButton = document.createElement("button"),
+  		    resetButton = document.createElement("button"),
+  		    allModulesLabel = document.createElement("label"),
+  		    allCheckbox = document.createElement("input"),
+  		    dropDownList = document.createElement("ul"),
   		    dirty = false;
 
   		moduleSearch.id = "qunit-modulefilter-search";
+  		moduleSearch.autocomplete = "off";
   		addEvent(moduleSearch, "input", searchInput);
   		addEvent(moduleSearch, "input", searchFocus);
   		addEvent(moduleSearch, "focus", searchFocus);
@@ -3612,9 +4954,27 @@
   		label.innerHTML = "Module: ";
   		label.appendChild(moduleSearch);
 
+  		applyButton.textContent = "Apply";
+  		applyButton.style.display = "none";
+
+  		resetButton.textContent = "Reset";
+  		resetButton.type = "reset";
+  		resetButton.style.display = "none";
+
+  		allCheckbox.type = "checkbox";
+  		allCheckbox.checked = config.moduleId.length === 0;
+
+  		allModulesLabel.className = "clickable";
+  		if (config.moduleId.length) {
+  			allModulesLabel.className = "checked";
+  		}
+  		allModulesLabel.appendChild(allCheckbox);
+  		allModulesLabel.appendChild(document.createTextNode("All modules"));
+
   		actions.id = "qunit-modulefilter-actions";
-  		actions.innerHTML = "<button style='display:none'>Apply</button>" + "<button type='reset' style='display:none'>Reset</button>" + "<label class='clickable" + (config.moduleId.length ? "" : " checked") + "'><input type='checkbox'" + (config.moduleId.length ? "" : " checked='checked'") + ">All modules</label>";
-  		allCheckbox = actions.lastChild.firstChild;
+  		actions.appendChild(applyButton);
+  		actions.appendChild(resetButton);
+  		actions.appendChild(allModulesLabel);
   		commit = actions.firstChild;
   		reset = commit.nextSibling;
   		addEvent(commit, "click", applyUrlParams);
@@ -3636,7 +4996,7 @@
   		addEvent(moduleFilter, "reset", function () {
 
   			// Let the reset happen, then update styles
-  			window.setTimeout(selectionChange);
+  			window$1.setTimeout(selectionChange);
   		});
 
   		// Enables show/hide for the dropdown
@@ -3646,8 +5006,8 @@
   			}
 
   			dropDown.style.display = "block";
-  			addEvent(document$$1, "click", hideHandler);
-  			addEvent(document$$1, "keydown", hideHandler);
+  			addEvent(document, "click", hideHandler);
+  			addEvent(document, "keydown", hideHandler);
 
   			// Hide on Escape keydown or outside-container click
   			function hideHandler(e) {
@@ -3658,8 +5018,8 @@
   						moduleSearch.focus();
   					}
   					dropDown.style.display = "none";
-  					removeEvent(document$$1, "click", hideHandler);
-  					removeEvent(document$$1, "keydown", hideHandler);
+  					removeEvent(document, "click", hideHandler);
+  					removeEvent(document, "keydown", hideHandler);
   					moduleSearch.value = "";
   					searchInput();
   				}
@@ -3720,14 +5080,23 @@
   		return moduleFilter;
   	}
 
+  	function toolbarFilters() {
+  		var toolbarFilters = document.createElement("span");
+
+  		toolbarFilters.id = "qunit-toolbar-filters";
+  		toolbarFilters.appendChild(toolbarLooseFilter());
+  		toolbarFilters.appendChild(toolbarModuleFilter());
+
+  		return toolbarFilters;
+  	}
+
   	function appendToolbar() {
   		var toolbar = id("qunit-testrunner-toolbar");
 
   		if (toolbar) {
   			toolbar.appendChild(toolbarUrlConfigContainer());
-  			toolbar.appendChild(toolbarModuleFilter());
-  			toolbar.appendChild(toolbarLooseFilter());
-  			toolbar.appendChild(document$$1.createElement("div")).className = "clearfix";
+  			toolbar.appendChild(toolbarFilters());
+  			toolbar.appendChild(document.createElement("div")).className = "clearfix";
   		}
   	}
 
@@ -3758,7 +5127,7 @@
 
   		if (tests) {
   			tests.innerHTML = "";
-  			result = document$$1.createElement("p");
+  			result = document.createElement("p");
   			result.id = "qunit-testresult";
   			result.className = "result";
   			tests.parentNode.insertBefore(result, tests);
@@ -3784,7 +5153,7 @@
 
   		if (userAgent) {
   			userAgent.innerHTML = "";
-  			userAgent.appendChild(document$$1.createTextNode("QUnit " + QUnit.version + "; " + navigator.userAgent));
+  			userAgent.appendChild(document.createTextNode("QUnit " + QUnit.version + "; " + navigator.userAgent));
   		}
   	}
 
@@ -3792,7 +5161,7 @@
   		var qunit = id("qunit");
 
   		if (qunit) {
-  			qunit.innerHTML = "<h1 id='qunit-header'>" + escapeText(document$$1.title) + "</h1>" + "<h2 id='qunit-banner'></h2>" + "<div id='qunit-testrunner-toolbar'></div>" + appendFilteredTest() + "<h2 id='qunit-userAgent'></h2>" + "<ol id='qunit-tests'></ol>";
+  			qunit.innerHTML = "<h1 id='qunit-header'>" + escapeText(document.title) + "</h1>" + "<h2 id='qunit-banner'></h2>" + "<div id='qunit-testrunner-toolbar'></div>" + appendFilteredTest() + "<h2 id='qunit-userAgent'></h2>" + "<ol id='qunit-tests'></ol>";
   		}
 
   		appendHeader();
@@ -3800,20 +5169,6 @@
   		appendTestResults();
   		appendUserAgent();
   		appendToolbar();
-  	}
-
-  	function appendTestsList(modules) {
-  		var i, l, x, z, test, moduleObj;
-
-  		for (i = 0, l = modules.length; i < l; i++) {
-  			moduleObj = modules[i];
-
-  			for (x = 0, z = moduleObj.tests.length; x < z; x++) {
-  				test = moduleObj.tests[x];
-
-  				appendTest(test.name, test.testId, moduleObj.name);
-  			}
-  		}
   	}
 
   	function appendTest(name, testId, moduleName) {
@@ -3827,19 +5182,19 @@
   			return;
   		}
 
-  		title = document$$1.createElement("strong");
+  		title = document.createElement("strong");
   		title.innerHTML = getNameHtml(name, moduleName);
 
-  		rerunTrigger = document$$1.createElement("a");
+  		rerunTrigger = document.createElement("a");
   		rerunTrigger.innerHTML = "Rerun";
   		rerunTrigger.href = setUrl({ testId: testId });
 
-  		testBlock = document$$1.createElement("li");
+  		testBlock = document.createElement("li");
   		testBlock.appendChild(title);
   		testBlock.appendChild(rerunTrigger);
   		testBlock.id = "qunit-test-output-" + testId;
 
-  		assertList = document$$1.createElement("ol");
+  		assertList = document.createElement("ol");
   		assertList.className = "qunit-assert-list";
 
   		testBlock.appendChild(assertList);
@@ -3849,7 +5204,7 @@
 
   	// HTML Reporter initialization and load
   	QUnit.begin(function (details) {
-  		var i, moduleObj, tests;
+  		var i, moduleObj;
 
   		// Sort modules by name for the picker
   		for (i = 0; i < details.modules.length; i++) {
@@ -3864,11 +5219,6 @@
 
   		// Initialize QUnit elements
   		appendInterface();
-  		appendTestsList(details.modules);
-  		tests = id("qunit-tests");
-  		if (tests && config.hidepassed) {
-  			addClass(tests, "hidepass");
-  		}
   	});
 
   	QUnit.done(function (details) {
@@ -3877,20 +5227,20 @@
   		    abortButton = id("qunit-abort-tests-button"),
   		    totalTests = stats.passedTests + stats.skippedTests + stats.todoTests + stats.failedTests,
   		    html = [totalTests, " tests completed in ", details.runtime, " milliseconds, with ", stats.failedTests, " failed, ", stats.skippedTests, " skipped, and ", stats.todoTests, " todo.<br />", "<span class='passed'>", details.passed, "</span> assertions of <span class='total'>", details.total, "</span> passed, <span class='failed'>", details.failed, "</span> failed."].join(""),
-  		    test,
+  		    test$$1,
   		    assertLi,
   		    assertList;
 
-  		// Update remaing tests to aborted
+  		// Update remaining tests to aborted
   		if (abortButton && abortButton.disabled) {
   			html = "Tests aborted after " + details.runtime + " milliseconds.";
 
   			for (var i = 0; i < tests.children.length; i++) {
-  				test = tests.children[i];
-  				if (test.className === "" || test.className === "running") {
-  					test.className = "aborted";
-  					assertList = test.getElementsByTagName("ol")[0];
-  					assertLi = document$$1.createElement("li");
+  				test$$1 = tests.children[i];
+  				if (test$$1.className === "" || test$$1.className === "running") {
+  					test$$1.className = "aborted";
+  					assertList = test$$1.getElementsByTagName("ol")[0];
+  					assertLi = document.createElement("li");
   					assertLi.className = "fail";
   					assertLi.innerHTML = "Test aborted.";
   					assertList.appendChild(assertLi);
@@ -3910,17 +5260,17 @@
   			id("qunit-testresult-display").innerHTML = html;
   		}
 
-  		if (config.altertitle && document$$1.title) {
+  		if (config.altertitle && document.title) {
 
   			// Show ✖ for good, ✔ for bad suite result in title
   			// use escape sequences in case file gets loaded with non-utf-8
   			// charset
-  			document$$1.title = [stats.failedTests ? "\u2716" : "\u2714", document$$1.title.replace(/^[\u2714\u2716] /i, "")].join(" ");
+  			document.title = [stats.failedTests ? "\u2716" : "\u2714", document.title.replace(/^[\u2714\u2716] /i, "")].join(" ");
   		}
 
   		// Scroll back to top to show results
-  		if (config.scrolltop && window.scrollTo) {
-  			window.scrollTo(0, 0);
+  		if (config.scrolltop && window$1.scrollTo) {
+  			window$1.scrollTo(0, 0);
   		}
   	});
 
@@ -3936,30 +5286,32 @@
   		return nameHtml;
   	}
 
+  	function getProgressHtml(runtime, stats, total) {
+  		var completed = stats.passedTests + stats.skippedTests + stats.todoTests + stats.failedTests;
+
+  		return ["<br />", completed, " / ", total, " tests completed in ", runtime, " milliseconds, with ", stats.failedTests, " failed, ", stats.skippedTests, " skipped, and ", stats.todoTests, " todo."].join("");
+  	}
+
   	QUnit.testStart(function (details) {
-  		var running, testBlock, bad;
+  		var running, bad;
 
-  		testBlock = id("qunit-test-output-" + details.testId);
-  		if (testBlock) {
-  			testBlock.className = "running";
-  		} else {
-
-  			// Report later registered tests
-  			appendTest(details.name, details.testId, details.module);
-  		}
+  		appendTest(details.name, details.testId, details.module);
 
   		running = id("qunit-testresult-display");
+
   		if (running) {
+  			addClass(running, "running");
+
   			bad = QUnit.config.reorder && details.previousFailure;
 
-  			running.innerHTML = [bad ? "Rerunning previously failed test: <br />" : "Running: <br />", getNameHtml(details.name, details.module)].join("");
+  			running.innerHTML = [bad ? "Rerunning previously failed test: <br />" : "Running: <br />", getNameHtml(details.name, details.module), getProgressHtml(now() - config.started, stats, Test.count)].join("");
   		}
   	});
 
   	function stripHtml(string) {
 
   		// Strip tags, html entity and whitespaces
-  		return string.replace(/<\/?[^>]+(>|$)/g, "").replace(/\&quot;/g, "").replace(/\s+/g, "");
+  		return string.replace(/<\/?[^>]+(>|$)/g, "").replace(/&quot;/g, "").replace(/\s+/g, "");
   	}
 
   	QUnit.log(function (details) {
@@ -3968,7 +5320,7 @@
   		    message,
   		    expected,
   		    actual,
-  		    diff,
+  		    diff$$1,
   		    showDiff = false,
   		    testItem = id("qunit-test-output-" + details.testId);
 
@@ -3983,7 +5335,7 @@
   		// The pushFailure doesn't provide details.expected
   		// when it calls, it's implicit to also not show expected and diff stuff
   		// Also, we need to check details.expected existence, as it can exist and be undefined
-  		if (!details.result && hasOwn.call(details, "expected")) {
+  		if (!details.result && hasOwn$$1.call(details, "expected")) {
   			if (details.negative) {
   				expected = "NOT " + QUnit.dump.parse(details.expected);
   			} else {
@@ -4000,18 +5352,18 @@
   				if (typeof details.actual === "number" && typeof details.expected === "number") {
   					if (!isNaN(details.actual) && !isNaN(details.expected)) {
   						showDiff = true;
-  						diff = details.actual - details.expected;
-  						diff = (diff > 0 ? "+" : "") + diff;
+  						diff$$1 = details.actual - details.expected;
+  						diff$$1 = (diff$$1 > 0 ? "+" : "") + diff$$1;
   					}
   				} else if (typeof details.actual !== "boolean" && typeof details.expected !== "boolean") {
-  					diff = QUnit.diff(expected, actual);
+  					diff$$1 = QUnit.diff(expected, actual);
 
   					// don't show diff if there is zero overlap
-  					showDiff = stripHtml(diff).length !== stripHtml(expected).length + stripHtml(actual).length;
+  					showDiff = stripHtml(diff$$1).length !== stripHtml(expected).length + stripHtml(actual).length;
   				}
 
   				if (showDiff) {
-  					message += "<tr class='test-diff'><th>Diff: </th><td><pre>" + diff + "</pre></td></tr>";
+  					message += "<tr class='test-diff'><th>Diff: </th><td><pre>" + diff$$1 + "</pre></td></tr>";
   				}
   			} else if (expected.indexOf("[object Array]") !== -1 || expected.indexOf("[object Object]") !== -1) {
   				message += "<tr class='test-message'><th>Message: </th><td>" + "Diff suppressed as the depth of object is more than current max depth (" + QUnit.config.maxDepth + ").<p>Hint: Use <code>QUnit.dump.maxDepth</code> to " + " run with a higher max depth or <a href='" + escapeText(setUrl({ maxDepth: -1 })) + "'>" + "Rerun</a> without max depth.</p></td></tr>";
@@ -4032,7 +5384,7 @@
 
   		assertList = testItem.getElementsByTagName("ol")[0];
 
-  		assertLi = document$$1.createElement("li");
+  		assertLi = document.createElement("li");
   		assertLi.className = details.result ? "pass" : "fail";
   		assertLi.innerHTML = message;
   		assertList.appendChild(assertLi);
@@ -4043,6 +5395,7 @@
   		    time,
   		    testItem,
   		    assertList,
+  		    status,
   		    good,
   		    bad,
   		    testCounts,
@@ -4055,6 +5408,16 @@
   		}
 
   		testItem = id("qunit-test-output-" + details.testId);
+
+  		removeClass(testItem, "running");
+
+  		if (details.failed > 0) {
+  			status = "failed";
+  		} else if (details.todo) {
+  			status = "todo";
+  		} else {
+  			status = details.skipped ? "skipped" : "passed";
+  		}
 
   		assertList = testItem.getElementsByTagName("ol")[0];
 
@@ -4091,7 +5454,7 @@
   			stats.skippedTests++;
 
   			testItem.className = "skipped";
-  			skipped = document$$1.createElement("em");
+  			skipped = document.createElement("em");
   			skipped.className = "qunit-skipped-label";
   			skipped.innerHTML = "skipped";
   			testItem.insertBefore(skipped, testTitle);
@@ -4103,14 +5466,14 @@
   			testItem.className = testPassed ? "pass" : "fail";
 
   			if (details.todo) {
-  				var todoLabel = document$$1.createElement("em");
+  				var todoLabel = document.createElement("em");
   				todoLabel.className = "qunit-todo-label";
   				todoLabel.innerHTML = "todo";
   				testItem.className += " todo";
   				testItem.insertBefore(todoLabel, testTitle);
   			}
 
-  			time = document$$1.createElement("span");
+  			time = document.createElement("span");
   			time.className = "runtime";
   			time.innerHTML = details.runtime + " ms";
   			testItem.insertBefore(time, assertList);
@@ -4126,8 +5489,8 @@
 
   		// Show the source of the test when showing assertions
   		if (details.source) {
-  			sourceName = document$$1.createElement("p");
-  			sourceName.innerHTML = "<strong>Source: </strong>" + details.source;
+  			sourceName = document.createElement("p");
+  			sourceName.innerHTML = "<strong>Source: </strong>" + escapeText(details.source);
   			addClass(sourceName, "qunit-source");
   			if (testPassed) {
   				addClass(sourceName, "qunit-collapsed");
@@ -4137,36 +5500,44 @@
   			});
   			testItem.appendChild(sourceName);
   		}
+
+  		if (config.hidepassed && status === "passed") {
+
+  			// use removeChild instead of remove because of support
+  			hiddenTests.push(testItem);
+
+  			tests.removeChild(testItem);
+  		}
   	});
 
   	// Avoid readyState issue with phantomjs
   	// Ref: #818
   	var notPhantom = function (p) {
   		return !(p && p.version && p.version.major > 0);
-  	}(window.phantom);
+  	}(window$1.phantom);
 
-  	if (notPhantom && document$$1.readyState === "complete") {
+  	if (notPhantom && document.readyState === "complete") {
   		QUnit.load();
   	} else {
-  		addEvent(window, "load", QUnit.load);
+  		addEvent(window$1, "load", QUnit.load);
   	}
 
   	// Wrap window.onerror. We will call the original window.onerror to see if
   	// the existing handler fully handles the error; if not, we will call the
   	// QUnit.onError function.
-  	var originalWindowOnError = window.onerror;
+  	var originalWindowOnError = window$1.onerror;
 
   	// Cover uncaught exceptions
   	// Returning true will suppress the default browser handler,
   	// returning false will let it run.
-  	window.onerror = function (message, fileName, lineNumber) {
+  	window$1.onerror = function (message, fileName, lineNumber, columnNumber, errorObj) {
   		var ret = false;
   		if (originalWindowOnError) {
-  			for (var _len = arguments.length, args = Array(_len > 3 ? _len - 3 : 0), _key = 3; _key < _len; _key++) {
-  				args[_key - 3] = arguments[_key];
+  			for (var _len = arguments.length, args = Array(_len > 5 ? _len - 5 : 0), _key = 5; _key < _len; _key++) {
+  				args[_key - 5] = arguments[_key];
   			}
 
-  			ret = originalWindowOnError.call.apply(originalWindowOnError, [this, message, fileName, lineNumber].concat(args));
+  			ret = originalWindowOnError.call.apply(originalWindowOnError, [this, message, fileName, lineNumber, columnNumber, errorObj].concat(args));
   		}
 
   		// Treat return value as window.onerror itself does,
@@ -4178,6 +5549,14 @@
   				lineNumber: lineNumber
   			};
 
+  			// According to
+  			// https://blog.sentry.io/2016/01/04/client-javascript-reporting-window-onerror,
+  			// most modern browsers support an errorObj argument; use that to
+  			// get a full stack trace if it's available.
+  			if (errorObj && errorObj.stack) {
+  				error.stacktrace = extractStacktrace(errorObj, 0);
+  			}
+
   			ret = QUnit.onError(error);
   		}
 
@@ -4185,7 +5564,7 @@
   	};
 
   	// Listen for unhandled rejections, and call QUnit.onUnhandledRejection
-  	window.addEventListener("unhandledrejection", function (event) {
+  	window$1.addEventListener("unhandledrejection", function (event) {
   		QUnit.onUnhandledRejection(event.reason);
   	});
   })();


### PR DESCRIPTION
Follows-up c9b4b63fd08847281260205b995ae644f6f2f4d2 and 13f71bc9711b3617dd0fd5f1f085655df8505cf8.

Contrary to the commit message, it actually restored the older QUnit 2.6, and not the newer QUnit 2.10 version from package.json.

The oldest Node.js LTS is currently Node 12.
The latest QUnit 2.18 supports Node 10+.
This repo currently has a Node 8 CI job.

While at it, update both to 2.10.1, the last version to support Node 8 ([changelog](https://github.com/qunitjs/qunit/blob/2.18.1/History.md#2110--2020-08-16)), and pin it to avoid "npm install" from expanding it and saving it to the lock file which Node 8 would see. Hopefully also avoiding e.g. using a newer method which would then fail on the website version later.