### PR TITLE
Hotfix for broken builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,8 +91,7 @@
     "build": "npm run bundle && npm run build-umd && npm run build-esm && npm run alias-bundle",
     "doc": "docco underscore-esm.js && docco modules/*.js -c docco.css -t docs/linked-esm.jst",
     "weight": "npm run bundle && npm run minify-umd | gzip-size | pretty-bytes",
-    "prepublishOnly": "npm run build && npm run doc",
-    "postinstall": "patch-package"
+    "prepublishOnly": "npm run build && npm run doc"
   },
   "files": [
     "underscore-esm.js",


### PR DESCRIPTION
patch-package is a dev dependency and should not be required by users of underscore.js

This hotfix removes the postinstall script which is causing multiple build failures across the ecosystem.

See #2967, #2968, #2969, #2970, #2971, #2973