### PR TITLE
Prepare 1.13.5

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@
     <div id="sidebar" class="interface overlay-content">
 
       <a class="toc_title" href="#">
-        Underscore.js <span class="version">(1.13.4)</span>
+        Underscore.js <span class="version">(1.13.5)</span>
       </a>
 
       <ul class="toc_section">
@@ -551,7 +551,7 @@
       <i>Underscore is an open-source component of <a href="https://documentcloud.org/">DocumentCloud</a>.</i>
     </p>
 
-    <h2>v1.13.4 Downloads <i style="padding-left: 12px; font-size:12px;">(Right-click, and use "Save As")</i></h2>
+    <h2>v1.13.5 Downloads <i style="padding-left: 12px; font-size:12px;">(Right-click, and use "Save As")</i></h2>
 
     <table>
       <tr>
@@ -595,32 +595,32 @@
       </tr>
     </table>
 
-    <h2>v1.13.4 CDN URLs <i style="padding-left: 12px; font-size:12px;">(Use with <tt>&lt;script src="..."&gt;&lt;/script&gt;</tt>)</i></h2>
+    <h2>v1.13.5 CDN URLs <i style="padding-left: 12px; font-size:12px;">(Use with <tt>&lt;script src="..."&gt;&lt;/script&gt;</tt>)</i></h2>
 
     <ul>
       <li>
-        <tt>https://cdn.jsdelivr.net/npm/underscore@1.13.4/underscore-umd-min.js</tt>
+        <tt>https://cdn.jsdelivr.net/npm/underscore@1.13.5/underscore-umd-min.js</tt>
       </li>
       <li>
-        <tt>https://cdn.jsdelivr.net/npm/underscore@1.13.4/underscore-esm-min.js</tt>
+        <tt>https://cdn.jsdelivr.net/npm/underscore@1.13.5/underscore-esm-min.js</tt>
       </li>
       <li>
-        <tt>https://unpkg.com/underscore@1.13.4/underscore-umd-min.js</tt>
+        <tt>https://unpkg.com/underscore@1.13.5/underscore-umd-min.js</tt>
       </li>
       <li>
-        <tt>https://unpkg.com/underscore@1.13.4/underscore-esm-min.js</tt>
+        <tt>https://unpkg.com/underscore@1.13.5/underscore-esm-min.js</tt>
       </li>
       <li>
-        <tt>https://pagecdn.io/lib/underscore/1.13.4/underscore-umd-min.js</tt>
+        <tt>https://pagecdn.io/lib/underscore/1.13.5/underscore-umd-min.js</tt>
       </li>
       <li>
-        <tt>https://pagecdn.io/lib/underscore/1.13.4/underscore-esm-min.js</tt>
+        <tt>https://pagecdn.io/lib/underscore/1.13.5/underscore-esm-min.js</tt>
       </li>
       <li>
-        <tt>https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.13.4/underscore-umd-min.js</tt>
+        <tt>https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.13.5/underscore-umd-min.js</tt>
       </li>
       <li>
-        <tt>https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.13.4/underscore-esm-min.js</tt>
+        <tt>https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.13.5/underscore-esm-min.js</tt>
       </li>
     </ul>
 

--- a/index.html
+++ b/index.html
@@ -2798,6 +2798,21 @@ _.chain([1, 2, 3]).reverse().value();
 
       <h2 id="changelog">Change Log</h2>
 
+      <p id="1.13.5">
+        <b class="header">1.13.5</b> &mdash; <small><i>September 23, 2022</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.13.4...1.13.5">Diff</a> &mdash; <a href="https://cdn.statically.io/gh/jashkenas/underscore/1.13.5/index.html">Docs</a><br />
+        <ul>
+          <li>
+            Adds a <tt>module</tt> sub-entry to the package.json&rsquo;s <tt>exports.require</tt> condition. When a bundling tool, such as Rollup with recent versions of <tt>@rollup/plugin-node-resolve</tt>, takes the exports map very literally, this should prevent situations in which the final bundle includes multiple copies of Underscore in different module formats.
+          </li>
+          <li>
+            Updates to the testing infrastructure and development dependencies.
+          </li>
+          <li>
+            No code changes.
+          </li>
+        </ul>
+      </p>
+
       <p id="1.13.4">
         <b class="header">1.13.4</b> &mdash; <small><i>June 2, 2022</i></small> &mdash; <a href="https://github.com/jashkenas/underscore/compare/1.13.3...1.13.4">Diff</a> &mdash; <a href="https://cdn.statically.io/gh/jashkenas/underscore/1.13.4/index.html">Docs</a><br />
         <ul>

--- a/modules/_setup.js
+++ b/modules/_setup.js
@@ -1,5 +1,5 @@
 // Current version.
-export var VERSION = '1.13.4';
+export var VERSION = '1.13.5';
 
 // Establish the root object, `window` (`self`) in the browser, `global`
 // on the server, or `this` in some virtual machines. We use `self`

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,7 +1,7 @@
 // Named Exports
 // =============
 
-//     Underscore.js 1.13.4
+//     Underscore.js 1.13.5
 //     https://underscorejs.org
 //     (c) 2009-2022 Jeremy Ashkenas, Julian Gonggrijp, and DocumentCloud and Investigative Reporters & Editors
 //     Underscore may be freely distributed under the MIT license.

--- a/modules/package.json
+++ b/modules/package.json
@@ -1,1 +1,1 @@
-{"type":"module","version":"1.13.4"}
+{"type":"module","version":"1.13.5"}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "underscore",
   "description": "JavaScript's functional programming helper library.",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "author": "Jeremy Ashkenas <jeremy@documentcloud.org>",
   "license": "MIT",
   "homepage": "https://underscorejs.org",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "default": "./underscore-esm.js"
       },
       "require": {
+        "module": "./modules/index-all.js",
         "browser": {
           "production": "./underscore-umd-min.js",
           "default": "./underscore-umd.js"

--- a/underscore-esm.js
+++ b/underscore-esm.js
@@ -1,10 +1,10 @@
-//     Underscore.js 1.13.4
+//     Underscore.js 1.13.5
 //     https://underscorejs.org
 //     (c) 2009-2022 Jeremy Ashkenas, Julian Gonggrijp, and DocumentCloud and Investigative Reporters & Editors
 //     Underscore may be freely distributed under the MIT license.
 
 // Current version.
-var VERSION = '1.13.4';
+var VERSION = '1.13.5';
 
 // Establish the root object, `window` (`self`) in the browser, `global`
 // on the server, or `this` in some virtual machines. We use `self`

--- a/underscore-node-f.cjs
+++ b/underscore-node-f.cjs
@@ -1,4 +1,4 @@
-//     Underscore.js 1.13.4
+//     Underscore.js 1.13.5
 //     https://underscorejs.org
 //     (c) 2009-2022 Jeremy Ashkenas, Julian Gonggrijp, and DocumentCloud and Investigative Reporters & Editors
 //     Underscore may be freely distributed under the MIT license.
@@ -6,7 +6,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 
 // Current version.
-var VERSION = '1.13.4';
+var VERSION = '1.13.5';
 
 // Establish the root object, `window` (`self`) in the browser, `global`
 // on the server, or `this` in some virtual machines. We use `self`

--- a/underscore-node.cjs
+++ b/underscore-node.cjs
@@ -1,4 +1,4 @@
-//     Underscore.js 1.13.4
+//     Underscore.js 1.13.5
 //     https://underscorejs.org
 //     (c) 2009-2022 Jeremy Ashkenas, Julian Gonggrijp, and DocumentCloud and Investigative Reporters & Editors
 //     Underscore may be freely distributed under the MIT license.

--- a/underscore-node.mjs
+++ b/underscore-node.mjs
@@ -1,4 +1,4 @@
-//     Underscore.js 1.13.4
+//     Underscore.js 1.13.5
 //     https://underscorejs.org
 //     (c) 2009-2022 Jeremy Ashkenas, Julian Gonggrijp, and DocumentCloud and Investigative Reporters & Editors
 //     Underscore may be freely distributed under the MIT license.

--- a/underscore-umd.js
+++ b/underscore-umd.js
@@ -7,13 +7,13 @@
     exports.noConflict = function () { global._ = current; return exports; };
   }()));
 }(this, (function () {
-  //     Underscore.js 1.13.4
+  //     Underscore.js 1.13.5
   //     https://underscorejs.org
   //     (c) 2009-2022 Jeremy Ashkenas, Julian Gonggrijp, and DocumentCloud and Investigative Reporters & Editors
   //     Underscore may be freely distributed under the MIT license.
 
   // Current version.
-  var VERSION = '1.13.4';
+  var VERSION = '1.13.5';
 
   // Establish the root object, `window` (`self`) in the browser, `global`
   // on the server, or `this` in some virtual machines. We use `self`


### PR DESCRIPTION
This release mostly serves to prevent duplicate copies of Underscore in bundles created with recent versions of `@rollup/plugin-node-resolve`.