### PR TITLE
Clarify _.template security

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,26 @@ disclose the issue.
 After receiving your email, we will respond as soon as possible and indicate
 what we plan to do.
 
+### A note on `_.template`
+
+[`template`][template] allows the user to inject arbitrary JavaScript
+code in the template string. This is allowed by design. In fact, it is
+the main feature of `template`. Without this feature, templates would
+not be able to have conditional or repeated sections.
+
+Because of this feature, it is the responsibility of the user not to
+pass any untrusted input to `template`. The contract is similar to
+that of the `Function` constructor or even `eval`: this function is so
+powerful that it can be dangerous, so use it with care.
+
+If this does not sound exactly like what you were considering to
+report, or in case of doubt, please do send us a report. Of course, we
+would rather be safe than sorry. You would not be the first to find a
+[vulnerability in `template`][cve-2021-23358].
+
+[template]: https://underscorejs.org/#template
+[cve-2021-23358]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23358
+
 ## Disclosure policy
 
 After confirming a vulnerability, we will generally release a security update

--- a/index.html
+++ b/index.html
@@ -2692,6 +2692,12 @@ _.now();
         should be a hash containing any <tt>_.templateSettings</tt> that should be overridden.
       </p>
 
+      <p role=note>
+        <em><tt>_.template</tt> allows the template author to insert arbitrary
+        JavaScript code by design. This means that you should only pass template
+        code from trusted authors.</em>
+      </p>
+
       <pre>
 var compiled = _.template("hello: &lt;%= name %&gt;");
 compiled({name: 'moe'});

--- a/index.html
+++ b/index.html
@@ -2695,7 +2695,9 @@ _.now();
       <p role=note>
         <em><tt>_.template</tt> allows the template author to insert arbitrary
         JavaScript code by design. This means that you should only pass template
-        code from trusted authors.</em>
+        code and template settings from trusted authors. Passing untrusted input
+        to <tt>_.template</tt> <strong>will</strong> create a code injection
+        vulnerability in your application or library!</em>
       </p>
 
       <pre>


### PR DESCRIPTION
Once a year or so (on average), someone reports a vulnerability because they noticed that `_.template` creates a string from user input and passes it to the `Function` constructor.  These reports are well-intended and understandable, but they are nevertheless false reports. Such logic might be considered a vulnerability in another context, but `_.template` is supposed to do this by design.

This pull request adds two pieces of documentation, with the aim to clarify `_.template`'s contract to security researchers. The aim is **not** to discourage reports; the misunderstanding does not happen often enough for this to be necessary.

I would like to ask reviewers three questions:

1. If you imagine being a security researcher (or if you are one), do you think that the additions would help you assess whether you found a real vulnerability in `_.template`? Do you think I could further improve on this?
2. Would you feel discouraged to report a vulnerability after reading the addition to the `SECURITY.md`? If yes, what should I remove or change in order to stop it from being discouraging?
3. Do you think the amount of text is proportional to the aims? What could be removed or expanded on to make it more proportional?

I welcome reviews from anyone. I will mention the following people because I think/hope they might be interested: @colingm @ByamB4 @GammaGames @Yahasana