### PR TITLE
Bump GitHub workflow actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,11 +45,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -61,7 +61,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
@@ -75,4 +75,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/modules/isDataView.js
+++ b/modules/isDataView.js
@@ -8,7 +8,7 @@ var isDataView = tagTester('DataView');
 // In IE 10 - Edge 13, we need a different heuristic
 // to determine whether an object is a `DataView`.
 // Also, in cases where the native `DataView` is
-// overriden we can't rely on the tag itself.
+// overridden we can't rely on the tag itself.
 function alternateIsDataView(obj) {
   return obj != null && isFunction(obj.getInt8) && isArrayBuffer(obj.buffer);
 }

--- a/test/vendor/qunit.js
+++ b/test/vendor/qunit.js
@@ -4499,7 +4499,7 @@
   	// Exact case-insensitive match of the module name
   	QUnit.config.module = urlParams.module;
 
-  	// Regular expression or case-insenstive substring match against "moduleName: testName"
+  	// Regular expression or case-insensitive substring match against "moduleName: testName"
   	QUnit.config.filter = urlParams.filter;
 
   	// Test order randomization

--- a/underscore-esm.js
+++ b/underscore-esm.js
@@ -154,7 +154,7 @@ var isDataView = tagTester('DataView');
 // In IE 10 - Edge 13, we need a different heuristic
 // to determine whether an object is a `DataView`.
 // Also, in cases where the native `DataView` is
-// overriden we can't rely on the tag itself.
+// overridden we can't rely on the tag itself.
 function alternateIsDataView(obj) {
   return obj != null && isFunction$1(obj.getInt8) && isArrayBuffer(obj.buffer);
 }

--- a/underscore-node-f.cjs
+++ b/underscore-node-f.cjs
@@ -156,7 +156,7 @@ var isDataView = tagTester('DataView');
 // In IE 10 - Edge 13, we need a different heuristic
 // to determine whether an object is a `DataView`.
 // Also, in cases where the native `DataView` is
-// overriden we can't rely on the tag itself.
+// overridden we can't rely on the tag itself.
 function alternateIsDataView(obj) {
   return obj != null && isFunction$1(obj.getInt8) && isArrayBuffer(obj.buffer);
 }

--- a/underscore-umd.js
+++ b/underscore-umd.js
@@ -163,7 +163,7 @@
   // In IE 10 - Edge 13, we need a different heuristic
   // to determine whether an object is a `DataView`.
   // Also, in cases where the native `DataView` is
-  // overriden we can't rely on the tag itself.
+  // overridden we can't rely on the tag itself.
   function alternateIsDataView(obj) {
     return obj != null && isFunction$1(obj.getInt8) && isArrayBuffer(obj.buffer);
   }

--- a/underscore.js
+++ b/underscore.js
@@ -163,7 +163,7 @@
   // In IE 10 - Edge 13, we need a different heuristic
   // to determine whether an object is a `DataView`.
   // Also, in cases where the native `DataView` is
-  // overriden we can't rely on the tag itself.
+  // overridden we can't rely on the tag itself.
   function alternateIsDataView(obj) {
     return obj != null && isFunction$1(obj.getInt8) && isArrayBuffer(obj.buffer);
   }


### PR DESCRIPTION
This PR bumps GitHub workflow actions to their latest versions, thus avoiding error messages and deprecation warnings as seen e.g. [here](https://github.com/jashkenas/underscore/actions/runs/8077342941).