### PR TITLE
docs: replace 'ticket' with 'issue' in contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 * This project adheres to a [code of conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
 
-* Please do not open a issue to report a security issue. Consult the [security policy](SECURITY.md) on what to do instead.
+* Please do not open an issue to report a security issue. Consult the [security policy](SECURITY.md) on what to do instead.
 
-* Before you open a issue or send a pull request, [search](https://github.com/jashkenas/underscore/issues) for previous discussions about the same feature or issue. Add to the earlier ticket if you find one.
+* Before you open an issue or send a pull request, [search](https://github.com/jashkenas/underscore/issues) for previous discussions about the same feature or issue. Add to the earlier ticket if you find one.
 
 * If you're proposing a new feature, make sure it isn't already implemented in [Underscore-Contrib](https://github.com/documentcloud/underscore-contrib).
 


### PR DESCRIPTION
### What changed
- Replaced the term “ticket” with “issue” for consistency with GitHub terminology.

### Why
- GitHub uses “issues” instead of “tickets”, so this improves clarity and consistency in the contributing guidelines.

### Checklist
- [x] No functional code changes
- [x] Documentation-only update
