### PR TITLE
fix(range): step documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1463,12 +1463,10 @@ _.findLastIndex(users, {
         <br />
         A function to create flexibly-numbered lists of integers, handy for
         <tt>each</tt> and <tt>map</tt> loops. <b>start</b>, if omitted,
-        defaults to <i>0</i>; <b>step</b> defaults to <i>1</i>. Returns a list
+        defaults to <i>0</i>; <b>step</b> defaults to <i>1</i> if <b>start</b>
+        is before <b>stop</b>, otherwise <i>-1</i>. Returns a list
         of integers from <b>start</b> (inclusive) to <b>stop</b> (exclusive),
-        incremented (or decremented) by <b>step</b>. Note that ranges that
-        <b>stop</b> before they <b>start</b> are considered to be zero-length
-        instead of negative — if you'd like a negative range, use a negative
-        <b>step</b>.
+        incremented (or decremented) by <b>step</b>.
       </p>
       <pre>
 _.range(10);


### PR DESCRIPTION
Fix the documentation for range step which changed behaviour in 1.10 to automatically set step to -1 if start is after stop.