### PR TITLE
Update repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://underscorejs.org",
   "repository": {
     "type": "git",
-    "url": "git://github.com/jashkenas/underscore.git"
+    "url": "git+https://github.com/jashkenas/underscore.git"
   },
   "keywords": [
     "util",


### PR DESCRIPTION
Summary:
- update the package repository URL from git:// to git+https://
- keep the existing GitHub repository target unchanged

Verification:
- parsed package.json with Node and confirmed repository.url
- ran git diff --check

This is a metadata-only change.