### PR TITLE
Add _.VERSION to the documentation 

### DIFF
--- a/index.html
+++ b/index.html
@@ -2979,6 +2979,15 @@ _.chain([1, 2, 3]).reverse().value();
         </ul>
       </p>
 
+      <p id="relational-operator-note">
+        <b class="header">Underscore version</b>
+        <br>
+        It's possible to get current Underscore version via
+        <tt>_.VERSION</tt> 
+        .
+        <pre>_.VERSION => 1.13.7</pre>
+      </p>
+
       <h2 id="changelog">Change Log</h2>
 
       <p id="1.13.7">

--- a/index.html
+++ b/index.html
@@ -499,6 +499,7 @@
           <li data-name="result">- <a href="#result">result</a></li>
           <li data-name="now">- <a href="#now">now</a></li>
           <li data-name="template">- <a href="#template">template</a></li>
+          <li data-name="version">- <a href="#version">version</a></li>
         </ul>
       </div>
 
@@ -2757,6 +2758,14 @@ _.template("Using 'with': <%= data.answer %>", {variable: 'data'})({answer: 'no'
   JST.project = <%= _.template(jstText).source %>;
 &lt;/script&gt;</pre>
 
+      <p id="version">
+        <b class="header">VERSION</b>
+        <br>
+        It is possible to get the current Underscore version via
+        <tt>_.VERSION</tt> 
+        .
+        <pre>_.VERSION =&gt; 1.13.7</pre>
+      </p>
 
       <h2 id="oop">Object-Oriented Style</h2>
 
@@ -2977,15 +2986,6 @@ _.chain([1, 2, 3]).reverse().value();
             behavior is consistent.
           </li>
         </ul>
-      </p>
-
-      <p id="relational-operator-note">
-        <b class="header">Underscore version</b>
-        <br>
-        It's possible to get current Underscore version via
-        <tt>_.VERSION</tt> 
-        .
-        <pre>_.VERSION => 1.13.7</pre>
       </p>
 
       <h2 id="changelog">Change Log</h2>


### PR DESCRIPTION
Added `_.VERSION` as per https://github.com/jashkenas/underscore/issues/2992 issue.

In my opinion placing it under `Notes` should be more than enough as `utility` section seems to include more complex methods than this one.

![version](https://github.com/user-attachments/assets/16ab13b8-a5c7-4177-9bbf-89364b2eb6f9)
